### PR TITLE
EnumValueName check implemented

### DIFF
--- a/sevntu-checks/src/main/java/com/github/sevntu/checkstyle/checks/naming/EnumValueName.java
+++ b/sevntu-checks/src/main/java/com/github/sevntu/checkstyle/checks/naming/EnumValueName.java
@@ -1,0 +1,125 @@
+////////////////////////////////////////////////////////////////////////////////
+// checkstyle: Checks Java source code for adherence to a set of rules.
+// Copyright (C) 2001-2013  Oliver Burn
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+////////////////////////////////////////////////////////////////////////////////
+package com.github.sevntu.checkstyle.checks.naming;
+
+import java.util.regex.Pattern;
+
+import com.puppycrawl.tools.checkstyle.api.DetailAST;
+import com.puppycrawl.tools.checkstyle.api.TokenTypes;
+import com.puppycrawl.tools.checkstyle.api.Utils;
+import com.puppycrawl.tools.checkstyle.checks.naming.AbstractNameCheck;
+
+/**
+ * Check forces enum values to match the specific pattern.
+ * @author Pavel Baranchikov
+ */
+public class EnumValueName extends AbstractNameCheck
+{
+    protected static final String MSG = "name.invalidPattern";
+    /**
+     * Default pattern for enum constant values.
+     */
+    protected static final String DEFAULT_CONST_PATTERN =
+            "^[A-Z][A-Z0-9]*(_[A-Z0-9]+)*$";
+    /**
+     * Default pattern for enum object values.
+     */
+    protected static final String DEFAULT_OBJ_PATTERN = "^[A-Z][a-zA-Z0-9]*$";
+
+    /**
+     * Regular expression to test enum object values against.
+     */
+    private Pattern mObjRegexp;
+    /**
+     * Format for enum object values to check for. Compiled to
+     * {@link #mObjRegexp}
+     */
+    private String mObjFormat;
+
+    /**
+     * Constructs check with the default pattern.
+     */
+    public EnumValueName()
+    {
+        super(DEFAULT_CONST_PATTERN);
+        setObjFormat(DEFAULT_OBJ_PATTERN);
+    }
+
+    @Override
+    public int[] getDefaultTokens()
+    {
+        return new int[]
+        {TokenTypes.ENUM_CONSTANT_DEF};
+    }
+
+    @Override
+    public void visitToken(DetailAST aAST)
+    {
+        if (mustCheckName(aAST)) {
+            final DetailAST nameAST = aAST.findFirstToken(TokenTypes.IDENT);
+            final boolean enumIsObject = isObject(aAST);
+            final Pattern pattern = enumIsObject ? getObjectRegexp()
+                    : getRegexp();
+            if (!pattern.matcher(nameAST.getText()).find()) {
+                final String format = enumIsObject ? getObjFormat()
+                        : getFormat();
+                log(nameAST.getLineNo(),
+                        nameAST.getColumnNo(),
+                        MSG,
+                        nameAST.getText(),
+                        format);
+            }
+        }
+    }
+
+    /**
+     * Method determines whether the specified enum is a constant or is an
+     * object.
+     * @param aAST token of a enum value definition
+     * @return <code>true</code> if enum is an object
+     */
+    protected boolean isObject(DetailAST aAST)
+    {
+        final DetailAST objBlock = aAST.getParent();
+        assert (objBlock.getType() == TokenTypes.OBJBLOCK);
+        final DetailAST methodDeclaration = objBlock
+                .findFirstToken(TokenTypes.METHOD_DEF);
+        return (methodDeclaration != null);
+    }
+
+    /**
+     * Method sets format to match enum object values.
+     * @param aObjectRegexp format to check against
+     */
+    public final void setObjFormat(String aObjectRegexp)
+    {
+        mObjRegexp = Utils.getPattern(aObjectRegexp, 0);
+        mObjFormat = aObjectRegexp;
+    }
+
+    public final Pattern getObjectRegexp()
+    {
+        return mObjRegexp;
+    }
+
+    public String getObjFormat()
+    {
+        return mObjFormat;
+    }
+}

