### PR TITLE
.classpath with minor additions, as per M2E

### DIFF
--- a/sevntu-checks/.classpath
+++ b/sevntu-checks/.classpath
@@ -34,6 +34,10 @@
 			<attribute name="maven.pomderived" value="true"/>
 		</attributes>
 	</classpathentry>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.7">
+		<attributes>
+			<attribute name="maven.pomderived" value="true"/>
+		</attributes>
+	</classpathentry>
 	<classpathentry kind="output" path="target/classes"/>
 </classpath>


### PR DESCRIPTION
The latest m2e (Maven support for Eclipse) creates the .classpath file
like this.  It's a PITA that it always shows up as "dirty" in Git, and
it would thus be best to merge this to avoid that.

An alternative could be to not keep Eclipse metadata in Git at all
anymore.

Change-Id: I91d4417183fa6d5a9db2b4fa4049b1e0fbfef04f
Signed-off-by: Michael Vorburger <vorburger@redhat.com>