### PR TITLE
Add SuppressionAnnotationFilter

### DIFF
--- a/eclipsecs-sevntu-plugin/src/checkstyle_packages.xml
+++ b/eclipsecs-sevntu-plugin/src/checkstyle_packages.xml
@@ -20,5 +20,6 @@
       <package name="whitespace"/>
     </package>
     <package name="grammars"/>
+    <package name="filters"/>
   </package>
 </checkstyle-packages>

--- a/sevntu-checks/import-control.xml
+++ b/sevntu-checks/import-control.xml
@@ -3,7 +3,7 @@
     "-//Puppy Crawl//DTD Import Control 1.1//EN"
     "http://www.puppycrawl.com/dtds/import_control_1_1.dtd">
 
-<import-control pkg="com.github.sevntu.checkstyle.checks">
+<import-control pkg="com.github.sevntu.checkstyle">
 
   <allow pkg="antlr"/>
   <allow pkg="org.antlr.v4.runtime"/>
@@ -67,6 +67,7 @@
 
   <subpackage name="filters">
     <allow pkg="java.lang.ref"/>
+    <allow class="com.github.sevntu.checkstyle.checks.DetailAstRootHolder" local-only="true"/>
   </subpackage>
 
   <subpackage name="gui">

--- a/sevntu-checks/src/main/java/com/github/sevntu/checkstyle/checks/DetailAstRootHolder.java
+++ b/sevntu-checks/src/main/java/com/github/sevntu/checkstyle/checks/DetailAstRootHolder.java
@@ -1,0 +1,71 @@
+////////////////////////////////////////////////////////////////////////////////
+// checkstyle: Checks Java source code for adherence to a set of rules.
+// Copyright (C) 2001-2016 the original author or authors.
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+////////////////////////////////////////////////////////////////////////////////
+
+package com.github.sevntu.checkstyle.checks;
+
+import com.puppycrawl.tools.checkstyle.api.Check;
+import com.puppycrawl.tools.checkstyle.api.DetailAST;
+
+/**
+ * Holds the link to the root of AST.
+ * Copy of FileContentsHolder.
+ * @author Mike McMahon
+ * @author Rick Giles
+ * @author attatrol
+ * @see com.puppycrawl.tools.checkstyle.checks.FileContentsHolder
+ */
+public class DetailAstRootHolder extends Check {
+    /** Thread local reference on the root of the current AST. */
+    private static final ThreadLocal<DetailAST> ROOT = new ThreadLocal<>();
+
+    /**
+     * @return reference on the root of the current AST.
+     */
+    public static DetailAST getASTRootReference() {
+        return ROOT.get();
+    }
+
+    @Override
+    public int[] getDefaultTokens() {
+        return new int[0];
+    }
+
+    @Override
+    public int[] getRequiredTokens() {
+        return new int[0];
+    }
+
+    @Override
+    public int[] getAcceptableTokens() {
+        return new int[0];
+    }
+
+    @Override
+    /**
+     * Creates new reference on the root of AST.
+     */
+    public void beginTree(DetailAST rootAST) {
+        ROOT.set(rootAST);
+    }
+
+    @Override
+    public void destroy() {
+        ROOT.remove();
+    }
+}

--- a/sevntu-checks/src/main/java/com/github/sevntu/checkstyle/checks/package-info.java
+++ b/sevntu-checks/src/main/java/com/github/sevntu/checkstyle/checks/package-info.java
@@ -1,0 +1,23 @@
+////////////////////////////////////////////////////////////////////////////////
+// checkstyle: Checks Java source code for adherence to a set of rules.
+// Copyright (C) 2001-2016 the original author or authors.
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+////////////////////////////////////////////////////////////////////////////////
+
+/**
+ * Contains the checks that are bundled with the main distribution.
+ */
+package com.github.sevntu.checkstyle.checks;

