### PR TITLE
Implemented UniformEnumConstantNameCheck

### DIFF
--- a/eclipsecs-sevntu-plugin/src/com/github/sevntu/checkstyle/checks/naming/checkstyle-metadata.properties
+++ b/eclipsecs-sevntu-plugin/src/com/github/sevntu/checkstyle/checks/naming/checkstyle-metadata.properties
@@ -7,3 +7,7 @@ EnumValueName.desc = <p>Check forces enum values to match the specific pattern. 
 EnumValueName.constFormat = Regex for Values Enumeration names to conform
 EnumValueName.objFormat = Regex for Class Enumeration names to conform
 EnumValueName.excludes = Exclude method and field names regexp list (comma-separated)
+
+UniformEnumConstantNameCheck.name = Enum values name
+UniformEnumConstantNameCheck.desc = Check forces enum values to match one of the specified patterns and forces all the values to follow only one of the specified patterns.
+UniformEnumConstantNameCheck.formats = Regex list that enum value names should conform

--- a/eclipsecs-sevntu-plugin/src/com/github/sevntu/checkstyle/checks/naming/checkstyle-metadata.xml
+++ b/eclipsecs-sevntu-plugin/src/com/github/sevntu/checkstyle/checks/naming/checkstyle-metadata.xml
@@ -25,5 +25,13 @@
                 <description>%EnumValueName.excludes</description>
             </property-metadata>
         </rule-metadata>
+
+        <rule-metadata name="%UniformEnumConstantNameCheck.name" internal-name="UniformEnumConstantNameCheck" parent="TreeWalker">
+            <alternative-name internal-name="com.github.sevntu.checkstyle.checks.naming.UniformEnumConstantNameCheck" />
+            <description>%UniformEnumConstantNameCheck.desc</description>
+            <property-metadata name="formats" datatype="String" default-value="^[A-Z][a-zA-Z0-9]*$,^[A-Z][A-Z0-9]*(_[A-Z0-9]+)*$">
+                <description>%UniformEnumConstantNameCheck.formats</description>
+             </property-metadata>
+        </rule-metadata>
     </rule-group-metadata>
 </checkstyle-metadata>

