### PR TITLE
Issue #463: extended ReturnCountExtendedCheck to accept lambdas

### DIFF
--- a/eclipsecs-sevntu-plugin/src/com/github/sevntu/checkstyle/checks/coding/checkstyle-metadata.xml
+++ b/eclipsecs-sevntu-plugin/src/com/github/sevntu/checkstyle/checks/coding/checkstyle-metadata.xml
@@ -431,6 +431,7 @@
 
       <message-key key="return.count.extended.method"/>
       <message-key key="return.count.extended.ctor"/>
+      <message-key key="return.count.extended.lambda"/>
     </rule-metadata>
 
     <rule-metadata name="%UnnecessaryParenthesesExtendedCheck.name" internal-name="UnnecessaryParenthesesExtendedCheck" parent="TreeWalker">

--- a/sevntu-checks/pom.xml
+++ b/sevntu-checks/pom.xml
@@ -175,7 +175,6 @@
               <regex><pattern>.*.checks.coding.OverridableMethodInConstructorCheck</pattern><branchRate>88</branchRate><lineRate>99</lineRate></regex>
               <regex><pattern>.*.checks.coding.RedundantReturnCheck</pattern><branchRate>98</branchRate><lineRate>97</lineRate></regex>
               <regex><pattern>.*.checks.coding.ReturnBooleanFromTernaryCheck</pattern><branchRate>75</branchRate><lineRate>100</lineRate></regex>
-              <regex><pattern>.*.checks.coding.ReturnCountExtendedCheck</pattern><branchRate>91</branchRate><lineRate>100</lineRate></regex>
               <regex><pattern>.*.checks.coding.ReturnNullInsteadOfBooleanCheck</pattern><branchRate>80</branchRate><lineRate>88</lineRate></regex>
               <regex><pattern>.*.checks.coding.SimpleAccessorNameNotationCheck</pattern><branchRate>72</branchRate><lineRate>100</lineRate></regex>
               <regex><pattern>.*.checks.coding.UnnecessaryParenthesesExtendedCheck</pattern><branchRate>90</branchRate><lineRate>100</lineRate></regex>

--- a/sevntu-checks/src/main/java/com/github/sevntu/checkstyle/checks/coding/ReturnCountExtendedCheck.java
+++ b/sevntu-checks/src/main/java/com/github/sevntu/checkstyle/checks/coding/ReturnCountExtendedCheck.java
@@ -21,8 +21,6 @@ package com.github.sevntu.checkstyle.checks.coding;
 
 import java.util.Collection;
 import java.util.HashSet;
-import java.util.LinkedList;
-import java.util.List;
 import java.util.Set;
 
 import com.puppycrawl.tools.checkstyle.api.AbstractCheck;
@@ -49,7 +47,12 @@ import com.puppycrawl.tools.checkstyle.checks.coding.ReturnCountCheck;
  * <li>Methods by name ("ignoreMethodsNames" property). Note, that the "ignoreMethodsNames"
  * property type is a RegExp:
  * using this property you can list the names of ignored methods separated by comma (but you
- * can also use '|' to separate different method names in usual for RegExp style).</li>
+ * can also use '|' to separate different method names in usual for RegExp style).
+ * If the violation is on a lambda, since it has no method name, you can specify the string
+ * {@code null} to ignore all lambda violations for now. It should be noted, that ignoring lambdas
+ * this way may not always be supported as it is a hack and giving all lambdas the same name. It
+ * could be changed if a better way to single out individual lambdas if found.
+ * </li>
  * <li>Methods which linelength less than given value ("linesLimit" property).
  * <li>"return" statements which depth is greater or equal to the given value ("returnDepthLimit"
  * property). There are few supported <br>
