### PR TITLE
improved InterfaceTypeParameterNameCheck code coverage

### DIFF
--- a/sevntu-checks/pom.xml
+++ b/sevntu-checks/pom.xml
@@ -126,7 +126,6 @@
                     <regex><pattern>.*.checks.design.NoMainMethodInAbstractClassCheck</pattern><branchRate>92</branchRate><lineRate>98</lineRate></regex>
                     <regex><pattern>.*.checks.design.PublicReferenceToPrivateTypeCheck</pattern><branchRate>97</branchRate><lineRate>98</lineRate></regex>
                     <regex><pattern>.*.checks.naming.EnumValueNameCheck</pattern><branchRate>86</branchRate><lineRate>100</lineRate></regex>
-                    <regex><pattern>.*.checks.naming.InterfaceTypeParameterNameCheck</pattern><branchRate>50</branchRate><lineRate>85</lineRate></regex>
                     <regex><pattern>.*.checks.sizes.LineLengthExtendedCheck</pattern><branchRate>100</branchRate><lineRate>6</lineRate></regex>
                     <regex><pattern>com.github.sevntu.checkstyle.Utils</pattern><branchRate>0</branchRate><lineRate>0</lineRate></regex>
                 </regexes>

--- a/sevntu-checks/src/main/java/com/github/sevntu/checkstyle/checks/naming/InterfaceTypeParameterNameCheck.java
+++ b/sevntu-checks/src/main/java/com/github/sevntu/checkstyle/checks/naming/InterfaceTypeParameterNameCheck.java
@@ -70,12 +70,7 @@ public class InterfaceTypeParameterNameCheck
     @Override
     protected final boolean mustCheckName(DetailAST ast)
     {
-        DetailAST location =    
-        		ast.getParent().getParent();
-
-        if (location.getType() == TokenTypes.MODIFIERS) {
-            location = location.getParent();
-        }
+        DetailAST location = ast.getParent().getParent();
 
         return location.getType() == TokenTypes.INTERFACE_DEF;
     }

--- a/sevntu-checks/src/test/java/com/github/sevntu/checkstyle/checks/naming/TypeParameterNameTest.java
+++ b/sevntu-checks/src/test/java/com/github/sevntu/checkstyle/checks/naming/TypeParameterNameTest.java
@@ -21,7 +21,6 @@ package com.github.sevntu.checkstyle.checks.naming;
 import org.junit.Test;
 
 import com.github.sevntu.checkstyle.BaseCheckTestSupport;
-import com.github.sevntu.checkstyle.checks.naming.InterfaceTypeParameterNameCheck;
 import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
 
 public class TypeParameterNameTest
@@ -38,8 +37,10 @@ public class TypeParameterNameTest
                 createCheckConfig(InterfaceTypeParameterNameCheck.class);
 
         final String[] expected = {
-        	"2:51: " + getCheckMessage(MSG_KEY, "it", "^[A-Z]$"),
-        	"6:27: " + getCheckMessage(MSG_KEY, "foo", "^[A-Z]$"),
+        	"5:51: " + getCheckMessage(MSG_KEY, "it", "^[A-Z]$"),
+        	"9:27: " + getCheckMessage(MSG_KEY, "foo", "^[A-Z]$"),
+        	"18:34: " + getCheckMessage(MSG_KEY, "Taa", "^[A-Z]$"),
+        	"18:52: " + getCheckMessage(MSG_KEY, "Vaa", "^[A-Z]$"),
         };
         verify(checkConfig, getPath("InputInterfaceTypeParameterName.java"), expected);
     }
@@ -52,8 +53,10 @@ public class TypeParameterNameTest
                 createCheckConfig(InterfaceTypeParameterNameCheck.class);
         checkConfig.addAttribute("format", "^foo$");
         final String[] expected = {
-        	"2:51: " + getCheckMessage(MSG_KEY, "it", "^foo$"),
-        	"10:27: " + getCheckMessage(MSG_KEY, "A", "^foo$"),
+        	"5:51: " + getCheckMessage(MSG_KEY, "it", "^foo$"),
+        	"13:27: " + getCheckMessage(MSG_KEY, "A", "^foo$"),
+        	"18:34: " + getCheckMessage(MSG_KEY, "Taa", "^foo$"),
+        	"18:52: " + getCheckMessage(MSG_KEY, "Vaa", "^foo$"),
         };
         verify(checkConfig, getPath("InputInterfaceTypeParameterName.java"), expected);
     }

--- a/sevntu-checks/src/test/resources/com/github/sevntu/checkstyle/checks/naming/InputInterfaceTypeParameterName.java
+++ b/sevntu-checks/src/test/resources/com/github/sevntu/checkstyle/checks/naming/InputInterfaceTypeParameterName.java
@@ -1,4 +1,7 @@
 package com.github.sevntu.checkstyle.checks.naming;
+
+import java.util.List;
+
 public interface InputInterfaceTypeParameterName <it> {
 
 }
@@ -9,4 +12,9 @@ interface OtherInterface <foo>{
 
 interface ThirdInterface <A>{
 	void action2();
+}
+
+class OuterClass <Aaa> {
+	interface InnerInterface<Taa extends List, Vaa> {
+	}
 }


### PR DESCRIPTION
Pull #320

- reduced condition that will never be true (modifiers are not direct parent for type definitions)
- added example which introduces interface as inner definition for outer class
- added example such as <T extends List>