--- a/sevntu-checks/src/main/java/com/github/sevntu/checkstyle/checks/naming/UniformEnumConstantNameCheck.java
+++ b/sevntu-checks/src/main/java/com/github/sevntu/checkstyle/checks/naming/UniformEnumConstantNameCheck.java
@@ -1,0 +1,229 @@
+////////////////////////////////////////////////////////////////////////////////
+// checkstyle: Checks Java source code for adherence to a set of rules.
+// Copyright (C) 2001-2016 the original author or authors.
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+////////////////////////////////////////////////////////////////////////////////
+
+package com.github.sevntu.checkstyle.checks.naming;
+
+import java.util.ArrayList;
+import java.util.BitSet;
+import java.util.Collection;
+import java.util.List;
+import java.util.regex.Pattern;
+
+import com.puppycrawl.tools.checkstyle.api.AbstractCheck;
+import com.puppycrawl.tools.checkstyle.api.DetailAST;
+import com.puppycrawl.tools.checkstyle.api.TokenTypes;
+
+/**
+ * Check forces enum constants to match one of the specified patterns and forces
+ * all the values to follow only one of the specified patterns.
+ *
+ * <p>By default both CamelCase and UPPER_CASE are allowed, so check validates,
+ * whether all the values conform the either of them.
+ *
+ * <p>For example, both enums are allowed by the check:<pre>
+ * public enum EnumOne {
+ *    FirstElement, SecondElement, ThirdElement;
+ * }
+ * public enum EnumTwo {
+ *    FIRST_ELEMENT, SECOND_ELEMENT, THIRD_ELEMENT;
+ * }</pre> But the following enum, is violated, because values conform
+ * different notations: <pre>
+ * public enum EnumThree {
+ *    FirstElement, SECOND_ELEMENT, ThirdElement;
+ * }
+ * </pre>
+ *
+ * <p>To use only CamelCase, use the following configuration:
+ *
+ * <pre>
+ * &lt;module name="UniformEnumConstantNameCheck"&gt;
+ *    &lt;property name="format" value="^[A-Z][a-zA-Z0-9]*$"/&gt;
+ * &lt;/module&gt;
+ * </pre>
+ *
+ * <p>If both CamelCase and UPPER_CASE are allowed, use the following configuration
+ * (this is the default):
+ *
+ * <pre>
+ * &lt;module name="UniformEnumConstantNameCheck"&gt;
+ *    &lt;property name="format" value="^[A-Z][a-zA-Z0-9]*$,^[A-Z][A-Z0-9]*(_[A-Z0-9]+)*$"/&gt;
+ * &lt;/module&gt;
+ * </pre>
+ *
+ * <p>Only first violation is reported for each enumeration because of the nature
+ * of the check: it's impossible to determine which specific pattern user should
+ * follow for this certain enumeration, as multiple patterns have been
+ * specified. The only thing that this check reports is whether there is at
+ * least one pattern (among specified in the configuration), which all the enum
+ * constant conform or there is no.
+ *
+ * @author Pavel Baranchikov
+ */
+public class UniformEnumConstantNameCheck extends AbstractCheck {
+    /**
+     * Message code for format violations. Used, when more than one format
+     * violated.
+     */
+    public static final String MSG_NOT_VALID_MULTI = "enum.name.formats.violated";
+    /**
+     * Message code for format violations. Used, when exactly one format
+     * violated.
+     */
+    public static final String MSG_NOT_VALID_SINGLE = "enum.name.format.violated";
+    /**
+     * Camel notation regular expression.
+     */
+    public static final String CAMEL_PATTERN = "^[A-Z][a-zA-Z0-9]*$";
+    /**
+     * Upper case notation regular expression.
+     */
+    public static final String UPPERCASE_PATTERN = "^[A-Z][A-Z0-9]*(_[A-Z0-9]+)*$";
+    /**
+     * Default pattern for enumeration values.
+     */
+    public static final String[] DEFAULT_PATTERN = {
+        CAMEL_PATTERN,
+        UPPERCASE_PATTERN,
+    };
+
+    /**
+     * Regular expression list to test Enumeration names against.
+     */
+    private List<Pattern> patterns;
+    /**
+     * Number of patterns specified for {@code patterns} field. This field is
+     * always the size of {@link #patterns}.
+     */
+    private int patternCount;
+
+    /**
+     * Constructs check with the default pattern.
+     */
+    public UniformEnumConstantNameCheck() {
+        setFormats(DEFAULT_PATTERN);
+    }
+
+    /**
+     * Method sets format to match Class Enumeration names.
+     * @param regexps format to check against
+     */
+    public final void setFormats(String[] regexps) {
+        this.patterns = new ArrayList<Pattern>(regexps.length);
+        for (final String regexp: regexps) {
+            final Pattern pattern = Pattern.compile(regexp, 0);
+            patterns.add(pattern);
+        }
+        patternCount = regexps.length;
+    }
+
+    @Override
+    public int[] getDefaultTokens() {
+        return getAcceptableTokens();
+    }
+
+    @Override
+    public int[] getAcceptableTokens() {
+        return new int[] {
+            TokenTypes.ENUM_DEF,
+            };
+    }
+
+    @Override
+    public int[] getRequiredTokens() {
+        return getAcceptableTokens();
+    }
+
+    @Override
+    public void visitToken(DetailAST ast) {
+        final DetailAST objBlock = ast.findFirstToken(TokenTypes.OBJBLOCK);
+        final BitSet conformedPatterns = new BitSet(patternCount);
+        conformedPatterns.set(0, patternCount);
+        for (DetailAST member = objBlock.getFirstChild(); member != null
+                && !conformedPatterns.isEmpty();
+                member = member.getNextSibling()) {
+            if (member.getType() != TokenTypes.ENUM_CONSTANT_DEF) {
+                continue;
+            }
+            final String enumName = member.findFirstToken(TokenTypes.IDENT).getText();
+            final BitSet matched = match(enumName, conformedPatterns);
+            if (matched.isEmpty()) {
+                logViolation(member, enumName, conformedPatterns);
+            }
+            conformedPatterns.and(matched);
+        }
+    }
+
+    /**
+     * Logs violation for the specified token, representing the specified enum
+     * value wich violates the specified patterns.
+     *
+     * @param member
+     *        token, which violates the check
+     * @param enumName
+     *        enum value name for this token
+     * @param violated
+     *        bit set of violated patterns
+     */
+    private void logViolation(DetailAST member, String enumName, BitSet violated) {
+        final String patternsString;
+        final String msgKey;
+        if (violated.cardinality() == 1) {
+            msgKey = MSG_NOT_VALID_SINGLE;
+            patternsString = patterns.get(violated.nextSetBit(0))
+                    .toString();
+        }
+        else {
+            msgKey = MSG_NOT_VALID_MULTI;
+            final Collection<Pattern> violatedPatterns = new ArrayList<>(
+                    violated.cardinality());
+            int index = violated.nextSetBit(0);
+            while (index >= 0) {
+                violatedPatterns.add(patterns.get(index));
+                index = violated.nextSetBit(index + 1);
+            }
+            patternsString = violatedPatterns.toString();
+        }
+        log(member.getLineNo(), member.getColumnNo(), msgKey, enumName,
+                patternsString);
+    }
+
+    /**
+     * Matches the specified enum name against the patterns, specified by
+     * {@code conformedPattenrs}.
+     *
+     * @param name
+     *        name to validate
+     * @param conformedPatterns
+     *        bit set of patterns, which the method should match against.
+     * @return bit set of matched patterns. Returned value is alwais a subset of
+     *         {@code conformedPatterns}
+     */
+    private BitSet match(String name, BitSet conformedPatterns) {
+        final BitSet result = new BitSet(patternCount);
+        for (int i = 0; i < patterns.size(); i++) {
+            if (conformedPatterns.get(i)) {
+                final Pattern pattern = patterns.get(i);
+                if (pattern.matcher(name).find()) {
+                    result.set(i);
+                }
+            }
+        }
+        return result;
+    }
+}

