### PR TITLE
Issue #437: Fix NumericLiteralNeedsUnderscore properties

### DIFF
--- a/sevntu-checks/src/main/java/com/github/sevntu/checkstyle/checks/coding/NumericLiteralNeedsUnderscoreCheck.java
+++ b/sevntu-checks/src/main/java/com/github/sevntu/checkstyle/checks/coding/NumericLiteralNeedsUnderscoreCheck.java
@@ -261,11 +261,11 @@ public class NumericLiteralNeedsUnderscoreCheck extends Check {
     /**
      * Sets how many characters in a decimal literal there must be before it checks for an
      * underscore.
-     * @param len
+     * @param length
      *        minimum checking length of the literal
      */
-    public void setMinDecimalSymbolLen(int len) {
-        minDecimalSymbolLength = len;
+    public void setMinDecimalSymbolLength(int length) {
+        minDecimalSymbolLength = length;
     }
 
     /**
@@ -281,11 +281,11 @@ public class NumericLiteralNeedsUnderscoreCheck extends Check {
     /**
      * Sets how many characters in a hex literal there must be before it checks for an
      * underscore.
-     * @param len
+     * @param length
      *        minimum checking length of the literal
      */
-    public void setMinHexSymbolLen(int len) {
-        minHexSymbolLength = len;
+    public void setMinHexSymbolLength(int length) {
+        minHexSymbolLength = length;
     }
 
     /**
@@ -301,11 +301,11 @@ public class NumericLiteralNeedsUnderscoreCheck extends Check {
     /**
      * Sets how many characters in a byte literal there must be before it checks for an
      * underscore.
-     * @param len
+     * @param length
      *        minimum checking length of the literal
      */
-    public void setMinBinarySymbolLen(int len) {
-        minBinarySymbolLength = len;
+    public void setMinBinarySymbolLength(int length) {
+        minBinarySymbolLength = length;
     }
 
     /**

--- a/sevntu-checks/src/test/java/com/github/sevntu/checkstyle/checks/coding/NumericLiteralNeedsUnderscoreCheckTest.java
+++ b/sevntu-checks/src/test/java/com/github/sevntu/checkstyle/checks/coding/NumericLiteralNeedsUnderscoreCheckTest.java
@@ -69,11 +69,11 @@ public class NumericLiteralNeedsUnderscoreCheckTest extends BaseCheckTestSupport
     @Test
     public void testWithConfig() throws Exception {
         DefaultConfiguration checkConfig = createCheckConfig(NumericLiteralNeedsUnderscoreCheck.class);
-        checkConfig.addAttribute("minDecimalSymbolLen", "1");
+        checkConfig.addAttribute("minDecimalSymbolLength", "1");
         checkConfig.addAttribute("maxDecimalSymbolsUntilUnderscore", "3");
-        checkConfig.addAttribute("minHexSymbolLen", "1");
+        checkConfig.addAttribute("minHexSymbolLength", "1");
         checkConfig.addAttribute("maxHexSymbolsUntilUnderscore", "2");
-        checkConfig.addAttribute("minBinarySymbolLen", "1");
+        checkConfig.addAttribute("minBinarySymbolLength", "1");
         checkConfig.addAttribute("maxBinarySymbolsUntilUnderscore", "4");
         final String[] expected = {
                 "23: " + warningMessage,
@@ -135,7 +135,7 @@ public class NumericLiteralNeedsUnderscoreCheckTest extends BaseCheckTestSupport
         final DefaultConfiguration checkConfig =
                 createCheckConfig(NumericLiteralNeedsUnderscoreCheck.class);
         checkConfig.addAttribute("ignoreFieldNamePattern", "RED");
-        checkConfig.addAttribute("minDecimalSymbolLen", "1");
+        checkConfig.addAttribute("minDecimalSymbolLength", "1");
         final String[] expected = {
                 "7: " + warningMessage,
                 "8: " + warningMessage,


### PR DESCRIPTION
Tested with sonarqube 5.3 with project analysis and different options.

Also tested with eclipsecs.