### PR TITLE
Issue #506: added unit test to verify checks referenced in config

### DIFF
--- a/sevntu-checks/sevntu-checks.xml
+++ b/sevntu-checks/sevntu-checks.xml
@@ -2,26 +2,47 @@
 <!DOCTYPE module PUBLIC "-//Puppy Crawl//DTD Check Configuration 1.2//EN" "http://www.puppycrawl.com/dtds/configuration_1_2.dtd">
 
 <module name="Checker">
+
+  <!-- Filters -->
   <module name="SuppressionCommentFilter"/>
+
   <module name="TreeWalker">
+    <property name="tabWidth" value="4"/>
+
+    <!-- Misc -->
     <module name="FileContentsHolder"/>
-    <module name="com.github.sevntu.checkstyle.checks.coding.ForbidCCommentsInMethods">
+
+    <!-- Annotation -->
+    <module name="com.github.sevntu.checkstyle.checks.annotation.ForbidAnnotationElementValue">
+      <property name="annotationName" value="Test"/>
+      <property name="elementName" value="expected"/>
+      <property name="forbiddenElementValueRegexp" value=".*"/>
     </module>
-    <module name="com.github.sevntu.checkstyle.checks.naming.InterfaceTypeParameterNameCheck">
-      <property name="format" value="^[A-Z]$"/>
+    <module name="com.github.sevntu.checkstyle.checks.annotation.ForbidAnnotation">
+      <property name="annotationNames" value="Ignore, VisibleForTesting"/>
+      <property name="annotationTargets" value="METHOD_DEF"/>
     </module>
-    <module name="com.github.sevntu.checkstyle.checks.coding.NoNullForCollectionReturnCheck">
-      <property name="collectionList" value="AbstractCollection AbstractList AbstractQueue AbstractSequentialList AbstractSet ArrayBlockingQueue ArrayDeque ArrayList AttributeList BeanContextServicesSupport BeanContextSupport ConcurrentLinkedDeque ConcurrentLinkedQueue ConcurrentSkipListSet CopyOnWriteArrayList CopyOnWriteArraySet DelayQueue EnumSet HashSet JobStateReasons LinkedBlockingDeque LinkedBlockingQueue LinkedHashSet LinkedList LinkedTransferQueue PriorityBlockingQueue PriorityQueue RoleList RoleUnresolvedList Stack SynchronousQueue TreeSet Vector Collection List Map Set"/>
+    <module name="com.github.sevntu.checkstyle.checks.annotation.RequiredParameterForAnnotation"/>
+    <module name="com.github.sevntu.checkstyle.checks.annotation.RequiredParameterForAnnotation">
+      <property name="annotationName" value="Generated"/>
+      <property name="requiredParameters" value="value"/>
+    </module>
+
+    <!-- Coding -->
+    <module name="com.github.sevntu.checkstyle.checks.coding.ForbidCCommentsInMethods"/>
+    <module name="com.github.sevntu.checkstyle.checks.coding.NoNullForCollectionReturn">
+      <property name="collectionList"
+        value="AbstractCollection AbstractList AbstractQueue AbstractSequentialList AbstractSet ArrayBlockingQueue ArrayDeque ArrayList AttributeList BeanContextServicesSupport BeanContextSupport ConcurrentLinkedDeque ConcurrentLinkedQueue ConcurrentSkipListSet CopyOnWriteArrayList CopyOnWriteArraySet DelayQueue EnumSet HashSet JobStateReasons LinkedBlockingDeque LinkedBlockingQueue LinkedHashSet LinkedList LinkedTransferQueue PriorityBlockingQueue PriorityQueue RoleList RoleUnresolvedList Stack SynchronousQueue TreeSet Vector Collection List Map Set"/>
       <property name="searchThroughMethodBody" value="false"/>
     </module>
-    <module name="com.github.sevntu.checkstyle.checks.coding.CustomDeclarationOrderCheck">
-      <property name="customDeclarationOrder" value="Field(public) ### Field(protected) ### Field(private) ### CTOR(.*) ### Method(.*)### InnerClass()"/>
+    <module name="com.github.sevntu.checkstyle.checks.coding.CustomDeclarationOrder">
+      <property name="customDeclarationOrder"
+        value="Field(public) ### Field(protected) ### Field(private) ### CTOR(.*) ### Method(.*)### InnerClass()"/>
       <property name="caseSensitive" value="true"/>
       <property name="fieldPrefix" value=""/>
     </module>