--- a/sevntu-checks/src/main/java/com/github/sevntu/checkstyle/checks/naming/package-info.java
+++ b/sevntu-checks/src/main/java/com/github/sevntu/checkstyle/checks/naming/package-info.java
@@ -1,0 +1,24 @@
+////////////////////////////////////////////////////////////////////////////////
+// checkstyle: Checks Java source code for adherence to a set of rules.
+// Copyright (C) 2001-2016 the original author or authors.
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+////////////////////////////////////////////////////////////////////////////////
+
+/**
+ * Contains the <span class="xdocspagetitle">Naming conventions</span> checks
+ * that are bundled with the main distribution.
+ */
+package com.github.sevntu.checkstyle.checks.naming;

--- a/sevntu-checks/src/main/resources/com/github/sevntu/checkstyle/checks/naming/messages.properties
+++ b/sevntu-checks/src/main/resources/com/github/sevntu/checkstyle/checks/naming/messages.properties
@@ -4,3 +4,5 @@ no.abstract.class.modifier=Class ''{0}'' must has abstract modifier.
 method.name.equals.class.name=Method Name ''{0}'' must not equal the enclosing class name.
 enum.name.const.invalidPattern=Name of Values Enumeration ''{0}'' must match pattern ''{1}''.
 enum.name.obj.invalidPattern=Name of Class Enumeration ''{0}'' must match pattern ''{1}''.
+enum.name.formats.violated=Name of enumeration value ''{0}'' must match one of patterns: {1}.
+enum.name.format.violated=Name of enumeration value ''{0}'' must match pattern {1}.