--- a/sevntu-checks/src/main/java/com/github/sevntu/checkstyle/filters/SuppressionAnnotationFilter.java
+++ b/sevntu-checks/src/main/java/com/github/sevntu/checkstyle/filters/SuppressionAnnotationFilter.java
@@ -1,0 +1,501 @@
+////////////////////////////////////////////////////////////////////////////////
+// checkstyle: Checks Java source code for adherence to a set of rules.
+// Copyright (C) 2001-2016 the original author or authors.
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+////////////////////////////////////////////////////////////////////////////////
+
+package com.github.sevntu.checkstyle.filters;
+
+import java.lang.ref.WeakReference;
+import java.util.List;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.regex.PatternSyntaxException;
+
+import com.github.sevntu.checkstyle.checks.DetailAstRootHolder;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Sets;
+import com.puppycrawl.tools.checkstyle.api.AuditEvent;
+import com.puppycrawl.tools.checkstyle.api.AutomaticBean;
+import com.puppycrawl.tools.checkstyle.api.CheckstyleException;
+import com.puppycrawl.tools.checkstyle.api.DetailAST;
+import com.puppycrawl.tools.checkstyle.api.Filter;
+import com.puppycrawl.tools.checkstyle.api.TokenTypes;
+
+/**
+ * <p>
+ * A filter that uses defined annotations to suppress defined audit events.
+ * </p>
+ * <p>
+ * Structurally based on SupressionCommentFilter.
+ * </p>
+ * <p>
+ * Usage:
+ * </p>
+ *
+ * <p>1. Make sure that AST is available to the filter by enabling DetailASTRootHolder:<br/>
+ * <pre>
+ * &lt;module name="TreeWalker"&gt;
+ *     ...
+ *     &lt;module name="DetailASTRootHolder"/&gt;
+ *     ...
+ * &lt;/module&gt;
+ * </pre>
+ * </p>
+ *
+ * <p>2. To configure a filter to suppress audit events for a certain annotated entities add:
+ * <br/>
+ * <pre>
+ * &lt;module name="Checker"&gt;
+ *     ...
+ *     &lt;module name="SuppressionAnnotationFilter"&gt;
+ *         &lt;property name="annotationNames" value="MyAnnotation, Generated"/&gt;
+ *     &lt;/module&gt;
+ *     ...
+ * &lt;/module&gt;
+ *      </pre>
+ * "annotationNames" defines a list of suppressor annotations, they may start
+ * from '@' symbol or not. Annotation names also may be given in a fully-qualified form,
+ * but internally they will be reduced to a simple form, and any annotation with that simple
+ * name will match. One may find particularly useful to suppress generated code marked with
+ * {@code @Generated} annotation, see
+ * <a href = "https://docs.oracle.com/javase/7/docs/api/javax/annotation/Generated.html">
+ * https://docs.oracle.com/javase/7/docs/api/javax/annotation/Generated.html </a>
+ * </p>
+ *
+ * <p>3.To configure a filter to suppress audit events for a certain annotated entities but
+ * allow passing of some checks through filter add:<br/>
+ * <pre>
+ * &lt;module name="Checker&gt;
+ *      ...
+ *      &lt;module name="SuppressionAnnotationFilter"&gt;
+ *          &lt;property name="annotationNames" value="MyAnnotation, Generated"/&gt;
+ *          &lt;property name="checkNames" value=".*Name.*"/&gt;
+ *      &lt;/module&gt;
+ *      ...
+ * &lt;/module&gt;
+ * </pre>
+ * "checkNames" defines a regular expression which must be found in name of the check
+ * in order to pass through.
+ * </p>
+ *
+ * <p>4.It is possible to avoid usage of regular expressions and simply list permitted
+ * check's names:<br/>
+ * <pre>
+ * &lt;module name="Checker&gt;
+ *      ...
+ *      &lt;module name="SuppressionAnnotationFilter"&gt;
+ *          &lt;property name="annotationNames" value="MyAnnotation, Generated"/&gt;
+ *          &lt;property name="checkNames" value="ThrowsCountCheck, FinalClassCheck"/&gt;
+ *      &lt;/module&gt;
+ *      ...
+ * &lt;/module&gt;
+ * </pre>
+ * </p>
+ *
+ * <p>5.In context of this filter annotations themselves, javadocs, access modifiers
+ * and other modifiers such as 'synchronized', 'transient' are
+ * called 'modifiers' and by default excluded from action of the filter.
+ * To add them into suppressed ranges,
+ * set "modifiersExcluded" to "false". Default value is "true":<br/>
+ *  <pre>
+ * &lt;module name="Checker&gt;
+ *      ...
+ *      &lt;module name="SuppressionAnnotationFilter"&gt;
+ *          &lt;property name="annotationNames" value="MyAnnotation, Generated"/&gt;
+ *          &lt;property name="modifiersExcluded" value="false"/&gt;
+ *      &lt;/module&gt;
+ *      ...
+ * &lt;/module&gt;
+ * </pre>
+ * </p>
+ * @author attatrol
+ * @see com.puppycrawl.tools.checkstyle.filters.SupressionCommentFilter
+ * @see com.github.sevntu.checkstyle.checks.DetailASTRootHolder
+ */
+public class SuppressionAnnotationFilter extends AutomaticBean implements Filter {
+
+    /** Set containing names of suppressive annotations. */
+    private Set<String> annotationNames = Sets.newHashSet();
+
+    /** The check format to suppress. */
+    private Set<String> checkNames = Sets.newHashSet();
+
+    /** Excludes modifiers from check if set true. */
+    private boolean modifiersExcluded = true;
+
+    /** The parsed check regexp, expanded for the text of this tag. */
+    private List<Pattern> checkRegexp = Lists.newArrayList();
+
+    /** Ranges of tokens being suppressed. */
+    private List<SuppressRange> ranges = Lists.newArrayList();
+
+    /**
+     * Reference to the root of the current AST. Since this is a weak reference to the AST, it can
+     * be reclaimed as soon as the strong references in TreeWalker are reassigned to the next AST,
+     * at which time filtering for the current AST is finished.
+     */
+    private WeakReference<DetailAST> currentASTRootRef = new WeakReference<>(null);
+
+    /**
+     * Sets the names of suppressive annotations.
+     * @param annotations
+     *        , the set of file extensions.
+     */
+    public void setAnnotationNames(String... annotations) {
+        for (String str : annotations) {
+            annotationNames.add(getSimpleName(str));
+        }
+    }
+
+    /**
+     * Getter for annotationsExcluded.
+     * @return excludeAnnotations, excludes annotations from check if set true.
+     */
+    public boolean isModifiersExcluded() {
+        return modifiersExcluded;
+    }
+
+    /**
+     * Setter for annotationsExcluded.
+     * @param excluded
+     *        , set value for excludeAnnotations
+     */
+    public void setModifiersExcluded(boolean excluded) {
+        modifiersExcluded = excluded;
+    }
+
+    /**
+     * Setter for checkNames.
+     * @param checks
+     *        , contains patterns for non-suppressed checks.
+     */
+    public void setCheckNames(String... checks) {
+        for (String string : checks) {
+            checkNames.add(string);
+        }
+    }
+
+    /**
+     * {@inheritDoc} Creates checkRegexp from checkFormat.
+     */
+    @Override
+    protected void finishLocalSetup()
+            throws CheckstyleException {
+        for (String string : checkNames) {
+            try {
+                checkRegexp.add(Pattern.compile(string));
+            }
+            catch (final PatternSyntaxException ex) {
+                throw new CheckstyleException("unable to compile check names regex " + string, ex);
+            }
+        }
+    }
+
+    /**
+     * {@inheritDoc} Filters event.
+     */
+    @Override
+    public boolean accept(AuditEvent event) {
+        final boolean accept;
+        if (event.getLocalizedMessage() == null || matchesCheck(event)) {
+            accept = true;
+        }
+        else {
+            final DetailAST currentRoot = DetailAstRootHolder.getASTRootReference();
+            if (currentRoot == null) {
+                accept = true;
+            }
+            else {
+                resetLocalData(currentRoot);
+                accept = !isIncludedInSuppressedRanges(event);
+            }
+        }
+        return accept;
+    }
+
+    /**
+     * Produces simple form from the annotation name.
+     * @param annotationName
+     *        , incoming annotation name.
+     * @return simple form of the annotation name.
+     */
+    private static String getSimpleName(String annotationName) {
+        final String simpleName;
+        if (annotationName.charAt(0) == '@') {
+            simpleName = annotationName.substring(1);
+        }
+        else {
+            simpleName = annotationName;
+        }
+        final int lastIndexOfPoint = simpleName.lastIndexOf('.');
+        return simpleName.substring(lastIndexOfPoint + 1);
+    }
+
+    /**
+     * If weak reference from DetailASTRootHolder gets update
+     * then resets ranges of suppression according to new AST.
+     * @param currentRoot
+     *        , current AST root reference.
+     */
+    private void resetLocalData(DetailAST currentRoot) {
+        final DetailAST localRoot = currentASTRootRef.get();
+        if (currentRoot != localRoot) {
+            currentASTRootRef =
+                    new WeakReference<DetailAST>(
+                        DetailAstRootHolder.getASTRootReference());
+            //clearing ranges here is a preparation for a recursive reset.
+            ranges.clear();
+            traverseAst(currentRoot);
+        }
+    }
+
+    /**
+     * Checks if event coordinates belong to some range in the set.
+     * @param event
+     *        , audited event.
+     * @return result of this check.
+     */
+    private boolean isIncludedInSuppressedRanges(AuditEvent event) {
+        boolean isIncluded = false;
+        final int eventColumn = event.getColumn();
+        final int eventLine = event.getLine();
+        for (SuppressRange range : ranges) {
+            if (range.isInRange(eventLine, eventColumn)) {
+                isIncluded = true;
+                break;
+            }
+        }
+        return isIncluded;
+    }
+
+    /**
+     * Searches AST for new ranges, where audit events are suppressed.
+     * @param currentRoot
+     *        , AST tree node, should be the root node.
+     */
+    private void traverseAst(DetailAST currentRoot) {
+        // it was already checked that node != null,
+        // in accept method, in case of root AST.
+        if (!findSuppressedRange(currentRoot)) {
+            final DetailAST child = currentRoot.getFirstChild();
+            if (child != null) {
+                traverseAst(child);
+            }
+        }
+        final DetailAST sibling = currentRoot.getNextSibling();
+        if (sibling != null) {
+            traverseAst(sibling);
+        }
+    }
+
+    /**
+     * Checks if this node has suppressive annotation, if it has, adds range occupied by it into
+     * range list.
+     * @param node
+     *        , AST tree node.
+     * @return if node was suppressed.
+     */
+    private boolean findSuppressedRange(DetailAST node) {
+        boolean belongsToSuppressedRange = false;
+        final DetailAST modifiers = node.findFirstToken(TokenTypes.MODIFIERS);
+        if (modifiers != null) {
+            DetailAST annotation = modifiers.findFirstToken(TokenTypes.ANNOTATION);
+            while (annotation != null) {
+                if (annotation.getType() == TokenTypes.ANNOTATION) {
+                    final String name = getAnnotationName(annotation);
+                    if (annotationNames.contains(name)) {
+                        ranges.add(getSuppressRange(node));
+                        belongsToSuppressedRange = true;
+                        break;
+                    }
+                }
+                annotation = annotation.getNextSibling();
+            }
+        }
+        return belongsToSuppressedRange;
+    }
+
+    /**
+     * Recovers string name of annotation from tree.
+     * @param annotation
+     *        , node which is annotation.
+     * @return simple name of the annotation.
+     */
+    private static String getAnnotationName(DetailAST annotation) {
+        DetailAST node = annotation.findFirstToken(TokenTypes.AT).getNextSibling();
+        final DetailAST returnNode = node;
+        while (node.getType() != TokenTypes.IDENT) {
+            node = node.getFirstChild();
+        }
+        String simpleName = node.getText();
+        if (node.getNextSibling() != null) {
+            while (node != returnNode) {
+                simpleName = node.getNextSibling().getText();
+                node = node.getParent();
+            }
+        }
+        return simpleName;
+    }
+
+    /**
+     * Generates a range occupied by the node in the list of all ranges which are to suppress.
+     * @param node
+     *        , that is annotated with suppressive annotation.
+     * @return new SuppressRange instance.
+     */
+    private SuppressRange getSuppressRange(DetailAST node) {
+        final DetailAST startNode = getStartNode(node);
+        final int startColumn;
+        if (columnIndexIsNecessary(node)) {
+            startColumn = startNode.getColumnNo();
+        }
+        else {
+            startColumn = 0;
+        }
+        final int startLine = startNode.getLineNo();
+
+        final DetailAST endNode = getEndNode(node);
+        final int endLine = endNode.getLineNo();
+        final int endColumn = endNode.getColumnNo() + 1;
+        return new SuppressRange(startLine, startColumn, endLine, endColumn);
+    }
+
+    /**
+     * Get node which starts suppressed range.
+     * @param node
+     *         , the node to be suppressed.
+     * @return start border node.
+     */
+    private DetailAST getStartNode(DetailAST node) {
+        final DetailAST result;
+        if (isModifiersExcluded()) {
+            // it was already checked that grand-child exists.
+            result = node.getFirstChild().getNextSibling();
+        }
+        else {
+            result = node;
+        }
+        return result;
+    }
+
+    /**
+     * Get the rightmost lowest node, which is the end border element of the suppressed node.
+     * @param node
+     *         , the node to be suppressed.
+     * @return end border node.
+     */
+    private static DetailAST getEndNode(DetailAST node) {
+        DetailAST nextNode = node.getFirstChild();
+        final DetailAST result;
+        if (nextNode == null) {
+            result = node;
+        }
+        else {
+            DetailAST probe = nextNode;
+            while (true) {
+                probe = probe.getNextSibling();
+                if (probe == null) {
+                    break;
+                }
+                else {
+                    nextNode = probe;
+                }
+            }
+            result = getEndNode(nextNode);
+        }
+        return result;
+    }
+
+    /**
+     * A lot of checks return only number of the line, and number of the column is zeroed. It is
+     * supposed that code is already formatted and a chance that events which don't address to the
+     * annotated element are generated on one string with the annotated element can be neglected.
+     * The obvious exception is a parameter's definition.
+     * @param node
+     *         , the node to be suppressed.
+     * @return true
+     *          , if the start column index should not be set 0.
+     */
+    private static boolean columnIndexIsNecessary(DetailAST node) {
+        return node.getType() == TokenTypes.PARAMETER_DEF;
+    }
+
+    /**
+     * Checks if a check that generated the event, is not suppressed.
+     * @param event
+     *        , the event under audit.
+     * @return result of check.
+     */
+    private boolean matchesCheck(AuditEvent event) {
+        boolean result = false;
+        for (Pattern pat : checkRegexp) {
+            final Matcher matcher = pat.matcher(event.getSourceName());
+            result |= matcher.matches();
+        }
+        return result;
+    }
+
+    /**
+     * A SuppressRange is a POJO that holds start and end ranges of an element
+     * annotated with a suppressive annotation.
+     */
+    public static class SuppressRange {
+        /** Index of the first line of a suppressed range. */
+        private final int startLine;
+
+        /** Index of the first column of a suppressed range. */
+        private final int startColumn;
+
+        /** Index of the last line of a suppressed range. */
+        private final int endLine;
+
+        /** Index of the last column of a suppressed range. */
+        private final int endColumn;
+
+        /**
+         * Default constructor.
+         * @param startLine
+         *        , index of the first line of a suppressed range.
+         * @param startColumn
+         *        , index of the first column of a suppressed range.
+         * @param endLine
+         *        , index of the last line of a suppressed range.
+         * @param endColumn
+         *        , index of the last column of a suppressed range.
+         */
+        public SuppressRange(int startLine, int startColumn, int endLine, int endColumn) {
+            this.startColumn = startColumn;
+            this.startLine = startLine;
+            this.endColumn = endColumn;
+            this.endLine = endLine;
+        }
+
+        /**
+         * Checks if coordinates of an event fall in the range.
+         * @param eventLine
+         *        , index line of the event.
+         * @param eventColumn
+         *        , index of column of the event.
+         * @return result of the check.
+         */
+        public boolean isInRange(int eventLine, int eventColumn) {
+            return (eventLine > startLine || eventLine == startLine && eventColumn >= startColumn)
+                    && (eventLine < endLine || eventLine == endLine && eventColumn <= endColumn);
+        }
+    }
+}