-    <module name="com.github.sevntu.checkstyle.checks.coding.ForbidReturnInFinallyBlockCheck">
-    </module>
-    <module name="com.github.sevntu.checkstyle.checks.coding.MultipleStringLiteralsExtendedCheck">
+    <module name="com.github.sevntu.checkstyle.checks.coding.ForbidReturnInFinallyBlock"/>
+    <module name="com.github.sevntu.checkstyle.checks.coding.MultipleStringLiteralsExtended">
       <property name="severity" value="warning"/>
       <property name="allowedDuplicates" value="1"/>
       <property name="ignoreOccurrenceContext" value="ANNOTATION"/>
@@ -31,62 +52,123 @@
     <module name="com.github.sevntu.checkstyle.checks.coding.AvoidDefaultSerializableInInnerClasses">
       <property name="allowPartialImplementation" value="false"/>
     </module>
-    <module name="com.github.sevntu.checkstyle.checks.coding.ConfusingConditionCheck">
+    <module name="com.github.sevntu.checkstyle.checks.coding.ConfusingCondition">
       <property name="multiplyFactorForElseBlocks" value="4"/>
       <property name="ignoreInnerIf" value="true"/>
       <property name="ignoreSequentialIf" value="true"/>
       <property name="ignoreNullCaseInIf" value="true"/>
       <property name="ignoreThrowInElse" value="true"/>
     </module>
-    <module name="com.github.sevntu.checkstyle.checks.sizes.LineLengthExtendedCheck">
-      <property name="severity" value="warning"/>
-      <property name="ignorePattern" value="^$"/>
-      <property name="max" value="80"/>
-      <property name="tabWidth" value="8"/>
-      <property name="ignoreClass" value="false"/>
-      <property name="ignoreConstructor" value="false"/>
-      <property name="ignoreField" value="false"/>
-      <property name="ignoreMethod" value="false"/>
-    </module>
-    <module name="com.github.sevntu.checkstyle.checks.coding.LogicConditionNeedOptimizationCheck">
-    </module>
-    <module name="com.github.sevntu.checkstyle.checks.design.ChildBlockLengthCheck">
-      <property name="severity" value="warning"/>
-      <property name="blockTypes" value="LITERAL_IF,LITERAL_ELSE,LITERAL_WHILE,LITERAL_DO,LITERAL_FOR,LITERAL_SWITCH,LITERAL_TRY,LITERAL_CATCH"/>
-      <property name="maxChildBlockPercentage" value="90"/>
-      <property name="ignoreBlockLinesCount" value="50"/>
-    </module>
-    <module name="com.github.sevntu.checkstyle.checks.coding.ReturnBooleanFromTernary">
-    </module>
-    <module name="com.github.sevntu.checkstyle.checks.coding.ReturnNullInsteadOfBoolean">
-    </module>
-    <module name="com.github.sevntu.checkstyle.checks.coding.ForbidCertainImportsCheck">
-    </module>
-    <module name="com.github.sevntu.checkstyle.checks.coding.AvoidModifiersForTypesCheck">
+    <module name="com.github.sevntu.checkstyle.checks.coding.LogicConditionNeedOptimization"/>
+    <module name="com.github.sevntu.checkstyle.checks.coding.ReturnBooleanFromTernary"/>
+    <module name="com.github.sevntu.checkstyle.checks.coding.ReturnNullInsteadOfBoolean"/>
+    <module name="com.github.sevntu.checkstyle.checks.coding.ForbidCertainImports"/>
+    <module name="com.github.sevntu.checkstyle.checks.coding.AvoidModifiersForTypes">
       <property name="forbiddenClassesRegexpFinal" value=""/>
       <property name="forbiddenClassesRegexpStatic" value="ULC.+"/>
       <property name="forbiddenClassesRegexpTransient" value=""/>
       <property name="forbiddenClassesRegexpVolatile" value=""/>