--- a/sevntu-checks/src/test/java/com/github/sevntu/checkstyle/checks/naming/UniformEnumConstantNameCheckTest.java
+++ b/sevntu-checks/src/test/java/com/github/sevntu/checkstyle/checks/naming/UniformEnumConstantNameCheckTest.java
@@ -1,0 +1,170 @@
+////////////////////////////////////////////////////////////////////////////////
+// checkstyle: Checks Java source code for adherence to a set of rules.
+// Copyright (C) 2001-2016 the original author or authors.
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+////////////////////////////////////////////////////////////////////////////////
+
+package com.github.sevntu.checkstyle.checks.naming;
+
+import java.io.IOException;
+import java.util.Arrays;
+
+import org.junit.Test;
+
+import com.github.sevntu.checkstyle.BaseCheckTestSupport;
+import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
+import com.puppycrawl.tools.checkstyle.api.CheckstyleException;
+
+/**
+ * Test unit for {@link UniformEnumConstantNameCheck}.
+ *
+ * @author Pavel Baranchikov
+ */
+public class UniformEnumConstantNameCheckTest extends BaseCheckTestSupport
+{
+    private final String inputFile;
+
+    public UniformEnumConstantNameCheckTest() throws IOException
+    {
+        inputFile = getPath("InputUniformEnumConstantNameCheck.java");
+    }
+
+    /**
+     * Tests for a default naming pattern.
+     *
+     * @throws Exception
+     *         on some errors during verification.
+     */
+    @Test
+    public void testDefault()
+            throws Exception
+    {
+        final DefaultConfiguration checkConfig =
+                createCheckConfig(UniformEnumConstantNameCheck.class);
+        final String[] expected =
+        {
+                buildMessage(37, 9, "SECOND_SIMPLE",
+                        UniformEnumConstantNameCheck.CAMEL_PATTERN),
+                buildMessage(48, 9, "SecondComplex",
+                        UniformEnumConstantNameCheck.UPPERCASE_PATTERN),
+                buildMessage(90, 9, "WF_First",
+                        UniformEnumConstantNameCheck.DEFAULT_PATTERN),
+        };
+        verify(checkConfig, inputFile, expected);
+    }
+
+    /**
+     * Tests for a format set to a single upper-case notation.
+     *
+     * @throws Exception
+     *         on some errors during verification.
+     */
+    @Test
+    public void testUpperCase()
+            throws Exception
+    {
+        final DefaultConfiguration checkConfig =
+                createCheckConfig(UniformEnumConstantNameCheck.class);
+        checkConfig.addAttribute("formats",
+                UniformEnumConstantNameCheck.UPPERCASE_PATTERN);
+        final String[] expected =
+        {
+                buildMessage(35, 9, "FirstSimple",
+                        UniformEnumConstantNameCheck.UPPERCASE_PATTERN),
+                buildMessage(48, 9, "SecondComplex",
+                        UniformEnumConstantNameCheck.UPPERCASE_PATTERN),
+                buildMessage(82, 9, "CcFirst",
+                        UniformEnumConstantNameCheck.UPPERCASE_PATTERN),
+                buildMessage(90, 9, "WF_First",
+                        UniformEnumConstantNameCheck.UPPERCASE_PATTERN),
+        };
+        verify(checkConfig, inputFile, expected);
+    }
+
+    /**
+     * Tests for a accepting all format is used as one of the formats.
+     *
+     * @throws Exception
+     *         on some errors during verification.
+     */
+    @Test
+    public void testAllAfterUpper()
+            throws Exception
+    {
+        final DefaultConfiguration checkConfig =
+                createCheckConfig(UniformEnumConstantNameCheck.class);
+        checkConfig.addAttribute("formats",
+                UniformEnumConstantNameCheck.UPPERCASE_PATTERN + ",.*");
+        final String[] expected = {};
+        verify(checkConfig, inputFile, expected);
+    }
+
+    /**
+     * Tests for wrong formatter string.
+     *
+     * @throws Exception
+     *         on some errors during verification.
+     */
+    @Test(expected = CheckstyleException.class)
+    public void testInvalidFormat()
+            throws Exception
+    {
+        final DefaultConfiguration checkConfig =
+                createCheckConfig(UniformEnumConstantNameCheck.class);
+        checkConfig.addAttribute("formats", "\\");
+        final String[] expected = {};
+        verify(checkConfig, inputFile, expected);
+    }
+
+    /**
+     * Tests for wrong tokens specified.
+     *
+     * @throws Exception
+     *         on some errors during verification.
+     */
+    @Test(expected = CheckstyleException.class)
+    public void testWrongToken()
+            throws Exception
+    {
+        final DefaultConfiguration checkConfig =
+                createCheckConfig(UniformEnumConstantNameCheck.class);
+        checkConfig.addAttribute("tokens", "INTERFACE_DEF");
+        final String[] expected = {};
+        verify(checkConfig, inputFile, expected);
+    }
+
+    private String buildMessage(int lineNumber, int colNumber,
+            String constName, String... pattern)
+    {
+        final String msgKey;
+        final String patternsString;
+        if (pattern.length == 1) {
+            msgKey = UniformEnumConstantNameCheck.MSG_NOT_VALID_SINGLE;
+            patternsString = pattern[0];
+        }
+        else {
+            msgKey = UniformEnumConstantNameCheck.MSG_NOT_VALID_MULTI;
+            patternsString = Arrays.asList(pattern).toString();
+        }
+        return lineNumber
+                + ":"
+                + colNumber
+                + ": "
+                + getCheckMessage(msgKey,
+                        constName, patternsString);
+    }
+
+}

