### PR TITLE
Introducing WhitespaceBeforeArrayInitializerCheck, fixing issue #333

### DIFF
--- a/sevntu-checks/src/main/java/com/github/sevntu/checkstyle/checks/coding/WhitespaceBeforeArrayInitializerCheck.java
+++ b/sevntu-checks/src/main/java/com/github/sevntu/checkstyle/checks/coding/WhitespaceBeforeArrayInitializerCheck.java
@@ -1,0 +1,99 @@
+package com.github.sevntu.checkstyle.checks.coding;
+
+import com.puppycrawl.tools.checkstyle.api.Check;
+import com.puppycrawl.tools.checkstyle.api.DetailAST;
+import com.puppycrawl.tools.checkstyle.api.TokenTypes;
+
+/**
+ * <p>
+ * This checks enforces whitespace before array initializer
+ * </p>
+ * Examples:
+ * This code is perfectly valid:
+ * <p>
+ * <code>
+ * <pre>
+ * int[] ints = new int[] {
+ *     0, 1, 2, 3
+ * };
+ * </pre>
+ * </code>
+ * </p>
+ * This example is valid too:
+ * <p>
+ * <code>
+ * <pre>
+ * int[] tab = new int[]
+ *                 {0, 1, 2, 3}
+ * </pre>
+ * </code>
+ * </p>
+ * But this violates check:
+ * <p>
+ * <code>
+ * <pre>
+ * int[] ints = new int[]{0, 1, 2, 3};
+ * </pre>
+ * </code>
+ * </p>
+ *
+ * @author <a href="mailto:piotr.listkiewicz@gmail.com">liscju</a>
+ */
+public class WhitespaceBeforeArrayInitializerCheck extends Check {
+
+    /**
+     * Violation message key.
+     */
+    public static final String MSG_KEY = "whitespace.before.array.initializer";
+
+    @Override
+    public int[] getDefaultTokens() {
+        return new int[] {TokenTypes.ARRAY_INIT};
+    }
+
+    @Override
+    public void visitToken(DetailAST ast) {
+        DetailAST previousAst = getPreviousAst(ast);
+        if (!areTokensSeparatedByWhitespace(previousAst, ast)) {
+            log(ast.getLineNo(), ast.getColumnNo(), MSG_KEY);
+        }
+    }
+
+    /**
+     * Checks if firstAst and secondAst are separated by whitespace
+     * @param firstAST DetailAST
+     * @param secondAST DetailAST
+     * @return true if firstAST and secondAST are separated by whitespace,false otherwise
+     */
+    private static boolean areTokensSeparatedByWhitespace(DetailAST firstAST, DetailAST secondAST) {
+        boolean isDistanceValid = true;
+        int columnDistance = secondAST.getColumnNo() - firstAST.getColumnNo();
+        if (columnDistance == 1) {
+            int lineDistance = secondAST.getLineNo() - firstAST.getLineNo();
+            if (lineDistance == 0) {
+                isDistanceValid = false;
+            }
+        }
+        return isDistanceValid;
+    }
+
+    /**
+     * Calculate previous ast from given
+     * @param ast given ast
+     * @return previous ast
+     */
+    private static DetailAST getPreviousAst(DetailAST ast) {
+        DetailAST previousAst;
+        if (ast.getPreviousSibling() != null) {
+            DetailAST previousSibling = ast.getPreviousSibling();
+            if (previousSibling.getChildCount() > 0) {
+                previousAst = previousSibling.getLastChild();
+            } else {
+                previousAst = previousSibling;
+            }
+        } else {
+            previousAst = ast.getParent();
+        }
+        return previousAst;
+    }
+}

--- a/sevntu-checks/src/main/resources/com/github/sevntu/checkstyle/checks/coding/messages.properties
+++ b/sevntu-checks/src/main/resources/com/github/sevntu/checkstyle/checks/coding/messages.properties
@@ -106,3 +106,4 @@ useless.super.ctor.call.in.not.derived.class= Super call could be removed: Class
 useless.super.ctor.call.without.args= Redundant super constructor call could be removed. Class ''{0}'' has superclass. Java compiler automatically inserts a call to the no-argument constructor of the superclass.
 return.null.Boolean=Method declares to return Boolean and returns null.
 return.boolean.ternary=Returning explicit boolean from ternary operator.
+whitespace.before.array.initializer=Array initializer should have whitespace before.

--- a/sevntu-checks/src/test/java/com/github/sevntu/checkstyle/checks/coding/WhitespaceBeforeArrayInitializerCheckTest.java
+++ b/sevntu-checks/src/test/java/com/github/sevntu/checkstyle/checks/coding/WhitespaceBeforeArrayInitializerCheckTest.java
@@ -1,0 +1,23 @@
+package com.github.sevntu.checkstyle.checks.coding;
+
+import com.github.sevntu.checkstyle.BaseCheckTestSupport;
+import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
+import org.junit.Test;
+
+import static com.github.sevntu.checkstyle.checks.coding.WhitespaceBeforeArrayInitializerCheck.MSG_KEY;
+
+public class WhitespaceBeforeArrayInitializerCheckTest extends BaseCheckTestSupport
+{
+    private final DefaultConfiguration mDefaultConfig = createCheckConfig(WhitespaceBeforeArrayInitializerCheck.class);
+
+    @Test
+    public void testWhitespaceBeforeArrayInitializer() throws Exception {
+        final String expected[] = {
+                "5:28: " + getCheckMessage(MSG_KEY),
+                "13:32: " + getCheckMessage(MSG_KEY),
+                "16:32: " + getCheckMessage(MSG_KEY),
+                "17:21: " + getCheckMessage(MSG_KEY)
+        };
+        verify(mDefaultConfig, getPath("InputWhitespaceBeforeArrayIntializer.java"), expected);
+    }
+}

--- a/sevntu-checks/src/test/resources/com/github/sevntu/checkstyle/checks/coding/InputWhitespaceBeforeArrayIntializer.java
+++ b/sevntu-checks/src/test/resources/com/github/sevntu/checkstyle/checks/coding/InputWhitespaceBeforeArrayIntializer.java
@@ -1,0 +1,28 @@
+package com.github.sevntu.checkstyle.checks.coding;
+
+public class InputWhitespaceBeforeArrayIntializer {
+    public void check(String[] args) {
+        calculate(new int[]{1,2,3,4});
+        int[] ints0 = {1,2,3,4};
+        int[] ints1 = new int[] {0, 1, 2, 3};
+        int[] ints2 = new int[] {
+            0, 1, 2, 3
+        };
+        int[] ints3 = new int[]
+            {0, 1, 2, 3};
+        int[] ints4 = new int[]{
+            0, 1, 2, 3
+        };
+        int[] ints5 = new int[]{0, 1, 2, 3};
+        int ints6[]={1,2,3};
+        int[] ints7 = new int[]
+                               {0, 1, 2, 3};
+        int[][] nested_ints = {
+                {1, 2, 3, 4, 5},
+                {6, 7, 8, 9, 10}
+        };
+    }
+    private int calculate(int[] tab) {
+        return tab.length;
+    }
+}


### PR DESCRIPTION
Introduces new WhitespaceBeforeArrayInitializerCheck. When we deal with Array Initializer we have to deal with two situations:
a) int ints[] = {1, 2, 3, 4};
b) new int[] {1,2,3,4}
In first situation we have to check where lays the parent of Array Initializer(Assignment) , in second we have to check previous sibling (Array Declarator int[]).