### PR TITLE
Improved ChildBlockLengthCheck a bit

### DIFF
--- a/sevntu-checks/pom.xml
+++ b/sevntu-checks/pom.xml
@@ -12,6 +12,7 @@
     </properties>
     
     <dependencies>
+    
 	<dependency>
 	  <groupId>com.puppycrawl.tools</groupId>
 	  <artifactId>checkstyle</artifactId>
@@ -24,6 +25,7 @@
 	  <version>4.10</version>
 	  <scope>test</scope>
 	</dependency>
+	
     </dependencies>
     <distributionManagement>
       <repository>
@@ -45,4 +47,29 @@
 	</plugin>
       </plugins>
     </build>
+        
+        
+    <!-- Solves the problem with 'missing artifact: com.sun:tools' 
+    appeared with Sun Java 1.6 -->
+    <profiles>
+    <profile>
+      <id>default-tools.jar</id>
+      <activation>
+        <property>
+          <name>java.vendor</name>
+          <value>Sun Microsystems Inc.</value>
+        </property>
+      </activation>
+      <dependencies>
+        <dependency>
+          <groupId>com.sun</groupId>
+          <artifactId>tools</artifactId>
+          <version>1.4.2</version>
+          <scope>system</scope>
+          <systemPath>${JAVA_HOME}/lib/tools.jar</systemPath>
+        </dependency>
+      </dependencies>
+    </profile>
+  </profiles>
+
 </project>

--- a/sevntu-checks/src/main/resources/com/github/sevntu/checkstyle/checks/design/messages.properties
+++ b/sevntu-checks/src/main/resources/com/github/sevntu/checkstyle/checks/design/messages.properties
@@ -1,6 +1,6 @@
 arrangement.members.before.inner=Fields and methods should be before inner classes.
 cause.parameter.in.exception=''{0}'' class should have a constructor with exception cause as parameter.
-child.block.length=Block length should be lesser or equal to {0} lines.
+child.block.length=Block length is {0} lines, but should be lesser or equal to {1} lines.
 variable.declaration.usage.distance=Distance between variable ''{0}'' declaration and its first usage is {1}, but allowed {2}.
 design.forExtension=Method ''{0}'' is not designed for extension - needs to be abstract, final or empty.
 final.class=Class {0} should be declared as final.

--- a/sevntu-checks/src/test/java/com/github/sevntu/checkstyle/checks/design/ChildBlockLengthTest.java
+++ b/sevntu-checks/src/test/java/com/github/sevntu/checkstyle/checks/design/ChildBlockLengthTest.java
@@ -18,10 +18,11 @@
 ////////////////////////////////////////////////////////////////////////////////
 package com.github.sevntu.checkstyle.checks.design;
 
+import static java.text.MessageFormat.format;
+
 import org.junit.Test;
 
 import com.github.sevntu.checkstyle.BaseCheckTestSupport;