-      <!-- 1.20.0 -->
       <property name="forbiddenClassesRegexpAnnotation" value=""/>
       <property name="forbiddenClassesRegexpPrivate" value=""/>
       <property name="forbiddenClassesRegexpPackagePrivate" value=""/>
       <property name="forbiddenClassesRegexpProtected" value=""/>
       <property name="forbiddenClassesRegexpPublic" value=""/>
     </module>
-    <module name="com.github.sevntu.checkstyle.checks.coding.OverridableMethodInConstructorCheck">
+    <module name="com.github.sevntu.checkstyle.checks.coding.OverridableMethodInConstructor">
       <property name="severity" value="warning"/>
       <property name="checkCloneMethod" value="false"/>
       <property name="checkReadObjectMethod" value="false"/>
       <property name="matchMethodsByArgCount" value="false"/>
     </module>
-    <module name="com.github.sevntu.checkstyle.checks.coding.AvoidNotShortCircuitOperatorsForBooleanCheck">
-    </module>
-    <module name="com.github.sevntu.checkstyle.checks.coding.MultipleVariableDeclarationsExtendedCheck">
+    <module name="com.github.sevntu.checkstyle.checks.coding.AvoidNotShortCircuitOperatorsForBoolean"/>
+    <module name="com.github.sevntu.checkstyle.checks.coding.MultipleVariableDeclarationsExtended">
       <property name="ignoreCycles" value="false"/>
       <property name="ignoreMethods" value="false"/>
     </module>
