### PR TITLE
Issue #520: 100% coverage for ForbidWildcardAsReturnTypeCheck

### DIFF
--- a/sevntu-checks/pom.xml
+++ b/sevntu-checks/pom.xml
@@ -173,7 +173,6 @@
               <regex><pattern>.*.checks.coding.ReturnNullInsteadOfBooleanCheck</pattern><branchRate>80</branchRate><lineRate>88</lineRate></regex>
               <regex><pattern>.*.checks.coding.SimpleAccessorNameNotationCheck</pattern><branchRate>72</branchRate><lineRate>100</lineRate></regex>
               <regex><pattern>.*.checks.design.ChildBlockLengthCheck</pattern><branchRate>89</branchRate><lineRate>100</lineRate></regex>
-              <regex><pattern>.*.checks.design.ForbidWildcardAsReturnTypeCheck</pattern><branchRate>98</branchRate><lineRate>100</lineRate></regex>
               <regex><pattern>.*.checks.design.HideUtilityClassConstructorCheck</pattern><branchRate>94</branchRate><lineRate>100</lineRate></regex>
               <regex><pattern>.*.checks.design.InnerClassCheck</pattern><branchRate>91</branchRate><lineRate>100</lineRate></regex>
               <regex><pattern>.*.checks.design.NoMainMethodInAbstractClassCheck</pattern><branchRate>92</branchRate><lineRate>98</lineRate></regex>

--- a/sevntu-checks/src/main/java/com/github/sevntu/checkstyle/checks/design/ForbidWildcardAsReturnTypeCheck.java
+++ b/sevntu-checks/src/main/java/com/github/sevntu/checkstyle/checks/design/ForbidWildcardAsReturnTypeCheck.java
@@ -266,11 +266,8 @@ public class ForbidWildcardAsReturnTypeCheck extends AbstractCheck {
      * @return identifier of aAST, null if AST does not have identifier.
      */
     private static String getIdentifier(final DetailAST ast) {
-        String result = null;
         final DetailAST identifier = ast.findFirstToken(TokenTypes.IDENT);
-        if (identifier != null) {
-            result = identifier.getText();
-        }
+        final String result = identifier.getText();
         return result;
     }
 


### PR DESCRIPTION
Issue #520

Identifiers and annotations always have an identifier, so code was removed.