--- a/sevntu-checks/src/test/resources/com/github/sevntu/checkstyle/checks/naming/InputUniformEnumConstantNameCheck.java
+++ b/sevntu-checks/src/test/resources/com/github/sevntu/checkstyle/checks/naming/InputUniformEnumConstantNameCheck.java
@@ -1,0 +1,93 @@
+////////////////////////////////////////////////////////////////////////////////
+// checkstyle: Checks Java source code for adherence to a set of rules.
+// Copyright (C) 2001-2016 the original author or authors.
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+////////////////////////////////////////////////////////////////////////////////
+package com.github.sevntu.checkstyle.checks.naming;
+
+/**
+ * Test case for
+ * {@link com.puppycrawl.tools.checkstyle.checks.naming.UniformEnumConstantNameCheck} unit
+ * test.
+ *
+ * @author Pavel Baranchikov
+ */
+public class InputUniformEnumConstantNameCheck
+{
+    /**
+     * Simple enum. It has neither fiels nor methods.
+     */
+    enum SimpleProperEnum
+    {
+        FirstSimple,
+        DB2,
+        SECOND_SIMPLE, // << failure
+        V1;
+    }
+
+    /**
+     * Complex enum, having both fields and methods.
+     */
+    enum ComplexProperEnum
+    {
+        FITST_COMPLEX(1),
+        V2(2),
+        SecondComplex(3); // << failure
+
+        private final int intValue;
+
+        private ComplexProperEnum(int intValue)
+        {
+            this.intValue = intValue;
+        }
+
+        public int getIntValue()
+        {
+            return intValue;
+        }
+
+        public int getLongValue()
+        {
+            return intValue;
+        }
+
+    }
+
+    /**
+     * Enum with upper case values.
+     */
+    enum UpperCaseEnum
+    {
+        UC_FIRST, UC_SECOND, DB2; // Ok
+    }
+
+    /**
+     * Enum with camel case values.
+     */
+    enum CamelCaseEnum
+    {
+        CcFirst, CcSecond, DB2; // Ok
+    }
+
+    /**
+     * Enum with wrong patterns in all the values.
+     */
+    enum WrongFormatterEnum
+    {
+        WF_First, // failure - wrong pattern
+        WF_Second;
+    }
+}

--- a/sevntu-checkstyle-sonar-plugin/src/main/resources/com/github/sevntu/checkstyle/sonar/checkstyle-extensions.xml
+++ b/sevntu-checkstyle-sonar-plugin/src/main/resources/com/github/sevntu/checkstyle/sonar/checkstyle-extensions.xml
@@ -713,6 +713,18 @@
 		</param>
 	</rule>
 
+    <rule>
+        <key>com.github.sevntu.checkstyle.checks.naming.UniformEnumConstantNameCheck</key>
+        <name>Check for enum constants name</name>
+        <category name="coding"/>
+        <description>Check forces enum constants to match one of the specified patterns and forces all the values to follow only one of the specified patterns.</description>
+        <configKey>Checker/TreeWalker/com.github.sevntu.checkstyle.checks.naming.UniformEnumConstantNameCheck</configKey>
+        <param key="formats" type="STRING">
+            <description>Regex for Enumeration constants name to conform</description>
+            <defaultValue>^[A-Z][a-zA-Z0-9]*$,^[A-Z][A-Z0-9]*(_[A-Z0-9]+)*$</defaultValue>
+        </param>
+    </rule>
+
 	<!-- 'annotation' checks -->
 	<rule>
 		<key>com.github.sevntu.checkstyle.checks.annotation.ForbidAnnotationCheck</key>


### PR DESCRIPTION
Removed logic to distinguish enum objects from enum constants.
Added support for multiple format of enum values. Enum is allowed if there is at least one format, that hist values conform.
Default formats are both CamelCase and UPPER_CASE

Check for guava

formats value | Number of violations found
------------- | -------------
default | 0
"^[A-Z][a-zA-Z0-9]*$" (CamelCase) | 59
"^[A-Z][A-Z0-9]*(_[A-Z0-9]+)*$" (UPPER_CASE) | 12

Reports:
http://pbaranchikov.github.io/checkstyle/enum-value-uppercase/checkstyle.html
http://pbaranchikov.github.io/checkstyle/enum-value-camel/checkstyle.html