--- a/sevntu-checks/src/main/java/com/github/sevntu/checkstyle/filters/package-info.java
+++ b/sevntu-checks/src/main/java/com/github/sevntu/checkstyle/filters/package-info.java
@@ -1,0 +1,23 @@
+////////////////////////////////////////////////////////////////////////////////
+// checkstyle: Checks Java source code for adherence to a set of rules.
+// Copyright (C) 2001-2016 the original author or authors.
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+////////////////////////////////////////////////////////////////////////////////
+
+/**
+ * Contains the filters that are bundled with the main distribution.
+ */
+package com.github.sevntu.checkstyle.filters;

--- a/sevntu-checks/src/test/java/com/github/sevntu/checkstyle/BaseCheckTestSupport.java
+++ b/sevntu-checks/src/test/java/com/github/sevntu/checkstyle/BaseCheckTestSupport.java
@@ -53,6 +53,11 @@ public abstract class BaseCheckTestSupport extends Assert
 	private final ByteArrayOutputStream baos = new ByteArrayOutputStream();
 	private final PrintStream printStream = new PrintStream(baos);
 
+	protected PrintStream getPrintStream()
+  {
+    return printStream;
+  }
+
 	public static DefaultConfiguration createCheckConfig(Class<?> clazz)
 	{
 		return new DefaultConfiguration(clazz.getName());

--- a/sevntu-checks/src/test/java/com/github/sevntu/checkstyle/checks/DetailAstRootHolderTest.java
+++ b/sevntu-checks/src/test/java/com/github/sevntu/checkstyle/checks/DetailAstRootHolderTest.java
@@ -1,0 +1,14 @@
+package com.github.sevntu.checkstyle.checks;
+
+import org.junit.Test;
+
+public class DetailAstRootHolderTest {
+
+    @Test
+    public void testGetters() throws Exception {
+        DetailAstRootHolder holder = new DetailAstRootHolder();
+        holder.getDefaultTokens();
+        holder.getAcceptableTokens();
+        holder.getRequiredTokens();
+    }
+}

--- a/sevntu-checks/src/test/java/com/github/sevntu/checkstyle/filters/SuppressionAnnotationFilterTest.java
+++ b/sevntu-checks/src/test/java/com/github/sevntu/checkstyle/filters/SuppressionAnnotationFilterTest.java
@@ -1,0 +1,316 @@
+////////////////////////////////////////////////////////////////////////////////
+// checkstyle: Checks Java source code for adherence to a set of rules.
+// Copyright (C) 2001-2015 the original author or authors.
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+////////////////////////////////////////////////////////////////////////////////
+
+package com.github.sevntu.checkstyle.filters;
+
+import com.google.common.collect.Lists;
+import com.puppycrawl.tools.checkstyle.Checker;
+import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
+import com.puppycrawl.tools.checkstyle.TreeWalker;
+import com.puppycrawl.tools.checkstyle.api.AuditEvent;
+import com.puppycrawl.tools.checkstyle.api.CheckstyleException;
+import com.puppycrawl.tools.checkstyle.api.Configuration;
+import com.puppycrawl.tools.checkstyle.api.LocalizedMessage;
+import com.puppycrawl.tools.checkstyle.checks.annotation.AnnotationLocationCheck;
+import com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocMethodCheck;
+import com.puppycrawl.tools.checkstyle.checks.naming.ConstantNameCheck;
+import com.puppycrawl.tools.checkstyle.checks.naming.MemberNameCheck;
+import com.puppycrawl.tools.checkstyle.checks.naming.MethodNameCheck;
+import com.puppycrawl.tools.checkstyle.checks.naming.ParameterNameCheck;
+
+import com.github.sevntu.checkstyle.BaseCheckTestSupport;
+import com.github.sevntu.checkstyle.checks.DetailAstRootHolder;
+
+import java.io.UnsupportedEncodingException;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Locale;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class SuppressionAnnotationFilterTest extends BaseCheckTestSupport {
+    private static String[] sAllMessages = {
+        "14:11: Missing a Javadoc comment.",
+        "21:5: Missing a Javadoc comment.",
+        "22:5: Missing a Javadoc comment.",
+        "35:3: Missing a Javadoc comment.",
+        "40: Expected an @return tag.",
+        "41:9: Name 'FOO' must match pattern '^[a-z][a-zA-Z0-9]*$'.",
+        "52:9: Name 'A1' must match pattern '^[a-z][a-zA-Z0-9]*$'.",
+        "55:11: Name 'A2' must match pattern '^[a-z][a-zA-Z0-9]*$'.",
+        "56:7: Missing a Javadoc comment.",
+        "56:12: Name 'TESTCLASS' must match pattern '^[a-z][a-zA-Z0-9]*$'.",
+        "64:5: Missing a Javadoc comment.",
+        "64:10: Name 'FOO1' must match pattern '^[a-z][a-zA-Z0-9]*$'.",
+        "64:48: Name 'A3' must match pattern '^[a-z][a-zA-Z0-9]*$'.",
+        "67:9: Name 'A4' must match pattern '^[a-z][a-zA-Z0-9]*$'.",
+        "70:9: Name 'A5' must match pattern '^[a-z][a-zA-Z0-9]*$'.",
+        "70:24: Name 'A6' must match pattern '^[a-z][a-zA-Z0-9]*$'.",
+        "70:32: Name 'A7' must match pattern '^[a-z][a-zA-Z0-9]*$'.",
+        "74:43: Name 'A8' must match pattern '^[a-z][a-zA-Z0-9]*$'.",
+        "83:9: Name 'A9' must match pattern '^[a-z][a-zA-Z0-9]*$'.",
+        "90:9: Name 'B1' must match pattern '^[a-z][a-zA-Z0-9]*$'.",
+        "93:9: Name 'B2' must match pattern '^[a-z][a-zA-Z0-9]*$'.",
+        "96:9: Name 'B3' must match pattern '^[a-z][a-zA-Z0-9]*$'.",
+        "99:9: Name 'B4' must match pattern '^[a-z][a-zA-Z0-9]*$'.",
+        "104:9: Name 'B5' must match pattern '^[a-z][a-zA-Z0-9]*$'.",
+        "108:9: Name 'B6' must match pattern '^[a-z][a-zA-Z0-9]*$'.",
+        "112:9: Name 'B7' must match pattern '^[a-z][a-zA-Z0-9]*$'.",
+        "117:9: Name 'B8' must match pattern '^[a-z][a-zA-Z0-9]*$'.",
+        "121:9: Name 'B9' must match pattern '^[a-z][a-zA-Z0-9]*$'.",
+        "125:9: Name 'B10' must match pattern '^[a-z][a-zA-Z0-9]*$'.",
+        "131:22: Name 'FOO2' must match pattern '^[a-z][a-zA-Z0-9]*$'.",
+        "135: Annotation 'Deprecated' should be alone on line.",
+        "135:5: Missing a Javadoc comment.",
+        "139:10: Name 'FOO3' must match pattern '^[a-z][a-zA-Z0-9]*$'.",
+        "146: Expected an @return tag.",
+        "146:9: Name 'FOO2' must match pattern '^[a-z][a-zA-Z0-9]*$'.",
+        "146:25: Expected @param tag for 'C1'.",
+        "146:25: Name 'C1' must match pattern '^[a-z][a-zA-Z0-9]*$'.",
+        "153:9: Name 'C2' must match pattern '^[a-z][a-zA-Z0-9]*$'.",
+        "153:13: Missing a Javadoc comment.",
+        "153:24: Name 'FOO3' must match pattern '^[a-z][a-zA-Z0-9]*$'.",
+        "153:34: Name 'C3' must match pattern '^[a-z][a-zA-Z0-9]*$'.",
+        "162:10: Unused @param tag for 'it'.",
+        "169:7: Missing a Javadoc comment.",
+        "171:21: Name 'C5' must match pattern '^[a-z][a-zA-Z0-9]*$'.",
+    };
+
+    @Test
+    public void testNone()
+            throws Exception {
+        final DefaultConfiguration filterConfig = null;
+        final String[] suppressed = {
+        };
+        verifySuppressed(filterConfig, suppressed);
+    }
+
+    @Test
+    public void testDefault()
+            throws Exception {
+        final DefaultConfiguration filterConfig =
+                createFilterConfig(SuppressionAnnotationFilter.class);
+        final String[] suppressed = {
+        };
+        verifySuppressed(filterConfig, suppressed);
+    }
+
+    //com.github.sevntu.checkstyle.filters
+    @Test
+    public void testNamesParsing1()
+            throws Exception {
+        final DefaultConfiguration filterConfig =
+                createFilterConfig(SuppressionAnnotationFilter.class);
+        filterConfig.addAttribute("annotationNames", "@Test1");
+        filterConfig.addAttribute("annotationNames", "@com.github.sevntu.checkstyle.filters.Test2");
+        filterConfig.addAttribute("annotationNames", "Test3");
+        filterConfig.addAttribute("annotationNames", "com.github.sevntu.checkstyle.filters.Test4");
+        filterConfig.addAttribute("annotationNames", "com.github.sevntu.checkstyle.checks.test.InputSuppressionAnnotation");
+        final String[] resulted = {
+            "14:11: Missing a Javadoc comment.",
+            "21:5: Missing a Javadoc comment.",
+            "22:5: Missing a Javadoc comment.",
+            "35:3: Missing a Javadoc comment.",
+            "40: Expected an @return tag.",
+            "64:5: Missing a Javadoc comment.",
+            "64:10: Name 'FOO1' must match pattern '^[a-z][a-zA-Z0-9]*$'.",
+            "70:32: Name 'A7' must match pattern '^[a-z][a-zA-Z0-9]*$'.",
+            "125:9: Name 'B10' must match pattern '^[a-z][a-zA-Z0-9]*$'.",
+            "131:22: Name 'FOO2' must match pattern '^[a-z][a-zA-Z0-9]*$'.",
+            "135: Annotation 'Deprecated' should be alone on line.",
+            "135:5: Missing a Javadoc comment.",
+            "146: Expected an @return tag.",
+            "146:9: Name 'FOO2' must match pattern '^[a-z][a-zA-Z0-9]*$'.",
+            "162:10: Unused @param tag for 'it'.",
+            "171:21: Name 'C5' must match pattern '^[a-z][a-zA-Z0-9]*$'.",
+        };
+        verify(createChecker(filterConfig),
+                getPath("InputSuppressionAnnotationtFilter.java"), resulted);
+    }
+
+    @Test
+    public void testNamesParsing2()
+            throws Exception {
+        final DefaultConfiguration filterConfig =
+                createFilterConfig(SuppressionAnnotationFilter.class);
+        filterConfig.addAttribute("annotationNames", "@Test1");
+        filterConfig.addAttribute("annotationNames", "@com.github.sevntu.checkstyle.filters.Test2");
+        filterConfig.addAttribute("annotationNames", "Test3");
+        filterConfig.addAttribute("annotationNames", "com.github.sevntu.checkstyle.filters.Test4");
+        filterConfig.addAttribute("annotationNames", "com.github.sevntu.checkstyle.filters.InputSuppressionAnnotation");
+        final String[] resulted = {
+            "14:11: Missing a Javadoc comment.",
+            "21:5: Missing a Javadoc comment.",
+            "22:5: Missing a Javadoc comment.",
+            "35:3: Missing a Javadoc comment.",
+            "40: Expected an @return tag.",
+            "64:5: Missing a Javadoc comment.",
+            "64:10: Name 'FOO1' must match pattern '^[a-z][a-zA-Z0-9]*$'.",
+            "70:32: Name 'A7' must match pattern '^[a-z][a-zA-Z0-9]*$'.",
+            "125:9: Name 'B10' must match pattern '^[a-z][a-zA-Z0-9]*$'.",
+            "131:22: Name 'FOO2' must match pattern '^[a-z][a-zA-Z0-9]*$'.",
+            "135: Annotation 'Deprecated' should be alone on line.",
+            "135:5: Missing a Javadoc comment.",
+            "146: Expected an @return tag.",
+            "146:9: Name 'FOO2' must match pattern '^[a-z][a-zA-Z0-9]*$'.",
+            "162:10: Unused @param tag for 'it'.",
+            "171:21: Name 'C5' must match pattern '^[a-z][a-zA-Z0-9]*$'.",
+        };
+        verify(createChecker(filterConfig),
+                getPath("InputSuppressionAnnotationtFilter.java"), resulted);
+    }
+
+    @Test
+    public void testModifiersExcluded()
+            throws Exception {
+        final DefaultConfiguration filterConfig =
+                createFilterConfig(SuppressionAnnotationFilter.class);
+        filterConfig.addAttribute("annotationNames", "@Test1");
+        filterConfig.addAttribute("annotationNames", "@com.github.sevntu.checkstyle.filters.Test2");
+        filterConfig.addAttribute("annotationNames", "Test3");
+        filterConfig.addAttribute("annotationNames", "com.github.sevntu.checkstyle.filters.Test4");
+        filterConfig.addAttribute("annotationNames", "InputSuppressionAnnotation");
+        filterConfig.addAttribute("modifiersExcluded", "false");
+        final String[] resulted = {
+            "14:11: Missing a Javadoc comment.",
+            "21:5: Missing a Javadoc comment.",
+            "22:5: Missing a Javadoc comment.",
+            "64:5: Missing a Javadoc comment.",
+            "64:10: Name 'FOO1' must match pattern '^[a-z][a-zA-Z0-9]*$'.",
+            "70:32: Name 'A7' must match pattern '^[a-z][a-zA-Z0-9]*$'.",
+            "125:9: Name 'B10' must match pattern '^[a-z][a-zA-Z0-9]*$'.",
+            "131:22: Name 'FOO2' must match pattern '^[a-z][a-zA-Z0-9]*$'.",
+            "146: Expected an @return tag.",
+            "146:9: Name 'FOO2' must match pattern '^[a-z][a-zA-Z0-9]*$'.",
+            "162:10: Unused @param tag for 'it'.",
+            "171:21: Name 'C5' must match pattern '^[a-z][a-zA-Z0-9]*$'.",
+        };
+        verify(createChecker(filterConfig),
+                getPath("InputSuppressionAnnotationtFilter.java"), resulted);
+    }
+
+    @Test
+    public void testRegEx1()
+            throws Exception {
+        final DefaultConfiguration filterConfig =
+                createFilterConfig(SuppressionAnnotationFilter.class);
+        filterConfig.addAttribute("annotationNames", "@Test1");
+        filterConfig.addAttribute("annotationNames", "@com.github.sevntu.checkstyle.filters.Test2");
+        filterConfig.addAttribute("annotationNames", "Test3");
+        filterConfig.addAttribute("annotationNames", "com.github.sevntu.checkstyle.filters.Test4");
+        filterConfig.addAttribute("annotationNames", "com.github.sevntu.checkstyle.filters.InputSuppressionAnnotation");
+        filterConfig.addAttribute("checkNames", ".*");
+        final String[] suppressed = {
+        };
+        verifySuppressed(filterConfig, suppressed);
+    }
+
+    @Test
+    public void testRegEx2()
+            throws Exception {
+        final DefaultConfiguration filterConfig =
+                createFilterConfig(SuppressionAnnotationFilter.class);
+        filterConfig.addAttribute("annotationNames", "@Test1");
+        filterConfig.addAttribute("annotationNames", "@com.github.sevntu.checkstyle.filters.Test2");
+        filterConfig.addAttribute("annotationNames", "Test3");
+        filterConfig.addAttribute("annotationNames", "com.github.sevntu.checkstyle.filters.Test4");
+        filterConfig.addAttribute("annotationNames", "InputSuppressionAnnotation");
+        filterConfig.addAttribute("modifiersExcluded", "false");
+        filterConfig.addAttribute("checkNames", ".*Name.*");
+        filterConfig.addAttribute("checkNames", ".*Javadoc.*");
+        final String[] suppressed = {
+            "135: Annotation 'Deprecated' should be alone on line.",
+        };
+        verifySuppressed(filterConfig, suppressed);
+    }
+
+    @Test(expected = CheckstyleException.class)
+    public void testThrowWrongRegexp()
+            throws Exception {
+        final DefaultConfiguration filterConfig =
+                createFilterConfig(SuppressionAnnotationFilter.class);
+        filterConfig.addAttribute("checkNames", "*\\.*");
+        createChecker(filterConfig);
+    }
+
+    @Test
+    public void testMisc()
+            throws Exception {
+        final SuppressionAnnotationFilter test = new SuppressionAnnotationFilter();
+        final String[] dummyArray = {
+        };
+        final AuditEvent noMessageEvent = new AuditEvent(test, "abc", null);
+        Assert.assertTrue(test.accept(noMessageEvent));
+        final LocalizedMessage dummyMessage =
+            new LocalizedMessage(0, 0, null, null, dummyArray, null, null, null, null);
+        final AuditEvent noTreeEvent = new AuditEvent(test, "abc", dummyMessage);
+        // Here abortive branch of accept method with no AST present is tested.
+        Assert.assertTrue(test.accept(noTreeEvent));
+    }
+
+    public static DefaultConfiguration createFilterConfig(Class<?> aClass) {
+        return new DefaultConfiguration(aClass.getName());
+    }
+
+    protected void verifySuppressed(Configuration aFilterConfig,
+            String[] aSuppressed)
+                    throws Exception {
+        verify(createChecker(aFilterConfig),
+                getPath("InputSuppressionAnnotationtFilter.java"),
+                removeSuppressed(sAllMessages, aSuppressed));
+    }
+
+    @Override
+    protected Checker createChecker(Configuration aFilterConfig)
+            throws CheckstyleException, UnsupportedEncodingException {
+        final DefaultConfiguration checkerConfig =
+                new DefaultConfiguration("configuration");
+        final DefaultConfiguration checksConfig = createCheckConfig(TreeWalker.class);
+        checksConfig.addChild(createCheckConfig(DetailAstRootHolder.class));
+        checksConfig.addChild(createCheckConfig(MemberNameCheck.class));
+        checksConfig.addChild(createCheckConfig(MethodNameCheck.class));
+        checksConfig.addChild(createCheckConfig(ParameterNameCheck.class));
+        checksConfig.addChild(createCheckConfig(ConstantNameCheck.class));
+        checksConfig.addChild(createCheckConfig(JavadocMethodCheck.class));
+        checksConfig.addChild(createCheckConfig(AnnotationLocationCheck.class));
+        checkerConfig.addChild(checksConfig);
+        if (aFilterConfig != null) {
+            checkerConfig.addChild(aFilterConfig);
+        }
+        final Checker checker = new Checker();
+        final Locale locale = Locale.ROOT;
+        checker.setLocaleCountry(locale.getCountry());
+        checker.setLocaleLanguage(locale.getLanguage());
+        checker.setModuleClassLoader(Thread.currentThread().getContextClassLoader());
+        checker.configure(checkerConfig);
+        //replace getPrintStream with stream in 6.9
+        checker.addListener(new BriefLogger(getPrintStream()));
+        return checker;
+    }
+
+    private String[] removeSuppressed(String[] from, String[] remove) {
+        final Collection<String> coll =
+                Lists.newArrayList(Arrays.asList(from));
+        coll.removeAll(Arrays.asList(remove));
+        return coll.toArray(new String[coll.size()]);
+    }
+    
+    
+}

--- a/sevntu-checks/src/test/resources/com/github/sevntu/checkstyle/checks/test/InputSuppressionAnnotation.java
+++ b/sevntu-checks/src/test/resources/com/github/sevntu/checkstyle/checks/test/InputSuppressionAnnotation.java
@@ -1,0 +1,14 @@
+////////////////////////////////////////////////////////////////////////////////
+// Test case file for checkstyle.
+////////////////////////////////////////////////////////////////////////////////
+
+package com.github.sevntu.checkstyle.checks.test;
+
+//this file is added to achieve compilation of 
+//filters/InputSuppressionAnnotationFilter
+
+
+public @interface InputSuppressionAnnotation{   
+}
+
+

--- a/sevntu-checks/src/test/resources/com/github/sevntu/checkstyle/filters/InputSuppressionAnnotationtFilter.java
+++ b/sevntu-checks/src/test/resources/com/github/sevntu/checkstyle/filters/InputSuppressionAnnotationtFilter.java
@@ -1,0 +1,174 @@
+////////////////////////////////////////////////////////////////////////////////
+// Test case file for checkstyle.
+////////////////////////////////////////////////////////////////////////////////
+
+package com.github.sevntu.checkstyle.filters;
+
+@interface Test1{   
+}
+
+@interface Test2{   
+}
+
+@interface Test3{
+    String[] value();    
+}
+
+@interface Test4{
+}
+
+@interface Nottest{
+    String id() default "N/A";
+    String name();  
+}
+
+@interface InputSuppressionAnnotation{
+}
+
+/**
+ * Test input for using annotations to suppress errors.
+ * only TestAnnotation* are input annotations
+ * @author attatrol
+ **/
+class InputSuppressionAnnotationFilter
+{
+  @Test1  
+  private InputSuppressionAnnotationFilter(){
+      
+    } 
+    /** Basic test, all should be suppressed. */
+    @Test1
+    int FOO(){
+      return 1;
+    }
+    
+    /** this is connemtaty*/
+    /** this is commentary*/
+    @Deprecated
+    //this is commentaty
+    @Test1 //this is commentary
+    /** this is commentary*/
+    //commentaries are garbage in AST, those before object are checked
+    int A1;
+    
+    @Test1 class TestClass{
+      int A2;
+      void TESTCLASS(){//need for javadoc is suppressed, class is a black hole now
+      }    
+    }//this will be suppressed
+    
+    @Test1 enum TestEnum{ONE,TWO,THREE,FOUR};
+
+    
+    //only parameter is suppressed
+    void FOO1(/** test*/ @Test1 /** test*/ int A3 /** test*/){}
+    
+    //this is COMPLETELY suppressed, use formmatter before checkstyle
+    int A4;  static{ @Test1 int A5;}
+    
+    //A5 will be suppressed, use formmatter before checkstyle
+    int A5; @Test1 int A6; int A7;
+    
+    /** Check annotation with elements. */
+    //will be suppressed
+    @Test3({"test","test"})/** test */int A8;
+    
+    //will be suppressed
+    @Nottest(
+        id="1",
+        name="test")
+    //test
+    @Test3(
+        value={"test","test"}/** test*/)
+    int A9;
+   
+    
+    /**Check qualified and simple names. */
+    
+    //first 4 show input names
+    @Test1 
+    int B1;
+    
+    @com.github.sevntu.checkstyle.filters.Test2
+    int B2;
+    
+    @Test3({"test","test"})
+    int B3;
+    
+    @com.github.sevntu.checkstyle.filters.Test4
+    int B4;
+    
+    //this is suppressed, cause it is difficult to determine 
+    //if it is a simple name of com.puppycrawl.checkstyle.annotations.TestAnnotation2
+    @Test2
+    int B5;
+    
+    //this is suppressed
+    @com.github.sevntu.checkstyle.filters.Test1
+    int B6;
+    
+    //this is suppressed TOO, simple name covers ALL possible qualified names based on it
+    @InputSuppressionAnnotation
+    int B7;
+    
+    //this is suppressed, cause
+    //filter operates with simple names
+    @com.github.sevntu.checkstyle.checks.test.InputSuppressionAnnotation
+    int B8;
+    
+    //this is suppressed
+    @Test3({"test","test"})
+    int B9;
+    
+    //this is not suppressed, not in input
+    @Deprecated 
+    int B10;
+    
+    
+    /**Test checks related to annotation, here excludeAnnotation flag is tested. */
+    
+    //this is not suppressed
+    @Deprecated void FOO2(){
+    }
+    
+    //AnnotationLocation is suppressed, if excludeAnnotation=false
+    @Test1 @Deprecated
+    /**
+     * javadoc.
+     */
+    void FOO3(){
+    }
+     
+    /** It is presumed that code is well formatted, and there is no multiple declarations on one string.
+     * Because a lot of check return column 0, for all  */
+    
+    //all but C1 checks are fired
+    int FOO2(@Test1 int C1){
+      int FOO2=1;
+      return FOO2;
+    }
+    
+    //C2 check and javadoc check will be suppressed because of bad formatting!
+    //use formatter before checks
+    int C2; @Test1 int FOO3( int C3){
+      int FOO3=1;
+      return FOO3;
+    }
+     
+    class TestClass2{
+      /**
+       * This is bad javadoc.
+       * It will not be suppressed.
+       * @param it doesnt exist.
+       */
+      void foo4(){
+        /** this one is suppressed*/
+        @Test1 int C3;      
+      }
+      
+      private final @Test1 void foo5(){
+        /** this one is suppressed*/
+        int C4;}int C5;/** this one is not suppressed*/
+    }
+    
+}

--- a/sevntu-checkstyle-sonar-plugin/src/main/resources/com/github/sevntu/checkstyle/sonar/checkstyle-extensions.xml
+++ b/sevntu-checkstyle-sonar-plugin/src/main/resources/com/github/sevntu/checkstyle/sonar/checkstyle-extensions.xml
@@ -727,4 +727,30 @@
         <configKey>Checker/TreeWalker/com.github.sevntu.checkstyle.checks.design.StaticMethodCandidateCheck</configKey>
     </rule>
 
+    <rule>
+        <key>com.github.sevntu.checkstyle.com.github.sevntu.checkstyle.checks.DetailASTHolder</key>
+        <name>AST root holder.</name>
+        <category name="annotation"/>
+        <description>Holds AST root for exterior usage.</description>
+        <configKey>Checker/TreeWalker/com.github.sevntu.checkstyle.com.github.sevntu.checkstyle.checks.DetailASTHolder</configKey>
+    </rule>
+    
+    <rule>
+        <key>com.github.sevntu.checkstyle.filters.SuppressionAnnotationFilter</key>
+        <name>Suppress Annotated Elements</name>
+        <category name="annotation"/>
+        <description>Suppress all reports from elements annotated by user defined annotations. Depends on DetailASTHolder.</description>
+        <configKey>Checker/com.github.sevntu.checkstyle.filters.SuppressionAnnotationFilter</configKey>
+        <param key="annotationName" type="s{}">
+            <description>Names of suppressive annotations. Can be either simple or fully-qualified.</description>
+        </param>
+        <param key="permittedChecks" type="s{}">
+            <description>Regular expressions that matches checks, which should bypass the filter.</description>
+        </param>
+                <param key="modifiersExcluded" type="BOOLEAN">
+                <defaultValue>true</defaultValue>
+            <description>Excludes modifiers of an annotated element from filtered area. Javadocs are included in modifiers.</description>
+        </param>
+    </rule>
+
 </rules>


### PR DESCRIPTION
A new filter is added. It satisfies issue #1340.
https://github.com/checkstyle/checkstyle/issues/1340

It suppresses events generated from code elements annotated by user defined annotations.

Here is a link to the xdocs entry for the filter:
https://gist.github.com/attatrol/699fd9863de8730dfc30

I was to add small changes to .travis.yml from the original, because somehow previous version errored:
https://travis-ci.org/attatrol/sevntu.checkstyle/jobs/72255048
<code>
[ERROR] Failed to execute goal org.eluder.coveralls:coveralls-maven-plugin:2.2.0:jacoco (default-cli) on project sevntu-checks: Processing of input or output data failed: Report submission to Coveralls API failed with HTTP status 422: Unprocessable Entity (Couldn't find a repository matching this job.) -> [Help 1]
</code>
