### PR TITLE
Fixes #116. Update for AbbreviationAsWordInNameCheck.

### DIFF
--- a/eclipsecs-sevntu-plugin/src/com/github/sevntu/checkstyle/checks/naming/checkstyle-metadata.xml
+++ b/eclipsecs-sevntu-plugin/src/com/github/sevntu/checkstyle/checks/naming/checkstyle-metadata.xml
@@ -10,7 +10,7 @@
             <property-metadata name="allowedAbbreviationLength" datatype="Integer" default-value="3">
                 <description>%AbbreviationAsWordInName.allowedAbbreviationLength</description>
             </property-metadata>
-            <property-metadata name="allowedAbbreviations" datatype="String" default-value="XML,URL">
+            <property-metadata name="allowedAbbreviations" datatype="String" default-value="XML,URL,IT,I">
                 <description>%AbbreviationAsWordInName.allowedAbbreviations</description>
             </property-metadata>
       		<property-metadata name="targets" datatype="MultiCheck" default-value="CLASS_DEF">

--- a/sevntu-checks/src/main/java/com/github/sevntu/checkstyle/checks/naming/AbbreviationAsWordInNameCheck.java
+++ b/sevntu-checks/src/main/java/com/github/sevntu/checkstyle/checks/naming/AbbreviationAsWordInNameCheck.java
@@ -31,19 +31,16 @@ import com.puppycrawl.tools.checkstyle.api.TokenTypes;
 
 /**
  * <p>
- * Check name of the targeted item to validate abbreviations(capital letters)
- * length in it. Options: Allowed Abbreviation Length - allowed abbreviation
- * length(length of capital characters). Allowed Abbreviations - list of
- * abbreviations separated by comma, without spaces.
- * Option IgnoreFinal allow to skip variables with final declarations, 
- * option IgnoreStatic allow to skip variables with static declarations,
- * option IgnoreOverriddenMethod - Allows to ignore methods tagged with 
- * '@Override' annotation (that usually mean inherited name).
+ * Check name of the targeted item to validate abbreviations(capital letters) length in it. Options: Allowed
+ * Abbreviation Length - allowed abbreviation length(length of capital characters). Allowed Abbreviations - list of
+ * abbreviations separated by comma, without spaces. Option IgnoreFinal allow to skip variables with final declarations,
+ * option IgnoreStatic allow to skip variables with static declarations, option IgnoreOverriddenMethod - Allows to
+ * ignore methods tagged with '@Override' annotation (that usually mean inherited name).
  * </p>
- * @author Roman Ivanov, Daniil Yaroslvtsev
+ * 
+ * @author Roman Ivanov, Daniil Yaroslvtsev, Baratali Izmailov
  */
