### PR TITLE
Short-circuit logic is used in boolean expressions, issue #169

### DIFF
--- a/sevntu-checks/src/main/java/com/github/sevntu/checkstyle/checks/coding/CustomDeclarationOrderCheck.java
+++ b/sevntu-checks/src/main/java/com/github/sevntu/checkstyle/checks/coding/CustomDeclarationOrderCheck.java
@@ -1339,7 +1339,7 @@ public class CustomDeclarationOrderCheck extends Check
         public Map<DetailAST, DetailAST> getWrongOrderedGettersSetters()
         {
             final Map<DetailAST, DetailAST> result = new LinkedHashMap<DetailAST, DetailAST>();
-            if (!getters.isEmpty() & !setters.isEmpty()) {
+            if (!getters.isEmpty() && !setters.isEmpty()) {
                 //  all getters and setters
                 final List<DetailAST> allGettersSetters = new ArrayList<DetailAST>(getters);
                 allGettersSetters.addAll(setters);

--- a/sevntu-checks/src/main/java/com/github/sevntu/checkstyle/checks/coding/MultipleVariableDeclarationsExtendedCheck.java
+++ b/sevntu-checks/src/main/java/com/github/sevntu/checkstyle/checks/coding/MultipleVariableDeclarationsExtendedCheck.java
@@ -150,11 +150,11 @@ public class MultipleVariableDeclarationsExtendedCheck extends Check
 		if (inClass) {
 			work(token);
 		}
-		else if (!ignoreCycles & inFor) {
+		else if (!ignoreCycles && inFor) {
 			work(token);
 		}
 
-		else if (!ignoreMethods & !inClass & !inFor) {
+		else if (!ignoreMethods && !inClass && !inFor) {
 			work(token);
 		}
 


### PR DESCRIPTION
All violations of rule [Short-circuit logic should be used in boolean contexts](http://nemo.sonarqube.org/coding_rules#rule_key=squid%3AS2178) are fixed.