### PR TITLE
Issue #520: 100% coverage for IllegalCatchExtendedCheck

### DIFF
--- a/sevntu-checks/pom.xml
+++ b/sevntu-checks/pom.xml
@@ -159,7 +159,6 @@
               <regex><pattern>.*.checks.coding.EitherLogOrThrowCheck</pattern><branchRate>88</branchRate><lineRate>99</lineRate></regex>
               <regex><pattern>.*.checks.coding.ForbidCertainImportsCheck</pattern><branchRate>61</branchRate><lineRate>84</lineRate></regex>
               <regex><pattern>.*.checks.coding.ForbidThrowAnonymousExceptionsCheck</pattern><branchRate>81</branchRate><lineRate>97</lineRate></regex>
-              <regex><pattern>.*.checks.coding.IllegalCatchExtendedCheck</pattern><branchRate>88</branchRate><lineRate>97</lineRate></regex>
               <regex><pattern>.*.checks.coding.MapIterationInForEachLoopCheck</pattern><branchRate>90</branchRate><lineRate>98</lineRate></regex>
               <regex><pattern>.*.checks.coding.MultipleStringLiteralsExtendedCheck</pattern><branchRate>92</branchRate><lineRate>96</lineRate></regex>
               <regex><pattern>.*.checks.coding.MultipleVariableDeclarationsExtendedCheck</pattern><branchRate>95</branchRate><lineRate>100</lineRate></regex>

--- a/sevntu-checks/src/main/java/com/github/sevntu/checkstyle/checks/coding/IllegalCatchExtendedCheck.java
+++ b/sevntu-checks/src/main/java/com/github/sevntu/checkstyle/checks/coding/IllegalCatchExtendedCheck.java
@@ -107,10 +107,7 @@ public final class IllegalCatchExtendedCheck extends AbstractIllegalCheck {
         // For warnings disable first lvl child must be an EXPR and
         // second lvl child must be IDENT or LITERAL_NEW with
         // appropriate boolean flags.
-        final boolean noWarning = throwAST != null
-                && firstLvlChild != null
-                && secondLvlChild != null
-             && firstLvlChild.getType() == TokenTypes.EXPR
+        final boolean noWarning = secondLvlChild != null
              && ((allowThrow && secondLvlChild.getType() == TokenTypes.IDENT)
              || (allowRethrow && secondLvlChild.getType() == TokenTypes.LITERAL_NEW));
 


### PR DESCRIPTION
Issue #520 
Couldn't satisfy the missing coverage. There is already null protections above, so it could be related to that.
Regression: http://rveach.no-ip.org/checkstyle/regression/reports/148/
No differences.