-public class AbbreviationAsWordInNameCheck extends Check
-{
+public class AbbreviationAsWordInNameCheck extends Check {
 
     /**
      * The default value of "allowedAbbreviationLength" option.
@@ -63,7 +60,7 @@ public class AbbreviationAsWordInNameCheck extends Check
             DEFAULT_ALLOWED_ABBREVIATIONS_LENGTH;
 
     /**
-     * Set of allowed abbreviation to ignore in check
+     * Set of allowed abbreviation to ignore in check.
      */
     private Set<String> mAllowedAbbreviations = new HashSet<String>();
 
@@ -181,33 +178,46 @@ public class AbbreviationAsWordInNameCheck extends Check
 
         boolean result = false;
         if (aAst.getType() == TokenTypes.VARIABLE_DEF) {
-        	if ((mIgnoreFinal || mIgnoreStatic) && isInterfaceDeclaration(aAst)) {
-        		// field declarations in interface are static/final
-        		result = true;
-        	} else {
-        		result = (mIgnoreFinal && modifiers.branchContains(TokenTypes.FINAL))
-                    || (mIgnoreStatic && modifiers.branchContains(TokenTypes.LITERAL_STATIC));
-        	}
-        } else if (aAst.getType() == TokenTypes.METHOD_DEF) {
-        	result = mIgnoreOverriddenMethods && hasOverrideAnnotation(modifiers);
+            if ((mIgnoreFinal || mIgnoreStatic)
+                    && isInterfaceDeclaration(aAst)) {
+                // field declarations in interface are static/final
+                result = true;
+            }
+            else {
+                result = (mIgnoreFinal
+                          && modifiers.branchContains(TokenTypes.FINAL))
+                    || (mIgnoreStatic
+                        && modifiers.branchContains(TokenTypes.LITERAL_STATIC));
+            }
+        }
+        else if (aAst.getType() == TokenTypes.METHOD_DEF) {
+            result = mIgnoreOverriddenMethods
+                    && hasOverrideAnnotation(modifiers);
         }
         return result;
     }
 
-	private static boolean isInterfaceDeclaration(DetailAST aAst) {
-    	boolean result = false;
-		DetailAST astBlock = aAst.getParent();
-    	if (astBlock != null) {
-    		DetailAST astParent2 = astBlock.getParent();
-    		if (astParent2 != null
-    				&& astParent2.getType() == TokenTypes.INTERFACE_DEF) {
-    			result = true;
-    		}
-    	}
-		return result;
-	}
+    /**
+     * Check that variable definition in interface definition.
+     * @param aVariableDefAst variable definition.
+     * @return true if variable definition(aVaribaleDefAst) is in interface
+     * definition.
+     */
+    private static boolean isInterfaceDeclaration(DetailAST aVariableDefAst)
+    {
+        boolean result = false;
+        final DetailAST astBlock = aVariableDefAst.getParent();
+        if (astBlock != null) {
+            final DetailAST astParent2 = astBlock.getParent();
+            if (astParent2 != null
+                    && astParent2.getType() == TokenTypes.INTERFACE_DEF) {
+                result = true;
+            }
+        }
+        return result;
+    }
 
-	/**
+    /**
      * Checks that the method has "@Override" annotation.
      * @param aMethodModifiersAST
      *        A DetailAST nod is related to the given method modifiers
@@ -275,7 +285,7 @@ public class AbbreviationAsWordInNameCheck extends Check
         if (abbrStarted) {
             final int endIndex = aString.length();
             final int abbrLength = endIndex - beginIndex;
-            if (abbrLength > mAllowedAbbreviationLength) {
+            if (abbrLength > 1 && abbrLength > mAllowedAbbreviationLength) {
                 result = aString.substring(beginIndex, endIndex);
                 if (mAllowedAbbreviations.contains(result)) {
                     result = null;

--- a/sevntu-checks/src/test/java/com/github/sevntu/checkstyle/checks/naming/AbbreviationAsWordInNameCheckTest.java
+++ b/sevntu-checks/src/test/java/com/github/sevntu/checkstyle/checks/naming/AbbreviationAsWordInNameCheckTest.java
@@ -3,7 +3,6 @@ package com.github.sevntu.checkstyle.checks.naming;
 import org.junit.Test;
 
 import com.github.sevntu.checkstyle.BaseCheckTestSupport;
-import com.github.sevntu.checkstyle.checks.naming.AbbreviationAsWordInNameCheck;
 import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
 
 public class AbbreviationAsWordInNameCheckTest extends BaseCheckTestSupport {
@@ -227,7 +226,50 @@ public class AbbreviationAsWordInNameCheckTest extends BaseCheckTestSupport {
         verify(checkConfig, 
         		getPath("InputAbbreviationAsWordInTypeNameCheckOverridableMethod.java"), expected);
     }
-	   
-	 
-	
+
+	@Test
+	public void testTypeNamesForZeroPermitedCapitalLetter() throws Exception {
+	    final DefaultConfiguration checkConfig =
+	            createCheckConfig(AbbreviationAsWordInNameCheck.class);
+	    final int expectedCapitalCount = 0;
+	    checkConfig.addAttribute("allowedAbbreviationLength",
+	            String.valueOf(expectedCapitalCount));
+	    checkConfig.addAttribute("allowedAbbreviations", "");
+	    checkConfig.addAttribute("ignoreStatic", "false");
+	    checkConfig.addAttribute("ignoreFinal", "false");
+	    checkConfig.addAttribute("ignoreOverriddenMethods", "false");
+	    checkConfig.addAttribute("targets", "CLASS_DEF,INTERFACE_DEF,ENUM_DEF,"
+	            + "ANNOTATION_DEF,ANNOTATION_FIELD_DEF,ENUM_CONSTANT_DEF,"
+	            + "PARAMETER_DEF,VARIABLE_DEF,METHOD_DEF"
+	    );
+	    final String[] expected = {
+	            String.format(message, 3, expectedCapitalCount),
+	            String.format(message, 6, expectedCapitalCount),
+	            String.format(message, 9, expectedCapitalCount),
+	            String.format(message, 12, expectedCapitalCount),
+	            String.format(message, 32, expectedCapitalCount),
+	            String.format(message, 37, expectedCapitalCount),
+	            String.format(message, 38, expectedCapitalCount),
+	            String.format(message, 39, expectedCapitalCount),
+	            String.format(message, 40, expectedCapitalCount),
+	            String.format(message, 46, expectedCapitalCount),
+	            String.format(message, 47, expectedCapitalCount),
+	            String.format(message, 48, expectedCapitalCount),
+	            String.format(message, 49, expectedCapitalCount),
+	            String.format(message, 57, expectedCapitalCount),
+	            String.format(message, 58, expectedCapitalCount),
+	            String.format(message, 59, expectedCapitalCount),
+	            String.format(message, 60, expectedCapitalCount),
+	            String.format(message, 61, expectedCapitalCount),
+	            String.format(message, 66, expectedCapitalCount),
+	            String.format(message, 72, expectedCapitalCount),
+	            String.format(message, 78, expectedCapitalCount),
+	            String.format(message, 84, expectedCapitalCount),
+	            String.format(message, 88, expectedCapitalCount),
+	            String.format(message, 90, expectedCapitalCount),
+                String.format(message, 98, expectedCapitalCount),
+	    };
+	    verify(checkConfig, 
+	            getPath("InputAbbreviationAsWordInTypeNameCheck.java"), expected);
+	}
 }

--- a/sevntu-checks/src/test/resources/com/github/sevntu/checkstyle/checks/naming/InputAbbreviationAsWordInTypeNameCheck.java
+++ b/sevntu-checks/src/test/resources/com/github/sevntu/checkstyle/checks/naming/InputAbbreviationAsWordInTypeNameCheck.java
@@ -85,3 +85,21 @@ interface Interface4 {
 	
 }
 
+public class FIleNameFormatException extends Exception {
+
+    private static final long serialVersionUID = 1L;
+
+    public FIleNameFormatException(Exception e) {
+        super(e);
+    }
+}
+
+class StateX {
+    int userID;
+    int scaleX, scaleY, scaleZ;
+    
+    int getScaleX() {
+        return this.scaleX;
+    }
+}
+


### PR DESCRIPTION
I added only one condition(`abbrLength > 1`) for abbreviation at the end of word. So `scaleX` will be ignored. Also, checksyle formatter has been applied to this check.
