### PR TITLE
Issue #520: 100% coverage for NoMainMethodInAbstractClassCheck

### DIFF
--- a/sevntu-checks/pom.xml
+++ b/sevntu-checks/pom.xml
@@ -176,7 +176,6 @@
               <regex><pattern>.*.checks.design.ForbidWildcardAsReturnTypeCheck</pattern><branchRate>98</branchRate><lineRate>100</lineRate></regex>
               <regex><pattern>.*.checks.design.HideUtilityClassConstructorCheck</pattern><branchRate>94</branchRate><lineRate>100</lineRate></regex>
               <regex><pattern>.*.checks.design.InnerClassCheck</pattern><branchRate>91</branchRate><lineRate>100</lineRate></regex>
-              <regex><pattern>.*.checks.design.NoMainMethodInAbstractClassCheck</pattern><branchRate>92</branchRate><lineRate>98</lineRate></regex>
               <regex><pattern>.*.checks.naming.EnumValueNameCheck</pattern><branchRate>86</branchRate><lineRate>100</lineRate></regex>
             </regexes>
           </check>

--- a/sevntu-checks/src/main/java/com/github/sevntu/checkstyle/checks/design/NoMainMethodInAbstractClassCheck.java
+++ b/sevntu-checks/src/main/java/com/github/sevntu/checkstyle/checks/design/NoMainMethodInAbstractClassCheck.java
@@ -110,13 +110,9 @@ public class NoMainMethodInAbstractClassCheck extends AbstractCheck {
      * @return true if AST has abstract modifier, false otherwise.
      */
     private static boolean hasAbstractModifier(final DetailAST classDefAST) {
-        boolean result = false;
-        if (hasChildToken(classDefAST, TokenTypes.MODIFIERS)) {
-            final DetailAST modifiers =
-                    classDefAST.findFirstToken(TokenTypes.MODIFIERS);
-            result = hasChildToken(modifiers, TokenTypes.ABSTRACT);
-        }
-        return result;
+        final DetailAST modifiers =
+                classDefAST.findFirstToken(TokenTypes.MODIFIERS);
+        return hasChildToken(modifiers, TokenTypes.ABSTRACT);
     }
 
     /**
@@ -148,10 +144,7 @@ public class NoMainMethodInAbstractClassCheck extends AbstractCheck {
      */
     private static String getIdentifier(final DetailAST ast) {
         final DetailAST ident = ast.findFirstToken(TokenTypes.IDENT);
-        if (ident != null) {
-            return ident.getText();
-        }
-        return null;
+        return ident.getText();
     }
 
     /**
@@ -162,14 +155,10 @@ public class NoMainMethodInAbstractClassCheck extends AbstractCheck {
      *         false otherwise.
      */
     private static boolean isMainMethodModifiers(final DetailAST methodAST) {
-        boolean result = false;
-        if (hasChildToken(methodAST, TokenTypes.MODIFIERS)) {
-            final DetailAST modifiers =
-                    methodAST.findFirstToken(TokenTypes.MODIFIERS);
-            result = hasChildToken(modifiers, TokenTypes.LITERAL_PUBLIC)
-                    && hasChildToken(modifiers, TokenTypes.LITERAL_STATIC);
-        }
-        return result;
+        final DetailAST modifiers =
+                methodAST.findFirstToken(TokenTypes.MODIFIERS);
+        return hasChildToken(modifiers, TokenTypes.LITERAL_PUBLIC)
+                && hasChildToken(modifiers, TokenTypes.LITERAL_STATIC);
     }
 
     /**
@@ -179,13 +168,8 @@ public class NoMainMethodInAbstractClassCheck extends AbstractCheck {
      * @return true if AST's type void, false otherwise.
      */
     private static boolean isVoidType(final DetailAST methodAST) {
-        boolean result = true;
-        DetailAST methodTypeAST = null;
-        if (hasChildToken(methodAST, TokenTypes.TYPE)) {
-            methodTypeAST = methodAST.findFirstToken(TokenTypes.TYPE);
-            result = hasChildToken(methodTypeAST, TokenTypes.LITERAL_VOID);
-        }
-        return result;
+        final DetailAST methodTypeAST = methodAST.findFirstToken(TokenTypes.TYPE);
+        return hasChildToken(methodTypeAST, TokenTypes.LITERAL_VOID);
     }
 
     /**


### PR DESCRIPTION
Issue #520 

Regression: http://rveach.no-ip.org/checkstyle/regression/reports/140/
No differences reported.

All removals are null protections that I couldn't hit.
`hasAbstractModifier` and `isMainMethodModifiers` always has modifiers.
`getIdentifier` cases that hit it always have the identifier as this is only checking abstract classes.
`isVoidType` methods always have a type.