### PR TITLE
Issue #454: fixed NPE in ConfusingConditionCheck

### DIFF
--- a/sevntu-checks/src/test/java/com/github/sevntu/checkstyle/checks/coding/ConfusingConditionCheckTest.java
+++ b/sevntu-checks/src/test/java/com/github/sevntu/checkstyle/checks/coding/ConfusingConditionCheckTest.java
@@ -37,12 +37,6 @@ public class ConfusingConditionCheckTest extends BaseCheckTestSupport {
     public void testDefault() throws Exception {
         final DefaultConfiguration checkConfig = createCheckConfig(ConfusingConditionCheck.class);
 
-        checkConfig.addAttribute("ignoreInnerIf", "true");
-        checkConfig.addAttribute("ignoreNullCaseInIf", "true");
-        checkConfig.addAttribute("ignoreSequentialIf", "true");
-        checkConfig.addAttribute("ignoreThrowInElse", "true");
-        checkConfig.addAttribute("multiplyFactorForElseBlocks", "4");
-
         final String[] expected = {
             "10: " + warningMessage,
             "13: " + warningMessage,
@@ -59,6 +53,8 @@ public class ConfusingConditionCheckTest extends BaseCheckTestSupport {
             "200: " + warningMessage,
             "215: " + warningMessage,
             "231: " + warningMessage,
+            "250: " + warningMessage,
+            "259: " + warningMessage,
         };
 
         verify(checkConfig, getPath("InputConfusingConditionCheck.java"),
@@ -99,6 +95,10 @@ public class ConfusingConditionCheckTest extends BaseCheckTestSupport {
             "215: " + warningMessage,
             "227: " + warningMessage,
             "231: " + warningMessage,
+            "247: " + warningMessage,
+            "250: " + warningMessage,
+            "257: " + warningMessage,
+            "259: " + warningMessage,
         };
 
         verify(checkConfig, getPath("InputConfusingConditionCheck.java"),
@@ -121,9 +121,20 @@ public class ConfusingConditionCheckTest extends BaseCheckTestSupport {
             "108: " + warningMessage,
             "111: " + warningMessage,
             "177: " + warningMessage,
+            "259: " + warningMessage,
         };
 
         verify(checkConfig, getPath("InputConfusingConditionCheck.java"),
+                expected);
+    }
+
+    @Test
+    public void testExceptions() throws Exception {
+        final DefaultConfiguration checkConfig = createCheckConfig(ConfusingConditionCheck.class);
+
+        final String[] expected = {};
+
+        verify(checkConfig, getPath("InputConfusingConditionCheck2.java"),
                 expected);
     }
 }

--- a/sevntu-checks/src/test/resources/com/github/sevntu/checkstyle/checks/coding/InputConfusingConditionCheck.java
+++ b/sevntu-checks/src/test/resources/com/github/sevntu/checkstyle/checks/coding/InputConfusingConditionCheck.java
@@ -242,7 +242,24 @@ public class InputConfusingConditionCheck
         }
         else {
             a = true;
-        }       
+        }
+        
+        if (!a) {
+            //
+        }
+        else if (!b) {
+            a = true;
+        }
+        else {
+            //
+        }
+        
+        if (!a) 
+            ;
+        else if (!b) 
+            ;
+        else 
+            ;
         
     }
 }

--- a/sevntu-checks/src/test/resources/com/github/sevntu/checkstyle/checks/coding/InputConfusingConditionCheck2.java
+++ b/sevntu-checks/src/test/resources/com/github/sevntu/checkstyle/checks/coding/InputConfusingConditionCheck2.java
@@ -1,0 +1,17 @@
+package com.github.sevntu.checkstyle.checks.coding;
+
+public class InputConfusingConditionCheck2 {
+    class InnerEmptyBlocks {
+        void foo() {
+        }
+    }
+
+    InnerEmptyBlocks anon = new InnerEmptyBlocks() {
+        boolean flag = true;
+
+        void foo() {
+            if(flag);
+            else;
+        }
+    };
+}


### PR DESCRIPTION
Issue #454

Fixed NPE in `getAmounOfCodeRowsInBlock`.
Since the method is counting for `blocks` I set the return to 0 if there is no block. Please let me know if we should count lines even if there is no block.