### PR TITLE
Issue #520: 100% coverage for UnnecessaryParenthesesExtendedCheck

### DIFF
--- a/sevntu-checks/pom.xml
+++ b/sevntu-checks/pom.xml
@@ -173,7 +173,6 @@
               <regex><pattern>.*.checks.coding.ReturnBooleanFromTernaryCheck</pattern><branchRate>75</branchRate><lineRate>100</lineRate></regex>
               <regex><pattern>.*.checks.coding.ReturnNullInsteadOfBooleanCheck</pattern><branchRate>80</branchRate><lineRate>88</lineRate></regex>
               <regex><pattern>.*.checks.coding.SimpleAccessorNameNotationCheck</pattern><branchRate>72</branchRate><lineRate>100</lineRate></regex>
-              <regex><pattern>.*.checks.coding.UnnecessaryParenthesesExtendedCheck</pattern><branchRate>90</branchRate><lineRate>100</lineRate></regex>
               <regex><pattern>.*.checks.design.AvoidConditionInversionCheck</pattern><branchRate>97</branchRate><lineRate>96</lineRate></regex>
               <regex><pattern>.*.checks.design.CauseParameterInExceptionCheck</pattern><branchRate>96</branchRate><lineRate>98</lineRate></regex>
               <regex><pattern>.*.checks.design.ChildBlockLengthCheck</pattern><branchRate>89</branchRate><lineRate>100</lineRate></regex>

--- a/sevntu-checks/src/main/java/com/github/sevntu/checkstyle/checks/coding/UnnecessaryParenthesesExtendedCheck.java
+++ b/sevntu-checks/src/main/java/com/github/sevntu/checkstyle/checks/coding/UnnecessaryParenthesesExtendedCheck.java
@@ -19,7 +19,6 @@
 
 package com.github.sevntu.checkstyle.checks.coding;
 
-import antlr.collections.AST;
 import com.puppycrawl.tools.checkstyle.api.AbstractCheck;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
 import com.puppycrawl.tools.checkstyle.api.TokenTypes;
@@ -271,8 +270,7 @@ public class UnnecessaryParenthesesExtendedCheck extends AbstractCheck {
         final DetailAST next = ast.getNextSibling();
 
         return (prev != null) && (next != null)
-            && (prev.getType() == TokenTypes.LPAREN)
-            && (next.getType() == TokenTypes.RPAREN);
+            && (prev.getType() == TokenTypes.LPAREN);
     }
 
     /**
@@ -285,15 +283,7 @@ public class UnnecessaryParenthesesExtendedCheck extends AbstractCheck {
      *         equal to <code>TokenTypes.EXPR</code>.
      */
     private static boolean exprSurrounded(DetailAST ast) {
-        boolean surrounded = false;
-        if (ast.getChildCount() >= MIN_CHILDREN_FOR_MATCH) {
-            final AST n1 = ast.getFirstChild();
-            final AST nn = ast.getLastChild();
-
-            surrounded = (n1.getType() == TokenTypes.LPAREN)
-                && (nn.getType() == TokenTypes.RPAREN);
-        }
-        return surrounded;
+        return ast.getChildCount() >= MIN_CHILDREN_FOR_MATCH;
     }
 
     /**

--- a/sevntu-checks/src/test/java/com/github/sevntu/checkstyle/checks/coding/UnnecessaryParenthesesExtendedCheckTest.java
+++ b/sevntu-checks/src/test/java/com/github/sevntu/checkstyle/checks/coding/UnnecessaryParenthesesExtendedCheckTest.java
@@ -156,6 +156,7 @@ public class UnnecessaryParenthesesExtendedCheckTest extends BaseCheckTestSuppor
             "82:27: " + getCheckMessage(MSG_KEY_ASSIGN),
             "96:19: " + getCheckMessage(MSG_KEY_ASSIGN),
             "100:24: " + getCheckMessage(MSG_KEY_EXPR),
+            "123:27: " + getCheckMessage(MSG_KEY_IDENT, "i"),
         };
         checkConfig.addAttribute("ignoreCalculationOfBooleanVariables", "true");
         checkConfig.addAttribute("ignoreCalculationOfBooleanVariablesWithReturn", "true");

--- a/sevntu-checks/src/test/resources/com/github/sevntu/checkstyle/checks/coding/InputUnnecessaryParenthesesUbv.java
+++ b/sevntu-checks/src/test/resources/com/github/sevntu/checkstyle/checks/coding/InputUnnecessaryParenthesesUbv.java
@@ -119,6 +119,10 @@ public class InputUnnecessaryParenthesesUbv {
 			return (flag != b);
 		}
 	}
+    void f8() {
+        for (int i = 1; ((i) == (6+6)); i += 1) {
+        }
+    }
     
     
     


### PR DESCRIPTION
Issue #520

I was able to achieve coverage for one spot, but the other 2 I couldn't achieve. Regression showed no differences when removed. http://rveach.no-ip.org/checkstyle/regression/reports/139/

` && (next.getType() == TokenTypes.RPAREN);` is not reachable because when we have the open parenthesis, we are guaranteed to have the close one.
I believe the same is true for `exprSurrounded` and we are already checking if they are surrounded else where.