@@ -81,12 +84,19 @@ public class ReturnCountExtendedCheck extends AbstractCheck {
             "return.count.extended.ctor";
 
     /**
-     * Default maximum allowed "return" literals count per method/ctor.
+     * A key is pointing to the warning message text in "messages.properties"
+     * file.
+     */
+    public static final String MSG_KEY_LAMBDA =
+            "return.count.extended.lambda";
+
+    /**
+     * Default maximum allowed "return" literals count per method/ctor/lambda.
      */
     private static final int DEFAULT_MAX_RETURN_COUNT = 1;
 
     /**
-     * Default number of lines of which method/ctor body may consist to be
+     * Default number of lines of which method/ctor/lambda body may consist to be
      * skipped by check.
      */
     private static final int DEFAULT_IGNORE_METHOD_LINES_COUNT = 20;
@@ -99,7 +109,7 @@ public class ReturnCountExtendedCheck extends AbstractCheck {
 
     /**
      * Number which defines, how many lines of code on the top of current
-     * processed method/ctor will be ignored by check.
+     * processed method/ctor/lambda will be ignored by check.
      */
     private static final int DEFAULT_TOP_LINES_TO_IGNORE_COUNT = 5;
 
@@ -109,12 +119,12 @@ public class ReturnCountExtendedCheck extends AbstractCheck {
     private Set<String> ignoreMethodsNames = new HashSet<>();
 
     /**
-     * Maximum allowed "return" literals count per method/ctor (1 by default).
+     * Maximum allowed "return" literals count per method/ctor/lambda (1 by default).
      */
     private int maxReturnCount = DEFAULT_MAX_RETURN_COUNT;
 
     /**
-     * Maximum number of lines of which method/ctor body may consist to be
+     * Maximum number of lines of which method/ctor/lambda body may consist to be
      * skipped by check. 20 by default.
      */
     private int ignoreMethodLinesCount = DEFAULT_IGNORE_METHOD_LINES_COUNT;
@@ -125,14 +135,14 @@ public class ReturnCountExtendedCheck extends AbstractCheck {
     private int minIgnoreReturnDepth = DEFAULT_MIN_IGNORE_RETURN_DEPTH;
 
     /**
-     * Option to ignore "empty" return statements in void methods and ctors.
+     * Option to ignore "empty" return statements in void methods and ctors and lambdas.
      * "true" by default.
      */
     private boolean ignoreEmptyReturns = true;
 
     /**
      * Number which defines, how many lines of code on the top of each
-     * processed method/ctor will be ignored by check. 5 by default.
+     * processed method/ctor/lambda will be ignored by check. 5 by default.
      */
     private int topLinesToIgnoreCount = DEFAULT_TOP_LINES_TO_IGNORE_COUNT;
 
@@ -159,7 +169,7 @@ public class ReturnCountExtendedCheck extends AbstractCheck {
     }
 
     /**
-     * Sets maximum allowed "return" literals count per method/ctor.
+     * Sets maximum allowed "return" literals count per method/ctor/lambda.
      * @param maxReturnCount - the new "maxReturnCount" property value.
      * @see ReturnCountExtendedCheck#maxReturnCount
      */
@@ -168,7 +178,7 @@ public class ReturnCountExtendedCheck extends AbstractCheck {
     }
 
     /**
-     * Sets the maximum number of lines of which method/ctor body may consist to
+     * Sets the maximum number of lines of which method/ctor/lambda body may consist to
      * be skipped by check.
      * @param ignoreMethodLinesCount
      *        - the new value of "ignoreMethodLinesCount" property.
@@ -189,7 +199,7 @@ public class ReturnCountExtendedCheck extends AbstractCheck {
     }
 
     /**
-     * Sets the "ignoring empty return statements in void methods and ctors"
+     * Sets the "ignoring empty return statements in void methods and ctors and lambdas"
      * option state.
      * @param ignoreEmptyReturns
      *        the new "allowEmptyReturns" property value.
@@ -212,16 +222,20 @@ public class ReturnCountExtendedCheck extends AbstractCheck {
 
     @Override
     public int[] getDefaultTokens() {
-        return new int[] {TokenTypes.METHOD_DEF, TokenTypes.CTOR_DEF, };
+        return new int[] {
+            TokenTypes.METHOD_DEF,
+            TokenTypes.CTOR_DEF,
+            TokenTypes.LAMBDA,
+        };
     }
 
     @Override
-    public void visitToken(final DetailAST methodDefNode) {
-        final DetailAST openingBrace = methodDefNode
+    public void visitToken(final DetailAST node) {
+        final DetailAST openingBrace = node
                 .findFirstToken(TokenTypes.SLIST);
-        final String methodName = getMethodName(methodDefNode);
+        final String nodeName = getMethodName(node);
         if (openingBrace != null
-                && !matches(methodName, ignoreMethodsNames)) {
+                && !matches(nodeName, ignoreMethodsNames)) {
             final DetailAST closingBrace = openingBrace.getLastChild();
 
             int curMethodLinesCount = getLinesCount(openingBrace,
@@ -233,33 +247,48 @@ public class ReturnCountExtendedCheck extends AbstractCheck {
 
             if (curMethodLinesCount >= ignoreMethodLinesCount) {
 
-                final int mCurReturnCount = getReturnCount(methodDefNode,
+                final int mCurReturnCount = getReturnCount(node,
                         openingBrace);
 
                 if (mCurReturnCount > maxReturnCount) {
-                    final String mKey;
-
-                    if (methodDefNode.getType() == TokenTypes.METHOD_DEF) {
-                        mKey = MSG_KEY_METHOD;
-                    }
-                    else {
-                        mKey = MSG_KEY_CTOR;
-                    }
-
-                    final DetailAST methodNameToken = methodDefNode
-                            .findFirstToken(TokenTypes.IDENT);
-
-                    log(methodNameToken, mKey,
-                            methodName, mCurReturnCount,
-                            maxReturnCount);
+                    logViolation(node, nodeName, mCurReturnCount);
                 }
             }
         }
     }
 
     /**
-     * Gets the "return" statements count for given method/ctor and saves the
-     * last "return" statement DetailAST node for given method/ctor body. Uses
+     * Reports violation to user based on the parameters given.
+     * @param node The node that the violation is on.
+     * @param nodeName The name given to the node.
+     * @param mCurReturnCount The return count violation amount.
+     */
+    private void logViolation(DetailAST node, String nodeName, int mCurReturnCount) {
+        if (node.getType() == TokenTypes.LAMBDA) {
+            // lambdas have no name
+            log(node, MSG_KEY_LAMBDA, mCurReturnCount, maxReturnCount);
+        }
+        else {
+            final DetailAST nodeNameToken = node
+                    .findFirstToken(TokenTypes.IDENT);
+            final String mKey;
+
+            if (node.getType() == TokenTypes.METHOD_DEF) {
+                mKey = MSG_KEY_METHOD;
+            }
+            else {
+                mKey = MSG_KEY_CTOR;
+            }
+
+            log(nodeNameToken, mKey,
+                    nodeName, mCurReturnCount,
+                    maxReturnCount);
+        }
+    }
+
+    /**
+     * Gets the "return" statements count for given method/ctor/lambda and saves the
+     * last "return" statement DetailAST node for given method/ctor/lambda body. Uses
      * an iterative algorithm.
      * @param methodOpeningBrace
      *        a DetailAST node that points to the current method`s opening
@@ -275,22 +304,16 @@ public class ReturnCountExtendedCheck extends AbstractCheck {
 
         DetailAST curNode = methodOpeningBrace;
 
-        while (curNode != null) {
+        // stop at closing brace
+        while (curNode.getType() != TokenTypes.RCURLY
+                || curNode.getParent() != methodOpeningBrace) {
 
-            // before node visiting
-            if (curNode.getType() == TokenTypes.RCURLY
-                    && curNode.getParent() == methodOpeningBrace) {
-                // stop at closing brace
-                break;
-            }
-            else {
-                if (curNode.getType() == TokenTypes.LITERAL_RETURN
-                        && getDepth(methodDefNode, curNode) < minIgnoreReturnDepth
-                        && shouldEmptyReturnStatementBeCounted(curNode)
-                        && getLinesCount(methodOpeningBrace,
-                                curNode) > topLinesToIgnoreCount) {
-                    result++;
-                }
+            if (curNode.getType() == TokenTypes.LITERAL_RETURN
+                    && getDepth(methodDefNode, curNode) < minIgnoreReturnDepth
+                    && shouldEmptyReturnStatementBeCounted(curNode)
+                    && getLinesCount(methodOpeningBrace,
+                            curNode) > topLinesToIgnoreCount) {
+                result++;
             }
 
             // before node leaving
@@ -300,11 +323,13 @@ public class ReturnCountExtendedCheck extends AbstractCheck {
             // skip nested methods (UI listeners, Runnable.run(), etc.)
             if (type == TokenTypes.METHOD_DEF
                   // skip anonymous classes
-                  || type == TokenTypes.CLASS_DEF) {
+                  || type == TokenTypes.CLASS_DEF
+                  // skip lambdas which is like an anonymous class/method
+                  || type == TokenTypes.LAMBDA) {
                 nextNode = curNode.getNextSibling();
             }
 
-            while ((curNode != null) && (nextNode == null)) {
+            while (nextNode == null) {
                 // leave the visited Node
                 nextNode = curNode.getNextSibling();
                 if (nextNode == null) {
@@ -371,12 +396,13 @@ public class ReturnCountExtendedCheck extends AbstractCheck {
      */
     private static String getMethodName(DetailAST methodDefNode) {
         String result = null;
-        for (DetailAST curNode : getChildren(methodDefNode)) {
-            if (curNode.getType() == TokenTypes.IDENT) {
-                result = curNode.getText();
-                break;
-            }
+        final DetailAST ident = methodDefNode.findFirstToken(TokenTypes.IDENT);
+
+        // lambdas don't have a name
+        if (ident != null && methodDefNode.getType() != TokenTypes.LAMBDA) {
+            result = ident.getText();
         }
+
         return result;
     }
 
@@ -394,23 +420,6 @@ public class ReturnCountExtendedCheck extends AbstractCheck {
     }
 
     /**
-     * Gets all the children which are one level below on the current DetailAST
-     * parent node.
-     * @param node
-     *        Current parent node.
-     * @return The list of children one level below on the current parent node.
-     */
-    private static List<DetailAST> getChildren(final DetailAST node) {
-        final List<DetailAST> result = new LinkedList<>();
-        DetailAST curNode = node.getFirstChild();
-        while (curNode != null) {
-            result.add(curNode);
-            curNode = curNode.getNextSibling();
-        }
-        return result;
-    }
-
-    /**
      * Matches string to given list of RegExp patterns.
      *
      * @param string
@@ -420,10 +429,16 @@ public class ReturnCountExtendedCheck extends AbstractCheck {
      * @return true if given string could be fully matched by one of given patterns, false otherwise
      */
     private static boolean matches(String string, Collection<String> patterns) {
+        String match = string;
+
+        if (match == null) {
+            match = "null";
+        }
+
         boolean result = false;
         if (!patterns.isEmpty()) {
             for (String pattern : patterns) {
-                if (string.matches(pattern)) {
+                if (match.matches(pattern)) {
                     result = true;
                     break;
                 }

--- a/sevntu-checks/src/main/resources/com/github/sevntu/checkstyle/checks/coding/messages.properties
+++ b/sevntu-checks/src/main/resources/com/github/sevntu/checkstyle/checks/coding/messages.properties
@@ -44,6 +44,7 @@ overridable.method.leads=Calling the method ''{0}'' in {1} body leads to the cal
 redundant.return.check=Redundant return.
 return.count.extended.method=Return count for ''{0}'' method is {1} (max allowed is {2}).
 return.count.extended.ctor=Return count for ''{0}'' constructor is {1} (max allowed is {2}).
+return.count.extended.lambda=Return count for the lambda is {0} (max allowed is {1}).
 single.break.or.continue.in.loops=Loops should not contain more than a single "break" or "continue" statement
 ternary.per.expression.count=More than {0} ternary operators in expression.
 unnecessary.paren.assign=Unnecessary parentheses around assignment right-hand side.

--- a/sevntu-checks/src/test/java/com/github/sevntu/checkstyle/checks/coding/ReturnCountExtendedCheckTest.java
+++ b/sevntu-checks/src/test/java/com/github/sevntu/checkstyle/checks/coding/ReturnCountExtendedCheckTest.java
@@ -20,6 +20,7 @@
 package com.github.sevntu.checkstyle.checks.coding;
 
 import static com.github.sevntu.checkstyle.checks.coding.ReturnCountExtendedCheck.MSG_KEY_CTOR;
+import static com.github.sevntu.checkstyle.checks.coding.ReturnCountExtendedCheck.MSG_KEY_LAMBDA;
 import static com.github.sevntu.checkstyle.checks.coding.ReturnCountExtendedCheck.MSG_KEY_METHOD;
 
 import org.junit.Test;
@@ -30,6 +31,20 @@ import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
 public class ReturnCountExtendedCheckTest extends BaseCheckTestSupport {
 
     private final DefaultConfiguration checkConfig = createCheckConfig(ReturnCountExtendedCheck.class);
+
+    @Test
+    public void testNullOnIgnoreMethodsNames() throws Exception {
+        checkConfig.addAttribute("maxReturnCount", "99");
+        checkConfig.addAttribute("ignoreMethodLinesCount", "99");
+        checkConfig.addAttribute("minIgnoreReturnDepth", "99");
+        checkConfig.addAttribute("ignoreEmptyReturns", "true");
+        checkConfig.addAttribute("topLinesToIgnoreCount", "99");
+        checkConfig.addAttribute("ignoreMethodsNames", null);
+
+        final String[] expected = {};
+
+        verify(checkConfig, getPath("InputReturnCountExtendedCheckMethods.java"), expected);
+    }
 
     @Test
     public void testMethodsMaxReturnLiteralsIsOne() throws Exception {
@@ -222,5 +237,40 @@ public class ReturnCountExtendedCheckTest extends BaseCheckTestSupport {
         };
 
         verify(checkConfig, getPath("InputReturnCountExtendedCheckMethods.java"), expected);
+    }
+
+    @Test
+    public void testAnonymousClass() throws Exception {
+        checkConfig.addAttribute("maxReturnCount", "1");
+        checkConfig.addAttribute("ignoreMethodLinesCount", "0");
+        checkConfig.addAttribute("minIgnoreReturnDepth", "99");
+        checkConfig.addAttribute("ignoreEmptyReturns", "false");
+        checkConfig.addAttribute("topLinesToIgnoreCount", "0");
+
+        final String[] expected = {
+            "14:16: " + getCheckMessage(MSG_KEY_METHOD, "method2", 2, 1),
+            "16:24: " + getCheckMessage(MSG_KEY_METHOD, "method2", 2, 1),
+        };
+
+        verify(checkConfig, getPath("InputReturnCountExtendedCheckAnonymousClasses.java"), expected);
+    }
+
+    @Test
+    public void testLambda() throws Exception {
+        checkConfig.addAttribute("maxReturnCount", "1");
+        checkConfig.addAttribute("ignoreMethodLinesCount", "0");
+        checkConfig.addAttribute("minIgnoreReturnDepth", "99");
+        checkConfig.addAttribute("ignoreEmptyReturns", "false");
+        checkConfig.addAttribute("topLinesToIgnoreCount", "0");
+
+        final String[] expected = {
+            "12:55: " + getCheckMessage(MSG_KEY_LAMBDA, 2, 1),
+            "24:49: " + getCheckMessage(MSG_KEY_LAMBDA, 2, 1),
+            "31:42: " + getCheckMessage(MSG_KEY_LAMBDA, 3, 1),
+            "38:9: " + getCheckMessage(MSG_KEY_METHOD, "methodWithTwoReturnWithLambdas", 2, 1),
+            "46:57: " + getCheckMessage(MSG_KEY_LAMBDA, 2, 1),
+        };
+
+        verify(checkConfig, getPath("InputReturnCountExtendedCheckLambdas.java"), expected);
     }
 }

--- a/sevntu-checks/src/test/resources/com/github/sevntu/checkstyle/checks/coding/InputReturnCountExtendedCheckAnonymousClasses.java
+++ b/sevntu-checks/src/test/resources/com/github/sevntu/checkstyle/checks/coding/InputReturnCountExtendedCheckAnonymousClasses.java
@@ -1,0 +1,29 @@
+package com.github.sevntu.checkstyle.checks.coding;
+
+public class InputReturnCountExtendedCheckAnonymousClasses {
+    public int method() {
+        class InnerClass {
+            public int method() {
+                return 1;
+            }
+        }
+
+        return 1;
+    }
+
+    public int method2() {
+        class InnerClass {
+            public int method2() {
+                if (false)
+                    return 0;
+
+                return 1;
+            }
+        }
+
+        if (false)
+            return 0;
+
+        return 1;
+    }
+}

--- a/sevntu-checks/src/test/resources/com/github/sevntu/checkstyle/checks/coding/InputReturnCountExtendedCheckLambdas.java
+++ b/sevntu-checks/src/test/resources/com/github/sevntu/checkstyle/checks/coding/InputReturnCountExtendedCheckLambdas.java
@@ -1,0 +1,60 @@
+package com.github.sevntu.checkstyle.checks.coding;
+
+import java.util.Optional;
+import java.util.concurrent.Callable;
+import java.util.function.Supplier;
+
+public class InputReturnCountExtendedCheckLambdas {
+    Runnable fieldWithOneReturnInLambda = () -> {
+        return;
+    };
+
+    Callable<Integer> fieldWithTwoReturnInLambda = () -> {
+        if (hashCode() == 0) return 0;
+        else return 1;
+    };
+
+    Optional<Integer> methodWithOneReturnInLambda() {
+        return Optional.of(hashCode()).filter(i -> {
+            return i > 0;
+        });
+    }
+
+    Optional<Integer> methodWithTwoReturnInLambda() {
+        return Optional.of(hashCode()).filter(i -> {
+            if (i > 0) return true;
+            else return false;
+        });
+    }
+
+    Optional<Object> methodWithThreeReturnInLambda(int number) {
+        return Optional.of(number).map(i -> {
+            if (i == 42) return true;
+            else if (i == 7) return true;
+            else return false;
+        });
+    }
+
+    int methodWithTwoReturnWithLambdas(final int number) {
+        if (hashCode() > 0) {
+            new Thread(
+                () -> {
+                }
+            ).start();
+            return number;
+        } else {
+            return Optional.of(hashCode()).orElseGet(() -> {
+                if (number > 0) return number;
+                else return 0;
+            });
+        }
+    }
+
+    Supplier<Supplier<Integer>> methodWithOneReturnPerLambda() {
+        return () -> {
+            return () -> {
+                return 1;
+            };
+        };
+    }
+}


### PR DESCRIPTION
Issue #463

Lambdas are now supported.
Also 100% code coverage. [Regression ](http://rveach.no-ip.org/checkstyle/regression/reports/120/) showed no NPEs.
````
<module name="ReturnCountExtendedCheck">
<property name="maxReturnCount" value="1"/>
<property name="ignoreMethodLinesCount" value="0"/>
<property name="minIgnoreReturnDepth" value="99"/>
<property name="ignoreEmptyReturns" value="false"/>
<property name="topLinesToIgnoreCount" value="0"/>
</module>
````

One thing to note, lambdas don't have a method name, so the violation message currently prints that as `null`. Should we drop that part of the message? Should we drop support for matching these patterns?