-    <module name="com.github.sevntu.checkstyle.checks.design.ForbidWildcardAsReturnTypeCheck">
+    <module name="com.github.sevntu.checkstyle.checks.coding.EitherLogOrThrow">
+      <property name="loggerFullyQualifiedClassName" value="org.slf4j.Logger"/>
+      <property name="loggingMethodNames" value="error, warn, info, debug"/>
+    </module>
+    <module name="com.github.sevntu.checkstyle.checks.coding.AvoidHidingCauseException"/>
+    <module name="com.github.sevntu.checkstyle.checks.coding.IllegalCatchExtended">
+      <property name="severity" value="warning"/>
+      <property name="allowThrow" value="true"/>
+      <property name="allowRethrow" value="false"/>
+    </module>
+    <module name="com.github.sevntu.checkstyle.checks.coding.ReturnCountExtended">
+      <property name="maxReturnCount" value="1"/>
+      <property name="ignoreMethodLinesCount" value="20"/>
+      <property name="minIgnoreReturnDepth" value="4"/>
+      <property name="ignoreEmptyReturns" value="true"/>
+      <property name="topLinesToIgnoreCount" value="5"/>
+      <property name="ignoreMethodsNames" value="equals"/>
+    </module>
+    <module name="com.github.sevntu.checkstyle.checks.coding.SimpleAccessorNameNotation">
+      <property name="severity" value="warning"/>
+    </module>
+    <module name="com.github.sevntu.checkstyle.checks.coding.UnnecessaryParenthesesExtended">
+      <property name="ignoreCalculationOfBooleanVariables" value="false"/>
+      <property name="ignoreCalculationOfBooleanVariablesWithReturn" value="false"/>
+      <property name="ignoreCalculationOfBooleanVariablesWithAssert" value="false"/>
+    </module>
+    <module name="com.github.sevntu.checkstyle.checks.coding.ForbidInstantiation">
+      <property name="forbiddenClasses" value="java.lang.NullPointerException"/>
+    </module>
+    <module name="com.github.sevntu.checkstyle.checks.coding.AvoidConstantAsFirstOperandInCondition">
+      <property name="targetConstantTypes"
+        value="LITERAL_NULL,LITERAL_TRUE,LITERAL_FALSE,NUM_INT,NUM_DOUBLE,NUM_LONG,NUM_FLOAT"/>
+    </module>
+    <module name="com.github.sevntu.checkstyle.checks.coding.FinalizeImplementation"/>
+    <module name="com.github.sevntu.checkstyle.checks.coding.ForbidThrowAnonymousExceptions">
+      <property name="exceptionClassNameRegex" value="^.*Exception"/>
+    </module>
+    <module name="com.github.sevntu.checkstyle.checks.coding.MapIterationInForEachLoop">
+      <property name="proposeValuesUsage" value="true"/>
+      <property name="proposeKeySetUsage" value="false"/>
+      <property name="proposeEntrySetUsage" value="false"/>
+    </module>
+    <module name="com.github.sevntu.checkstyle.checks.coding.TernaryPerExpressionCount">
+      <property name="maxTernaryPerExpressionCount" value="1"/>
+      <property name="ignoreTernaryOperatorsInBraces" value="true"/>
+      <property name="ignoreIsolatedTernaryOnLine" value="true"/>
+    </module>
+    <module name="com.github.sevntu.checkstyle.checks.coding.RedundantReturn">
+      <property name="allowReturnInEmptyMethodsAndConstructors" value="false"/>
+    </module>
+    <module name="com.github.sevntu.checkstyle.checks.coding.SingleBreakOrContinue"/>
+    <module name="com.github.sevntu.checkstyle.checks.coding.NumericLiteralNeedsUnderscore">
+      <property name="minDecimalSymbolLength" value="7"/>
+      <property name="maxDecimalSymbolsUntilUnderscore" value="3"/>
+      <property name="minHexSymbolLength" value="5"/>
+      <property name="maxHexSymbolsUntilUnderscore" value="4"/>
+      <property name="minBinarySymbolLength" value="9"/>
+      <property name="maxBinarySymbolsUntilUnderscore" value="8"/>
+      <property name="ignoreFieldNamePattern" value="serialVersionUID"/>
+    </module>
+    <module name="com.github.sevntu.checkstyle.checks.coding.EmptyPublicCtorInClass">
+      <property name="severity" value="warning"/>
+    </module>
+    <module name="com.github.sevntu.checkstyle.checks.coding.DiamondOperatorForVariableDefinition">
+      <property name="severity" value="warning"/>
+    </module>
+    <module name="com.github.sevntu.checkstyle.checks.coding.NameConventionForJunit4TestClasses"/>
+    <module name="com.github.sevntu.checkstyle.checks.coding.UselessSuperCtorCall">
+      <property name="severity" value="warning"/>
+    </module>
+    <module name="com.github.sevntu.checkstyle.checks.coding.UselessSingleCatch"/>
+    <module name="com.github.sevntu.checkstyle.checks.coding.WhitespaceBeforeArrayInitializer">
+      <property name="severity" value="warning"/>
+    </module>
+
+    <!-- Design -->
+    <module name="com.github.sevntu.checkstyle.checks.design.ChildBlockLength">
+      <property name="severity" value="warning"/>
+      <property name="blockTypes"
+        value="LITERAL_IF,LITERAL_ELSE,LITERAL_WHILE,LITERAL_DO,LITERAL_FOR,LITERAL_SWITCH,LITERAL_TRY,LITERAL_CATCH"/>
+      <property name="maxChildBlockPercentage" value="90"/>
+      <property name="ignoreBlockLinesCount" value="50"/>
+    </module>
+    <module name="com.github.sevntu.checkstyle.checks.design.ForbidWildcardAsReturnType">
       <property name="checkPublicMethods" value="true"/>
       <property name="checkPackageMethods" value="true"/>
       <property name="checkProtectedMethods" value="true"/>
@@ -97,103 +179,53 @@
       <property name="allowReturnWildcardWithExtends" value="false"/>
       <property name="returnTypeClassNamesIgnoreRegex" value="^(Comparator|Comparable)$"/>
     </module>
-    <module name="com.github.sevntu.checkstyle.checks.coding.EitherLogOrThrowCheck">
-      <property name="loggerFullyQualifiedClassName" value="org.slf4j.Logger"/>
-      <property name="loggingMethodNames" value="error, warn, info, debug"/>
+    <module name="com.github.sevntu.checkstyle.checks.design.NoMainMethodInAbstractClass"/>
+    <module name="com.github.sevntu.checkstyle.checks.design.PublicReferenceToPrivateType"/>
+    <module name="com.github.sevntu.checkstyle.checks.design.StaticMethodCandidate">
+      <property name="skippedMethods" value="readObject, writeObject, readObjectNoData, readResolve, writeReplace"/>
     </module>
