### PR TITLE
Update to checkstyle 6.7 Fixes #351

### DIFF
--- a/sevntu-checks/pom.xml
+++ b/sevntu-checks/pom.xml
@@ -16,7 +16,7 @@
 	<dependency>
 	  <groupId>com.puppycrawl.tools</groupId>
 	  <artifactId>checkstyle</artifactId>
-	  <version>6.5</version>
+	  <version>6.7</version>
 	</dependency>
 	
 	<dependency>

--- a/sevntu-checks/src/main/java/com/github/sevntu/checkstyle/Utils.java
+++ b/sevntu-checks/src/main/java/com/github/sevntu/checkstyle/Utils.java
@@ -41,7 +41,7 @@ public final class Utils
     public static void reportInvalidToken(int token)
     {
         throw new IllegalArgumentException("Found unsupported token: "
-                + TokenTypes.getTokenName(token));
+                + com.puppycrawl.tools.checkstyle.Utils.getTokenName(token));
     }
 
     /**

--- a/sevntu-checks/src/main/java/com/github/sevntu/checkstyle/checks/annotation/ForbidAnnotationCheck.java
+++ b/sevntu-checks/src/main/java/com/github/sevntu/checkstyle/checks/annotation/ForbidAnnotationCheck.java
@@ -22,6 +22,7 @@ import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Set;
 
+import com.puppycrawl.tools.checkstyle.Utils;
 import com.puppycrawl.tools.checkstyle.api.Check;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
 import com.puppycrawl.tools.checkstyle.api.TokenTypes;
@@ -76,7 +77,7 @@ public class ForbidAnnotationCheck extends Check
         if (targets != null) {
             annotationTargets = new int[targets.length];
             for (int i = 0; i < targets.length; i++) {
-                annotationTargets[i] = TokenTypes.getTokenId(targets[i]);
+                annotationTargets[i] = Utils.getTokenId(targets[i]);
             }
             Arrays.sort(annotationTargets);
         }

--- a/sevntu-checks/src/main/java/com/github/sevntu/checkstyle/checks/coding/AvoidConstantAsFirstOperandInConditionCheck.java
+++ b/sevntu-checks/src/main/java/com/github/sevntu/checkstyle/checks/coding/AvoidConstantAsFirstOperandInConditionCheck.java
@@ -18,6 +18,7 @@
 ////////////////////////////////////////////////////////////////////////////////
 package com.github.sevntu.checkstyle.checks.coding;
 
+import com.puppycrawl.tools.checkstyle.Utils;
 import com.puppycrawl.tools.checkstyle.api.Check;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
 import com.puppycrawl.tools.checkstyle.api.TokenTypes;
@@ -70,7 +71,7 @@ public class AvoidConstantAsFirstOperandInConditionCheck extends Check {
         if (targets != null) {
             targetConstantTypes = new int[targets.length];
             for (int i = 0; i < targets.length; i++) {
-                targetConstantTypes[i] = TokenTypes.getTokenId(targets[i]);
+                targetConstantTypes[i] = Utils.getTokenId(targets[i]);
             }
             Arrays.sort(targetConstantTypes);
         }

--- a/sevntu-checks/src/main/java/com/github/sevntu/checkstyle/checks/coding/MultipleStringLiteralsExtendedCheck.java
+++ b/sevntu-checks/src/main/java/com/github/sevntu/checkstyle/checks/coding/MultipleStringLiteralsExtendedCheck.java
@@ -26,6 +26,7 @@ import java.util.regex.Pattern;
 
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
+import com.puppycrawl.tools.checkstyle.Utils;
 import com.puppycrawl.tools.checkstyle.api.Check;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
 import com.puppycrawl.tools.checkstyle.api.TokenTypes;
@@ -124,7 +125,7 @@ public class MultipleStringLiteralsExtendedCheck extends Check
 	{
 		ignoreOccurrenceContext.clear();
 		for (final String s : strRep) {
-			final int type = TokenTypes.getTokenId(s);
+			final int type = Utils.getTokenId(s);
 			ignoreOccurrenceContext.set(type);
 		}
 	}

--- a/sevntu-checks/src/main/java/com/github/sevntu/checkstyle/checks/design/ChildBlockLengthCheck.java
+++ b/sevntu-checks/src/main/java/com/github/sevntu/checkstyle/checks/design/ChildBlockLengthCheck.java
@@ -22,6 +22,7 @@ import java.util.LinkedList;
 import java.util.List;
 
 import com.google.common.collect.Lists;
+import com.puppycrawl.tools.checkstyle.Utils;
 import com.puppycrawl.tools.checkstyle.api.Check;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
 import com.puppycrawl.tools.checkstyle.api.TokenTypes;
@@ -102,7 +103,7 @@ public class ChildBlockLengthCheck extends Check
     {
         this.blockTypes = new int[blockTypes.length];
         for (int i = 0; i < blockTypes.length; i++) {
-            this.blockTypes[i] = TokenTypes.getTokenId(blockTypes[i]);
+            this.blockTypes[i] = Utils.getTokenId(blockTypes[i]);
         }
     }
 

--- a/sevntu-checks/src/test/java/com/github/sevntu/checkstyle/BaseCheckTestSupport.java
+++ b/sevntu-checks/src/test/java/com/github/sevntu/checkstyle/BaseCheckTestSupport.java
@@ -10,6 +10,7 @@ import java.io.IOException;
 import java.io.InputStreamReader;
 import java.io.OutputStream;
 import java.io.PrintStream;
+import java.io.UnsupportedEncodingException;
 import java.net.URL;
 import java.util.List;
 import java.util.Locale;
@@ -31,7 +32,7 @@ public abstract class BaseCheckTestSupport extends Assert
 	protected static class BriefLogger extends DefaultLogger
 	{
 
-		public BriefLogger(OutputStream out)
+		public BriefLogger(OutputStream out) throws UnsupportedEncodingException
 		{
 			super(out, true);
 		}


### PR DESCRIPTION
TokenTypes methods getTokenId() and getTokenName() moved to Utils in
checkstyle 6.7.

DefaultLogger now trows UnsupportedEncodingExpection in 6.7.