--- a/sevntu-checks/src/test/java/com/github/sevntu/checkstyle/checks/naming/EnumValueNameTest.java
+++ b/sevntu-checks/src/test/java/com/github/sevntu/checkstyle/checks/naming/EnumValueNameTest.java
@@ -1,0 +1,123 @@
+////////////////////////////////////////////////////////////////////////////////
+// checkstyle: Checks Java source code for adherence to a set of rules.
+// Copyright (C) 2001-2013  Oliver Burn
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+////////////////////////////////////////////////////////////////////////////////
+package com.github.sevntu.checkstyle.checks.naming;
+
+import java.io.IOException;
+import java.text.MessageFormat;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import com.github.sevntu.checkstyle.BaseCheckTestSupport;
+import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
+import com.puppycrawl.tools.checkstyle.api.CheckstyleException;
+
+/**
+ * Test unit for
+ * {@link com.puppycrawl.tools.checkstyle.checks.naming.EnumValueName}.
+ * @author Pavel Baranchikov
+ */
+public class EnumValueNameTest extends BaseCheckTestSupport
+{
+    private final String msg = getCheckMessage(EnumValueName.MSG);
+    private final String inputFile;
+
+    public EnumValueNameTest() throws IOException
+    {
+        inputFile = getPath("InputEnumValueNameCheck.java");
+    }
+
+    /**
+     * Tests for a default naming patter - uppercase letters with underscores.
+     * @throws Exception on some errors during verification.
+     */
+    @Test
+    public void testDefault()
+        throws Exception
+    {
+        final DefaultConfiguration checkConfig =
+                createCheckConfig(EnumValueName.class);
+        final String constPattern = EnumValueName.DEFAULT_CONST_PATTERN;
+        final String objPattern = EnumValueName.DEFAULT_OBJ_PATTERN;
+        final String[] expected =
+        {
+                buildMessage(34, 9, "FirstSimple", constPattern),
+                buildMessage(34, 22, "SecondSimple", constPattern),
+                buildMessage(34, 36, "ThirdSimple", constPattern),
+                buildMessage(70, 9, "FIRST_COMPLEX", objPattern),
+                buildMessage(70, 27, "SECOND_COMPLEX", objPattern),
+                buildMessage(70, 46, "THIRD_COMPLEX", objPattern),
+        };
+        verify(checkConfig, inputFile, expected);
+    }
+
+    @Test
+    public void testInvalidFormat()
+        throws Exception
+    {
+        final DefaultConfiguration checkConfig =
+                createCheckConfig(EnumValueName.class);
+        checkConfig.addAttribute("format", "\\");
+        final String[] expected =
+        {
+        };
+        try {
+            verify(checkConfig, inputFile, expected);
+            Assert.fail();
+        }
+        catch (CheckstyleException ex) {
+            return;
+        }
+    }
+
+    /**
+     * Tests for a camel naming.
+     * @throws Exception on some errors during verification.
+     */
+    @Test
+    public void testUpset()
+        throws Exception
+    {
+        final DefaultConfiguration checkConfig =
+                createCheckConfig(EnumValueName.class);
+        final String constPattern = EnumValueName.DEFAULT_OBJ_PATTERN;
+        final String objPattern = EnumValueName.DEFAULT_CONST_PATTERN;
+        checkConfig.addAttribute("format", constPattern);
+        checkConfig.addAttribute("objFormat", objPattern);
+
+        final String[] expected =
+        {
+                buildMessage(42, 9, "FirstComplex", objPattern),
+                buildMessage(42, 26, "SecondComplex", objPattern),
+                buildMessage(42, 44, "ThirdComplex", objPattern),
+                buildMessage(62, 9, "FIRST_SIMPLE", constPattern),
+                buildMessage(62, 23, "SECOND_SIMPLE", constPattern),
+                buildMessage(62, 38, "THIRD_SIMPLE", constPattern),
+        };
+        verify(checkConfig, inputFile, expected);
+    }
+
+    private String buildMessage(int lineNumber, int colNumber,
+            String constName, String pattern)
+    {
+        return lineNumber + ":" + colNumber + ": "
+                + MessageFormat.format(msg, constName, pattern);
+    }
+
+}

--- a/sevntu-checks/src/test/resources/com/github/sevntu/checkstyle/checks/naming/InputEnumValueNameCheck.java
+++ b/sevntu-checks/src/test/resources/com/github/sevntu/checkstyle/checks/naming/InputEnumValueNameCheck.java
@@ -1,0 +1,85 @@
+////////////////////////////////////////////////////////////////////////////////
+// checkstyle: Checks Java source code for adherence to a set of rules.
+// Copyright (C) 2001-2013  Oliver Burn
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+////////////////////////////////////////////////////////////////////////////////
+package com.puppycrawl.tools.checkstyle.checks.naming;
+
+/**
+ * Test case for
+ * {@link com.puppycrawl.tools.checkstyle.checks.naming.EnumValueNameTest} unit
+ * test.
+ * @author Pavel Baranchikov
+ */
+public class InputEnumNamingCheck
+{
+    /**
+     * Cammel notation simple enums.
+     */
+    enum SimpleProperEnum
+    {
+        FirstSimple, SecondSimple, ThirdSimple;
+    }
+
+    /**
+     * Cammel notation complex enums.
+     */
+    enum ComplexProperEnum
+    {
+        FirstComplex(1), SecondComplex(2), ThirdComplex(3);
+
+        private final int intValue;
+
+        private ComplexProperEnum(int intValue)
+        {
+            this.intValue = intValue;
+        }
+
+        public int getIntValue()
+        {
+            return intValue;
+        }
+    }
+
+    /**
+     * uppercase notation simple enums.
+     */
+    enum SimpleErrorEnum
+    {
+        FIRST_SIMPLE, SECOND_SIMPLE, THIRD_SIMPLE;
+    }
+
+    /**
+     * uppercase notation complex enums.
+     */
+    enum ComplexErrorEnum
+    {
+        FIRST_COMPLEX(1), SECOND_COMPLEX(2), THIRD_COMPLEX(3);
+
+        private final int intValue;
+
+        private ComplexErrorEnum(int intValue)
+        {
+            this.intValue = intValue;
+        }
+
+        public int getIntValue()
+        {
+            return intValue;
+        }
+    }
+
+}


### PR DESCRIPTION
This check should force a specific formatting of  enum values. As of a discussion for what we should call constants and what - static objects, the suggested check provides an ability to specify format for them differently. Distinguishing (discussed in https://github.com/checkstyle/checkstyle/issues/23#issuecomment-26578088) is made on the basis of user-defined methods existing in the enum class.

Unfortunately, I could not find any references to xdocs, that is why they are absent here at all.