-    <module name="com.github.sevntu.checkstyle.checks.coding.AvoidHidingCauseExceptionCheck">
+    <module name="com.github.sevntu.checkstyle.checks.design.ConstructorWithoutParams">
+      <property name="classNameFormat" value=".*Exception"/>
+      <property name="ignoredClassNameFormat" value="UnsupportedOperationException"/>
     </module>
-    <module name="com.github.sevntu.checkstyle.checks.coding.IllegalCatchExtendedCheck">
-      <property name="allowThrow" value="true"/>
-      <property name="allowRethrow" value="false"/>
-    </module>
-    <module name="com.github.sevntu.checkstyle.checks.coding.ReturnCountExtendedCheck">
-      <property name="maxReturnCount" value="1"/>
-      <property name="ignoreMethodLinesCount" value="20"/>
-      <property name="minIgnoreReturnDepth" value="4"/>
-      <property name="ignoreEmptyReturns" value="true"/>
-      <property name="topLinesToIgnoreCount" value="5"/>
-      <property name="ignoreMethodsNames" value="equals"/>
-    </module>
-    <module name="com.github.sevntu.checkstyle.checks.coding.SimpleAccessorNameNotationCheck">
+    <module name="com.github.sevntu.checkstyle.checks.design.InnerClass"/>
+    <module name="com.github.sevntu.checkstyle.checks.design.HideUtilityClassConstructor"/>
+    <module name="com.github.sevntu.checkstyle.checks.design.NestedSwitch"/>
+    <module name="com.github.sevntu.checkstyle.checks.design.AvoidConditionInversion">
       <property name="severity" value="warning"/>
     </module>
-    <module name="com.github.sevntu.checkstyle.checks.coding.UnnecessaryParenthesesExtendedCheck">
-      <property name="ignoreCalculationOfBooleanVariables" value="false"/>
-      <property name="ignoreCalculationOfBooleanVariablesWithReturn" value="false"/>
-      <property name="ignoreCalculationOfBooleanVariablesWithAssert" value="false"/>
+    <module name="com.github.sevntu.checkstyle.checks.design.CauseParameterInException"/>
+
+    <!-- Naming -->
+    <module name="com.github.sevntu.checkstyle.checks.naming.InterfaceTypeParameterName">
+      <property name="format" value="^[A-Z]$"/>
     </module>
-    <module name="com.github.sevntu.checkstyle.checks.coding.ForbidInstantiationCheck">
-      <property name="forbiddenClasses" value="java.lang.NullPointerException"/>
-    </module>
-    <module name="com.github.sevntu.checkstyle.checks.coding.AvoidConstantAsFirstOperandInConditionCheck">
-      <property name="targetConstantTypes" value="LITERAL_NULL,LITERAL_TRUE,LITERAL_FALSE,NUM_INT,NUM_DOUBLE,NUM_LONG,NUM_FLOAT"/>
-    </module>
-    <module name="com.github.sevntu.checkstyle.checks.design.NoMainMethodInAbstractClassCheck">
-    </module>
-    <!-- since 1.11 -->
-    <module name="com.github.sevntu.checkstyle.checks.naming.EnumValueNameCheck">
+    <module name="com.github.sevntu.checkstyle.checks.naming.EnumValueName">
       <property name="objFormat" value="^[A-Z][a-zA-Z0-9]*$"/>
       <property name="constFormat" value="^[A-Z][A-Z0-9]*(_[A-Z0-9]+)*$"/>
       <property name="excludes" value="toString"/>
     </module>
