### PR TITLE
Issue #520: 100% coverage for ChildBlockLengthCheck

### DIFF
--- a/sevntu-checks/pom.xml
+++ b/sevntu-checks/pom.xml
@@ -160,7 +160,6 @@
               <regex><pattern>.*.checks.coding.MapIterationInForEachLoopCheck</pattern><branchRate>90</branchRate><lineRate>98</lineRate></regex>
               <regex><pattern>.*.checks.coding.NoNullForCollectionReturnCheck</pattern><branchRate>85</branchRate><lineRate>96</lineRate></regex>
               <regex><pattern>.*.checks.coding.OverridableMethodInConstructorCheck</pattern><branchRate>88</branchRate><lineRate>99</lineRate></regex>
-              <regex><pattern>.*.checks.design.ChildBlockLengthCheck</pattern><branchRate>89</branchRate><lineRate>100</lineRate></regex>
               <regex><pattern>.*.checks.design.HideUtilityClassConstructorCheck</pattern><branchRate>94</branchRate><lineRate>100</lineRate></regex>
               <regex><pattern>.*.checks.naming.EnumValueNameCheck</pattern><branchRate>86</branchRate><lineRate>100</lineRate></regex>
             </regexes>

--- a/sevntu-checks/src/main/java/com/github/sevntu/checkstyle/checks/design/ChildBlockLengthCheck.java
+++ b/sevntu-checks/src/main/java/com/github/sevntu/checkstyle/checks/design/ChildBlockLengthCheck.java
@@ -186,16 +186,9 @@ public class ChildBlockLengthCheck extends AbstractCheck {
 
         DetailAST curNode = blockOpeningBrace;
 
-        while (curNode != null) {
-            // before node visiting
-            if (curNode == blockClosingBrace) {
-                // stop at closing brace
-                break;
-            }
-            else {
-                if (isAllowedBlockType(curNode.getType())) {
-                    childBlocks.add(curNode);
-                }
+        while (curNode != blockClosingBrace) {
+            if (isAllowedBlockType(curNode.getType())) {
+                childBlocks.add(curNode);
             }
             // before node leaving
             DetailAST nextNode = curNode.getFirstChild();
@@ -207,7 +200,7 @@ public class ChildBlockLengthCheck extends AbstractCheck {
                 nextNode = curNode.getNextSibling();
             }
 
-            while ((curNode != null) && (nextNode == null)) {
+            while (nextNode == null) {
                 // leave the visited node
                 nextNode = curNode.getNextSibling();
                 if (nextNode == null) {

--- a/sevntu-checks/src/test/resources/com/github/sevntu/checkstyle/checks/design/InputChildBlockLengthCheck.java
+++ b/sevntu-checks/src/test/resources/com/github/sevntu/checkstyle/checks/design/InputChildBlockLengthCheck.java
@@ -14,7 +14,7 @@ public class InputChildBlockLengthCheck {
           if (isTrue()) { // 2: simple if with braces
               number = 2;
           }
-                    
+
           if (isTrue()) { // 3: if-else     
               number = 3; 
           } else {
@@ -57,8 +57,17 @@ public class InputChildBlockLengthCheck {
           default:
               number = 15;
               break;          
-          }        
+          }
 
+          try {
+          } 
+          catch (Exception e) {
+          }
+          finally
+          {
+          }
+
+          if (isTrue()) {}
         }
 
     }

--- a/sevntu-checks/src/test/resources/com/github/sevntu/checkstyle/checks/design/InputChildBlockLengthCheckDoubleNested.java
+++ b/sevntu-checks/src/test/resources/com/github/sevntu/checkstyle/checks/design/InputChildBlockLengthCheckDoubleNested.java
@@ -49,4 +49,13 @@ public class InputChildBlockLengthCheckDoubleNested {
       }
     }
   }
+
+  public void inClass(int type) {
+    switch (type) {
+    case 3:
+      new Object() {
+        public void anonymousMethod() {}
+      };
+    }
+  }
 }

--- a/sevntu-checks/src/test/resources/com/github/sevntu/checkstyle/checks/design/InputChildBlockLengthCheckManyBlocksOnOneScope.java
+++ b/sevntu-checks/src/test/resources/com/github/sevntu/checkstyle/checks/design/InputChildBlockLengthCheckManyBlocksOnOneScope.java
@@ -42,6 +42,17 @@ public class InputChildBlockLengthCheckManyBlocksOnOneScope {
 
     }
 
+    public void test() {
+        int number;
+
+        if (isTrue()) {
+            if (isTrue())
+                number = 3;
+            else
+                number = 3;
+        }
+    }
+
     public static boolean isTrue() {
         return Boolean.TRUE;
     }


### PR DESCRIPTION
Issue #520 
Added tests for some cases I found in regression.

`while (curNode != null) {` and `while ((curNode != null) && `
They can't be `null` because we are in a block and are guaranteed some type of end.

Regression: http://rveach.no-ip.org/checkstyle/regression/reports/150/
No differences.