### PR TITLE
Issue #520: 100% coverage for ConfusingConditionCheck

### DIFF
--- a/sevntu-checks/pom.xml
+++ b/sevntu-checks/pom.xml
@@ -157,7 +157,6 @@
             <regexes>
               <regex><pattern>.*.checks.annotation.ForbidAnnotationCheck</pattern><branchRate>70</branchRate><lineRate>96</lineRate></regex>
               <regex><pattern>.*.checks.coding.AvoidConstantAsFirstOperandInConditionCheck</pattern><branchRate>87</branchRate><lineRate>100</lineRate></regex>
-              <regex><pattern>.*.checks.coding.ConfusingConditionCheck</pattern><branchRate>82</branchRate><lineRate>100</lineRate></regex>
               <regex><pattern>.*.checks.coding.CustomDeclarationOrderCheck.*</pattern><branchRate>81</branchRate><lineRate>83</lineRate></regex>
               <regex><pattern>.*.checks.coding.DiamondOperatorForVariableDefinitionCheck</pattern><branchRate>90</branchRate><lineRate>100</lineRate></regex>
               <regex><pattern>.*.checks.coding.EitherLogOrThrowCheck</pattern><branchRate>88</branchRate><lineRate>99</lineRate></regex>

--- a/sevntu-checks/src/main/java/com/github/sevntu/checkstyle/checks/coding/ConfusingConditionCheck.java
+++ b/sevntu-checks/src/main/java/com/github/sevntu/checkstyle/checks/coding/ConfusingConditionCheck.java
@@ -250,7 +250,7 @@ public class ConfusingConditionCheck extends AbstractCheck {
         if (detailAST.getType() == TokenTypes.LITERAL_ELSE) {
             firstBrace = detailAST.getFirstChild();
         }
-        else if (detailAST.getType() == TokenTypes.LITERAL_IF) {
+        else {
             firstBrace = detailAST.getFirstChild().getNextSibling()
                     .getNextSibling().getNextSibling();
         }

--- a/sevntu-checks/src/test/java/com/github/sevntu/checkstyle/checks/coding/ConfusingConditionCheckTest.java
+++ b/sevntu-checks/src/test/java/com/github/sevntu/checkstyle/checks/coding/ConfusingConditionCheckTest.java
@@ -33,10 +33,10 @@ public class ConfusingConditionCheckTest extends BaseCheckTestSupport {
 
     private final String warningMessage = getCheckMessage(MSG_KEY);
 
-    private final DefaultConfiguration checkConfig = createCheckConfig(ConfusingConditionCheck.class);
-
     @Test
     public void testDefault() throws Exception {
+        final DefaultConfiguration checkConfig = createCheckConfig(ConfusingConditionCheck.class);
+
         checkConfig.addAttribute("ignoreInnerIf", "true");
         checkConfig.addAttribute("ignoreNullCaseInIf", "true");
         checkConfig.addAttribute("ignoreSequentialIf", "true");
@@ -59,6 +59,68 @@ public class ConfusingConditionCheckTest extends BaseCheckTestSupport {
             "200: " + warningMessage,
             "215: " + warningMessage,
             "231: " + warningMessage,
+        };
+
+        verify(checkConfig, getPath("InputConfusingConditionCheck.java"),
+                expected);
+    }
+
+    @Test
+    public void testFalseProperties() throws Exception {
+        final DefaultConfiguration checkConfig = createCheckConfig(ConfusingConditionCheck.class);
+
+        checkConfig.addAttribute("ignoreInnerIf", "false");
+        checkConfig.addAttribute("ignoreNullCaseInIf", "false");
+        checkConfig.addAttribute("ignoreSequentialIf", "false");
+        checkConfig.addAttribute("ignoreThrowInElse", "false");
+
+        final String[] expected = {
+            "10: " + warningMessage,
+            "13: " + warningMessage,
+            "16: " + warningMessage,
+            "19: " + warningMessage,
+            "22: " + warningMessage,
+            "105: " + warningMessage,
+            "108: " + warningMessage,
+            "111: " + warningMessage,
+            "127: " + warningMessage,
+            "134: " + warningMessage,
+            "138: " + warningMessage,
+            "145: " + warningMessage,
+            "149: " + warningMessage,
+            "157: " + warningMessage,
+            "160: " + warningMessage,
+            "162: " + warningMessage,
+            "166: " + warningMessage,
+            "177: " + warningMessage,
+            "181: " + warningMessage,
+            "199: " + warningMessage,
+            "200: " + warningMessage,
+            "215: " + warningMessage,
+            "227: " + warningMessage,
+            "231: " + warningMessage,
+        };
+
+        verify(checkConfig, getPath("InputConfusingConditionCheck.java"),
+                expected);
+    }
+
+    @Test
+    public void testMultiplyFactor() throws Exception {
+        final DefaultConfiguration checkConfig = createCheckConfig(ConfusingConditionCheck.class);
+
+        checkConfig.addAttribute("multiplyFactorForElseBlocks", "0");
+
+        final String[] expected = {
+            "10: " + warningMessage,
+            "13: " + warningMessage,
+            "16: " + warningMessage,
+            "19: " + warningMessage,
+            "22: " + warningMessage,
+            "105: " + warningMessage,
+            "108: " + warningMessage,
+            "111: " + warningMessage,
+            "177: " + warningMessage,
         };
 
         verify(checkConfig, getPath("InputConfusingConditionCheck.java"),


### PR DESCRIPTION
Issue #520 

`else if (detailAST.getType() == TokenTypes.LITERAL_IF) {` was removed because we are only looking at 2 types of tokens, `if` and `else`. If it isn't one, it must be the other.