-    <module name="com.github.sevntu.checkstyle.checks.coding.FinalizeImplementationCheck">
-    </module>
-    <module name="com.github.sevntu.checkstyle.checks.coding.ForbidThrowAnonymousExceptionsCheck">
-    <property name="exceptionClassNameRegex" value="^.*Exception"/>
-    </module>
-    <module name="com.github.sevntu.checkstyle.checks.coding.MapIterationInForEachLoopCheck">
-      <property name="proposeValuesUsage" value="true"/>
-      <property name="proposeKeySetUsage" value="false"/>
-      <property name="proposeEntrySetUsage" value="false"/>
-    </module>
-    <!-- since 1.12 -->
-    <module name="com.github.sevntu.checkstyle.checks.coding.TernaryPerExpressionCountCheck">
-      <property name="maxTernaryPerExpressionCount" value="1"/>
-      <property name="ignoreTernaryOperatorsInBraces" value="true"/>
-      <property name="ignoreIsolatedTernaryOnLine" value="true"/>
-    </module>
-    <module name="com.github.sevntu.checkstyle.checks.coding.RedundantReturnCheck">
-      <property name="allowReturnInEmptyMethodsAndConstructors" value="false"/>
-    </module>
-    <module name="com.github.sevntu.checkstyle.checks.design.PublicReferenceToPrivateTypeCheck">
-    </module>
-    <!-- 1.16.0 , but moved to checkstyle project since 1.21.0 -->
-    <!-- <module name="com.github.sevntu.checkstyle.checks.whitespace.SingleSpaceSeparatorCheck">
-      <property name="validateCommentNodes" value="false"/>
-    </module>
-    -->
-    <!-- 1.17.0 -->
-    <module name="com.github.sevntu.checkstyle.checks.design.StaticMethodCandidateCheck">
-      <property name="skippedMethods" value="readObject, writeObject, readObjectNoData, readResolve, writeReplace"/>
-    </module>
-    <!-- 1.18.0 -->
-    <module name="com.github.sevntu.checkstyle.checks.coding.SingleBreakOrContinueCheck">
-    </module>
-    <module name="com.github.sevntu.checkstyle.checks.coding.NumericLiteralNeedsUnderscoreCheck" >
-      <property name="minDecimalSymbolLength" value="7"/>
-      <property name="maxDecimalSymbolsUntilUnderscore" value="3"/>
-      <property name="minHexSymbolLength" value="5"/>
-      <property name="maxHexSymbolsUntilUnderscore" value="4"/>
-      <property name="minBinarySymbolLength" value="9"/>
-      <property name="maxBinarySymbolsUntilUnderscore" value="8"/>
-      <!-- 1.19.1 -->
-      <property name="ignoreFieldNamePattern" value="serialVersionUID"/>
-    </module>
-    <!-- 1.20.0 -->
-    <module name="com.github.sevntu.checkstyle.checks.design.ConstructorWithoutParamsCheck" >
-      <property name="classNameFormat" value=".*Exception"/>
-      <property name="ignoredClassNameFormat" value="UnsupportedOperationException"/>
-    </module>
-    <!-- 1.21.0 -->
-    <module name="com.github.sevntu.checkstyle.checks.naming.UniformEnumConstantNameCheck" >
+    <module name="com.github.sevntu.checkstyle.checks.naming.UniformEnumConstantName">
       <property name="formats" value="^[A-Z][a-zA-Z0-9]*$,^[A-Z][A-Z0-9]*(_[A-Z0-9]+)*$"/>
     </module>
-    <!-- 1.22.0 -->
-    <module name="com.github.sevntu.checkstyle.checks.annotation.ForbidAnnotationElementValueCheck" >
-      <property name="annotationName" value="Test"/>
-      <property name="elementName" value="expected"/>
-      <property name="forbiddenElementValueRegexp" value=".*"/>
+
+    <!-- Sizes -->
+    <module name="com.github.sevntu.checkstyle.checks.sizes.LineLengthExtended">
+      <property name="severity" value="warning"/>
+      <property name="ignorePattern" value="^$"/>
+      <property name="max" value="80"/>
+      <property name="tabWidth" value="8"/>
+      <property name="ignoreClass" value="false"/>
+      <property name="ignoreConstructor" value="false"/>
+      <property name="ignoreField" value="false"/>
+      <property name="ignoreMethod" value="false"/>
     </module>
+
+    <!-- moved to checkstyle project since 1.21.0 -->
+    <!--
+        <module name="com.github.sevntu.checkstyle.checks.whitespace.SingleSpaceSeparator">
+            <property name="validateCommentNodes" value="false"/>
+        </module>
+    -->
   </module>
 </module>

