### PR TITLE
Clean up to remove <subpackage-s from import-control.xml

### DIFF
--- a/sevntu-checks/import-control.xml
+++ b/sevntu-checks/import-control.xml
@@ -30,49 +30,10 @@
   <allow pkg="com.puppycrawl.tools.checkstyle.grammars" local-only="true"/>
   <allow pkg="org.apache.commons.cli" local-only="true"/>
 
-  <subpackage name="ant">
-    <allow pkg="org.apache.tools.ant" local-only="true"/>
-  </subpackage>
-
-  <subpackage name="api">
-    <allow pkg="com.puppycrawl.tools.checkstyle.grammars"/>
-    <allow pkg="java.beans"/>
-    <allow pkg="java.text"/>
-    <allow class="com.puppycrawl.tools.checkstyle.grammars.CommentListener"
-           local-only="true"/>
-    <allow class="com.puppycrawl.tools.checkstyle.grammars.GeneratedJavaTokenTypes"
-           local-only="true"/>
-    <allow class="com.puppycrawl.tools.checkstyle.Utils"
-           local-only="true"/>
-  </subpackage>
-
   <subpackage name="checks">
     <allow pkg="com.github.sevntu.checkstyle.checks"/>
     <allow class="com.puppycrawl.tools.checkstyle.Definitions"/>
     <allow pkg="java.math"/>
-
-    <subpackage name="indentation">
-      <allow pkg="java.lang.reflect"/>
-    </subpackage>
-    <subpackage name="header">
-      <allow class="java.nio.charset.Charset" local-only="true"/>
-    </subpackage>
-    <subpackage name="javadoc">
-      <allow pkg="com.puppycrawl.tools.checkstyle.grammars.javadoc"/>
-      <allow pkg="java.lang.reflect"/>
-    </subpackage>
   </subpackage>
 
-  <subpackage name="doclets">
-    <allow pkg="com.sun.javadoc"/>
-  </subpackage>
-
-  <subpackage name="filters">
-    <allow pkg="java.lang.ref"/>
-  </subpackage>
-
-  <subpackage name="gui">
-    <allow pkg="java.awt"/>
-    <allow pkg="javax.swing"/>
-  </subpackage>
 </import-control>


### PR DESCRIPTION
These appear to be left over from another project, or by gone days...
the current src/ code of this project (sevntu-checks) does not have any
such packages.

It's causing no real harm, but it's initially confusing to read the
import-control.xml when something goes wrong in it to see all these
useless declarations.

Signed-off-by: Michael Vorburger <mike@vorburger.ch>