-import com.github.sevntu.checkstyle.checks.design.ChildBlockLengthCheck;
 import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
 
 /**
@@ -67,7 +68,7 @@ public class ChildBlockLengthTest extends BaseCheckTestSupport
         checkConfig.addAttribute("ignoreBlockLinesCount", "0");
 
         String[] expected = {
-            "15:15: " + getMessage("5"),  // 5.2%
+                "15:15: " + getMessage(5, 13), // 5.2%
         };
 
         verify(checkConfig, getPath("InputChildBlockLengthCheckManyBlocksOnOneScope.java"), expected);
@@ -82,15 +83,15 @@ public class ChildBlockLengthTest extends BaseCheckTestSupport
         checkConfig.addAttribute("ignoreBlockLinesCount", "0");
 
         String[] expected = {
-            "15:15: " + getMessage("4"),
-            "31:15: " + getMessage("4"),
+                "15:15: " + getMessage(4, 13),
+                "31:15: " + getMessage(4, 5),
         };
 
         verify(checkConfig, getPath("InputChildBlockLengthCheckManyBlocksOnOneScope.java"), expected);
     }
 
     @Test
-    public void testBadChildBlocksThatAreDoubleNested() throws Exception
+    public void testNestedBadChildBlocks() throws Exception
     {
         checkConfig.addAttribute("maxChildBlockPercentage", "70");
         checkConfig.addAttribute("blockTypes", "LITERAL_IF, LITERAL_SWITCH, LITERAL_FOR, "
@@ -98,8 +99,8 @@ public class ChildBlockLengthTest extends BaseCheckTestSupport
         checkConfig.addAttribute("ignoreBlockLinesCount", "0");
 
         String[] expected = {
-            "41:7: " + getMessage("6"),
-            "42:9: " + getMessage("4"),
+                "41:7: " + getMessage(6, 7),
+                "42:9: " + getMessage(4, 5),
         };
 
         verify(checkConfig, getPath("InputChildBlockLengthCheckDoubleNested.java"), expected);
@@ -133,9 +134,12 @@ public class ChildBlockLengthTest extends BaseCheckTestSupport
         verify(checkConfig, getPath("InputChildBlockLengthCheckCheckNPE.java"), expected);
     }
 
-    private static String getMessage(String linesCount)
+    private static String getMessage(int allowedLinesCount,
+            int currentLineCount)
     {
-        return "Block length should be lesser or equal to " + linesCount + " lines.";
+
+        return format("Block length is {0} lines, but should be lesser " +
+                "or equal to {1} lines.", currentLineCount, allowedLinesCount);
     }
 
 }

--- a/sevntu-checks/src/test/resources/com/github/sevntu/checkstyle/checks/design/InputChildBlockLengthCheckDoubleNested.java
+++ b/sevntu-checks/src/test/resources/com/github/sevntu/checkstyle/checks/design/InputChildBlockLengthCheckDoubleNested.java
@@ -37,9 +37,9 @@ public class InputChildBlockLengthCheckDoubleNested {
     int i4 = 0;
     int i5 = 0;
 
-    for (i1 = 0; i1 < 10; i1++) {
-      for (i2 = 0; i2 < 10; i2++) { // !
-        for (i3 = 0; i3 < 10; i3++) { // ! but double-nested
+    for (i1 = 0; i1 < 10; i1++) { // 9 lines
+      for (i2 = 0; i2 < 10; i2++) { // 7 lines = 77% ! 
+        for (i3 = 0; i3 < 10; i3++) { // 5 lines = 71% !
           for (i4 = 0; i4 < 10; i4++) {
             for (i5 = 0; i5 < 10; i5++) {
               i += 1;

--- a/sevntu-checks/src/test/resources/com/github/sevntu/checkstyle/checks/design/InputChildBlockLengthCheckManyBlocksOnOneScope.java
+++ b/sevntu-checks/src/test/resources/com/github/sevntu/checkstyle/checks/design/InputChildBlockLengthCheckManyBlocksOnOneScope.java
@@ -36,31 +36,8 @@ public class InputChildBlockLengthCheckManyBlocksOnOneScope {
                   
               }
               
-          }
-                  
+          }                 
           
-//          if (isTrue()) { // 18 lines
-//              number = 2;
-//              
-//              if (isTrue()) { // 6 lines !
-//                  
-//                  
-//                  number = 3;
-//                  
-//                  
-//              }
-//
-//              if (isTrue()) { // 6 lines !
-//                  
-//                  
-//                  number = 3;
-//                  
-//                  
-//              }
-//
-//          }
-
-
         }
 
     }


### PR DESCRIPTION
Improved ChildBlockLengthCheck to show current size of 'bad' blocks, not only allowed sizes for it.

Also I`ve fixed the problem when Maven is unable to find system 'com.sun:tools' library (which comes with Sun Java by default and present in JAVA_HOME/lib, but is invisible for Maven).

see http://stackoverflow.com/questions/8375423/missing-artifact-com-suntoolsjar
and http://maven.apache.org/general.html - paragraph ' How do I include tools.jar in my dependencies? '