--- a/sevntu-checks/src/test/java/com/github/sevntu/checkstyle/internal/AllChecksTest.java
+++ b/sevntu-checks/src/test/java/com/github/sevntu/checkstyle/internal/AllChecksTest.java
@@ -1,0 +1,52 @@
+////////////////////////////////////////////////////////////////////////////////
+// checkstyle: Checks Java source code for adherence to a set of rules.
+// Copyright (C) 2001-2016 the original author or authors.
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+////////////////////////////////////////////////////////////////////////////////
+
+package com.github.sevntu.checkstyle.internal;
+
+import java.util.Locale;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class AllChecksTest {
+    @Test
+    public void testAllChecksAreReferencedInConfigFile() throws Exception {
+        final Set<String> checksReferencedInConfig = CheckUtil.getConfigCheckStyleChecks();
+        final Set<String> checksNames = getFullNames(CheckUtil.getCheckstyleChecks());
+
+        checksNames.stream().filter(check -> !checksReferencedInConfig.contains(check))
+            .forEach(check -> {
+                final String errorMessage = String.format(Locale.ROOT,
+                    "%s is not referenced in sevntu-checks.xml", check);
+                Assert.fail(errorMessage);
+            });
+    }
+
+    /**
+     * Removes 'Check' suffix from each class name in the set.
+     * @param checks class instances.
+     * @return a set of simple names.
+     */
+    private static Set<String> getFullNames(Set<Class<?>> checks) {
+        return checks.stream().map(check -> check.getName().replace("Check", ""))
+            .collect(Collectors.toSet());
+    }
+}

--- a/sevntu-checks/suppressions.xml
+++ b/sevntu-checks/suppressions.xml
@@ -30,6 +30,7 @@
     <suppress checks="MagicNumber" files=".*[\\/]src[\\/]test[\\/]"/>
     <suppress checks="AvoidStaticImport" files=".*[\\/]src[\\/]test[\\/]"/>
     <suppress checks="WriteTag" files=".*[\\/]src[\\/]test[\\/]"/>
+    <suppress checks="IllegalCatch" files="[\\/]internal[\\/]\w+Util\.java"/>
 
     <!-- they are aggregators of logic, usage a several of classes are ok -->
     <suppress checks="ClassDataAbstractionCoupling" files=".*[\\/]BaseCheckTestSupport\.java"/>


### PR DESCRIPTION
Issue #506

Unit test added. It will fail for now as configs aren't added.
The following are the missing configs:
````
    <module name="com.github.sevntu.checkstyle.checks.annotation.ForbidAnnotation"/>
    <module name="com.github.sevntu.checkstyle.checks.coding.EmptyPublicCtorInClass"/>
    <module name="com.github.sevntu.checkstyle.checks.coding.DiamondOperatorForVariableDefinition"/>
    <module name="com.github.sevntu.checkstyle.checks.design.InnerClass"/>
    <module name="com.github.sevntu.checkstyle.checks.design.HideUtilityClassConstructor"/>
    <module name="com.github.sevntu.checkstyle.checks.annotation.RequiredParameterForAnnotation"/>
    <module name="com.github.sevntu.checkstyle.checks.coding.NameConventionForJunit4TestClasses"/>
    <module name="com.github.sevntu.checkstyle.checks.coding.UselessSuperCtorCall"/>
    <module name="com.github.sevntu.checkstyle.checks.coding.UselessSingleCatch"/>
    <module name="com.github.sevntu.checkstyle.checks.design.NestedSwitch"/>
    <module name="com.github.sevntu.checkstyle.checks.coding.WhitespaceBeforeArrayInitializer"/>
    <module name="com.github.sevntu.checkstyle.checks.design.AvoidConditionInversion"/>
    <module name="com.github.sevntu.checkstyle.checks.design.CauseParameterInException"/>
````

Questions for continuing:
1) Current config is ordered by release. Do you know what releases these checks are in or do we want to change the order to by package like main?
2) How do we want to customize these checks that have extra properties?