### PR TITLE
Changes to 'Related Projects' section in README.textile

### DIFF
--- a/README.textile
+++ b/README.textile
@@ -10,7 +10,7 @@ Additional(non-standard) checks for Checkstyle that are compiled as:
 
 h3. Related Projects
 
-"Checkstyle":http://checkstyle.sourceforge.net/, "EclipseCS":http://eclipse-cs.sourceforge.net/, "Maven Checkstyle Plugin":http://maven.apache.org/plugins/maven-checkstyle-plugin/, "Checkstyle IDEA":https://github.com/jshiell/checkstyle-idea, "Sonar Checkstyle Plugin":https://github.com/SonarSource/sonar-java/tree/master/sonar-checkstyle-plugin, "Checkstyle Beans to NetBeans":http://plugins.netbeans.org/plugin/3413/checkstyle-beans
+"Checkstyle":http://checkstyle.sourceforge.net/, "EclipseCS":http://eclipse-cs.sourceforge.net/, "Checkstyle IDEA":https://github.com/jshiell/checkstyle-idea, "Checkstyle Beans to NetBeans":http://plugins.netbeans.org/plugin/3413/checkstyle-beans, "Checkstyle Addons":http://checkstyle-addons.thomasjensen.com/, "Maven Checkstyle Plugin":http://maven.apache.org/plugins/maven-checkstyle-plugin/, "Gradle Checkstyle Plugin":https://docs.gradle.org/current/userguide/checkstyle_plugin.html, "Sonar Checkstyle Plugin":http://redirect.sonarsource.com/plugins/checkstyle.html
 
 h3. Contributors
 


### PR DESCRIPTION
I am proposing a small update to the list of 'related projects' in the README:

- Mention the Gradle Checkstyle plugin (on the grounds that the Maven Plugin was mentioned as well, and Gradle is increasingly popular)
- Correct the link to the SonarQube Checkstyle plugin
- Change the order of entries so that related projects are grouped together

In addition to that, I would like to ask you to accept the fourth change, which is including a reference to [Checkstyle Addons](http://checkstyle-addons.thomasjensen.com/), a small collection of additional checks that I am the author of - it's free and open source.

Thanks for your support!