### PR TITLE
Issue #520: 100% coverage for AvoidConstantAsFirstOperandInCondition

### DIFF
--- a/sevntu-checks/pom.xml
+++ b/sevntu-checks/pom.xml
@@ -155,7 +155,6 @@
             <totalBranchRate>88</totalBranchRate>
             <totalLineRate>96</totalLineRate>
             <regexes>
-              <regex><pattern>.*.checks.coding.AvoidConstantAsFirstOperandInConditionCheck</pattern><branchRate>87</branchRate><lineRate>100</lineRate></regex>
               <regex><pattern>.*.checks.coding.CustomDeclarationOrderCheck.*</pattern><branchRate>81</branchRate><lineRate>83</lineRate></regex>
               <regex><pattern>.*.checks.coding.DiamondOperatorForVariableDefinitionCheck</pattern><branchRate>90</branchRate><lineRate>100</lineRate></regex>
               <regex><pattern>.*.checks.coding.EitherLogOrThrowCheck</pattern><branchRate>88</branchRate><lineRate>99</lineRate></regex>

--- a/sevntu-checks/src/main/java/com/github/sevntu/checkstyle/checks/coding/AvoidConstantAsFirstOperandInConditionCheck.java
+++ b/sevntu-checks/src/main/java/com/github/sevntu/checkstyle/checks/coding/AvoidConstantAsFirstOperandInConditionCheck.java
@@ -117,7 +117,6 @@ public class AvoidConstantAsFirstOperandInConditionCheck extends AbstractCheck {
         final int constantType = firstOperand.getType();
 
         return isTargetConstantType(constantType)
-                && firstOperand.branchContains(constantType)
                 && !secondOperand.branchContains(constantType);
     }
 

--- a/sevntu-checks/src/test/java/com/github/sevntu/checkstyle/checks/coding/AvoidConstantAsFirstOperandInConditionCheckTest.java
+++ b/sevntu-checks/src/test/java/com/github/sevntu/checkstyle/checks/coding/AvoidConstantAsFirstOperandInConditionCheckTest.java
@@ -76,4 +76,44 @@ public class AvoidConstantAsFirstOperandInConditionCheckTest extends BaseCheckTe
         verify(checkConfig, getPath("InputAvoidConstantAsFirstOperandInConditionCheck.java"), expected);
 
     }
+
+    @Test
+    public void testNullProperties() throws Exception {
+        final DefaultConfiguration checkConfig = createCheckConfig(AvoidConstantAsFirstOperandInConditionCheck.class);
+
+        checkConfig.addAttribute("targetConstantTypes", null);
+
+        final String[] expected = {
+            "24: " + getCheckMessage(MSG_KEY, "=="),
+            "25: " + getCheckMessage(MSG_KEY, "=="),
+            "27: " + getCheckMessage(MSG_KEY, "=="),
+            "28: " + getCheckMessage(MSG_KEY, "=="),
+            "29: " + getCheckMessage(MSG_KEY, "=="),
+            "30: " + getCheckMessage(MSG_KEY, "=="),
+            "31: " + getCheckMessage(MSG_KEY, "=="),
+            "46: " + getCheckMessage(MSG_KEY, "=="),
+            "47: " + getCheckMessage(MSG_KEY, "!="),
+            "52: " + getCheckMessage(MSG_KEY, "=="),
+            "53: " + getCheckMessage(MSG_KEY, "!="),
+            "58: " + getCheckMessage(MSG_KEY, "=="),
+            "59: " + getCheckMessage(MSG_KEY, "!="),
+            "67: " + getCheckMessage(MSG_KEY, "=="),
+            "71: " + getCheckMessage(MSG_KEY, "=="),
+            "72: " + getCheckMessage(MSG_KEY, "=="),
+            "73: " + getCheckMessage(MSG_KEY, "=="),
+            "74: " + getCheckMessage(MSG_KEY, "=="),
+            "76: " + getCheckMessage(MSG_KEY, "=="),
+            "77: " + getCheckMessage(MSG_KEY, "=="),
+            "78: " + getCheckMessage(MSG_KEY, "=="),
+            "84: " + getCheckMessage(MSG_KEY, "=="),
+            "85: " + getCheckMessage(MSG_KEY, "=="),
+            "86: " + getCheckMessage(MSG_KEY, "=="),
+            "97: " + getCheckMessage(MSG_KEY, "=="),
+            "101: " + getCheckMessage(MSG_KEY, "=="),
+            "111: " + getCheckMessage(MSG_KEY, "=="),
+            "112: " + getCheckMessage(MSG_KEY, "=="),
+        };
+
+        verify(checkConfig, getPath("InputAvoidConstantAsFirstOperandInConditionCheck.java"), expected);
+    }
 }


### PR DESCRIPTION
Issue #520

`firstOperand.branchContains(constantType)` is removed because `constantType` gets its value from `firstOperand` at `final int constantType = firstOperand.getType();`, so it will always return true.

Regression showed no differences. http://rveach.no-ip.org/checkstyle/regression/reports/131/