### PR TITLE
Issue #520: 100% coverage for ForbidAnnotationCheck

### DIFF
--- a/sevntu-checks/pom.xml
+++ b/sevntu-checks/pom.xml
@@ -155,7 +155,6 @@
             <totalBranchRate>88</totalBranchRate>
             <totalLineRate>96</totalLineRate>
             <regexes>
-              <regex><pattern>.*.checks.annotation.ForbidAnnotationCheck</pattern><branchRate>70</branchRate><lineRate>96</lineRate></regex>
               <regex><pattern>.*.checks.coding.AvoidConstantAsFirstOperandInConditionCheck</pattern><branchRate>87</branchRate><lineRate>100</lineRate></regex>
               <regex><pattern>.*.checks.coding.ConfusingConditionCheck</pattern><branchRate>82</branchRate><lineRate>100</lineRate></regex>
               <regex><pattern>.*.checks.coding.CustomDeclarationOrderCheck.*</pattern><branchRate>81</branchRate><lineRate>83</lineRate></regex>

--- a/sevntu-checks/src/main/java/com/github/sevntu/checkstyle/checks/annotation/ForbidAnnotationCheck.java
+++ b/sevntu-checks/src/main/java/com/github/sevntu/checkstyle/checks/annotation/ForbidAnnotationCheck.java
@@ -130,8 +130,7 @@ public class ForbidAnnotationCheck extends AbstractCheck {
      * @return boolean
      */
     private boolean isRequiredAnnotationName(String annotationName) {
-        return annotationName != null
-                && annotationNames.contains(annotationName);
+        return annotationNames.contains(annotationName);
     }
 
     /**

--- a/sevntu-checks/src/test/java/com/github/sevntu/checkstyle/checks/annotation/ForbidAnnotationTest.java
+++ b/sevntu-checks/src/test/java/com/github/sevntu/checkstyle/checks/annotation/ForbidAnnotationTest.java
@@ -35,8 +35,31 @@ import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
 public class ForbidAnnotationTest extends BaseCheckTestSupport {
 
     @Test
+    public void testDefaultCheck() throws Exception {
+        final DefaultConfiguration checkConfig = createCheckConfig(ForbidAnnotationCheck.class);
+
+        final String[] expected1 = {};
+
+        verify(checkConfig, getPath("InputForbidAnnotation2.java"), expected1);
+    }
+
+    @Test
+    public void testNullProperties() throws Exception {
+        final DefaultConfiguration checkConfig = createCheckConfig(ForbidAnnotationCheck.class);
+
+        checkConfig.addAttribute("annotationNames", null);
+        checkConfig.addAttribute("annotationTargets", null);
+
+        final String[] expected1 = {};
+
+        verify(checkConfig, getPath("InputForbidAnnotation2.java"), expected1);
+    }
+
+    @Test
     public void testFullAnnotationName() throws Exception {
         final DefaultConfiguration checkConfig = createCheckConfig(ForbidAnnotationCheck.class);
+
+        checkConfig.addAttribute("annotationNames", "Test");
 
         final String[] expected1 = {};
 

--- a/sevntu-checks/src/test/resources/com/github/sevntu/checkstyle/checks/annotation/InputForbidAnnotation2.java
+++ b/sevntu-checks/src/test/resources/com/github/sevntu/checkstyle/checks/annotation/InputForbidAnnotation2.java
@@ -1,7 +1,7 @@
 package com.github.sevntu.checkstyle.checks.annotation;
-import java.awt.Component;
 
-public class InputForbidAnnotation2 extends Component {
-	private static final long serialVersionUID = 1L;
-
+public class InputForbidAnnotation2 {
+    @org.junit.Test
+    public void method() {
+    }
 }


### PR DESCRIPTION
Issue #520 

`InputForbidAnnotation2.java` was changed to bring back the spirit of what the test was about, which originally had a full classpath annotation in it. See https://github.com/sevntu-checkstyle/sevntu.checkstyle/issues/54#issue-7286166 .