### PR TITLE
Issue #520: 100% coverage for SimpleAccessorNameNotationCheck

### DIFF
--- a/sevntu-checks/pom.xml
+++ b/sevntu-checks/pom.xml
@@ -164,7 +164,6 @@
               <regex><pattern>.*.checks.coding.NameConventionForJunit4TestClassesCheck</pattern><branchRate>86</branchRate><lineRate>96</lineRate></regex>
               <regex><pattern>.*.checks.coding.NoNullForCollectionReturnCheck</pattern><branchRate>85</branchRate><lineRate>96</lineRate></regex>
               <regex><pattern>.*.checks.coding.OverridableMethodInConstructorCheck</pattern><branchRate>88</branchRate><lineRate>99</lineRate></regex>
-              <regex><pattern>.*.checks.coding.SimpleAccessorNameNotationCheck</pattern><branchRate>72</branchRate><lineRate>100</lineRate></regex>
               <regex><pattern>.*.checks.design.ChildBlockLengthCheck</pattern><branchRate>89</branchRate><lineRate>100</lineRate></regex>
               <regex><pattern>.*.checks.design.HideUtilityClassConstructorCheck</pattern><branchRate>94</branchRate><lineRate>100</lineRate></regex>
               <regex><pattern>.*.checks.naming.EnumValueNameCheck</pattern><branchRate>86</branchRate><lineRate>100</lineRate></regex>

--- a/sevntu-checks/src/main/java/com/github/sevntu/checkstyle/checks/coding/SimpleAccessorNameNotationCheck.java
+++ b/sevntu-checks/src/main/java/com/github/sevntu/checkstyle/checks/coding/SimpleAccessorNameNotationCheck.java
@@ -134,8 +134,8 @@ public class SimpleAccessorNameNotationCheck extends AbstractCheck {
             if (containsOnlyExpression(currentVerifiedTop)) {
 
                 currentVerifiedTop = currentVerifiedTop.getFirstChild();
-                final boolean containsOnlyOneAssignment = currentVerifiedTop.getChildCount() == 1
-                        && currentVerifiedTop.getFirstChild().getType() == TokenTypes.ASSIGN;
+                final boolean containsOnlyOneAssignment = currentVerifiedTop.getFirstChild()
+                        .getType() == TokenTypes.ASSIGN;
                 if (containsOnlyOneAssignment) {
 
                     currentVerifiedTop = currentVerifiedTop.getFirstChild();
@@ -207,8 +207,7 @@ public class SimpleAccessorNameNotationCheck extends AbstractCheck {
     private static boolean containsOnlyExpression(DetailAST objectBlock) {
         //three child: EXPR, SEMI and RCURLY
         return objectBlock.getChildCount() == EXPRESSION_BLOCK_CHILD_COUNT
-                && objectBlock.getFirstChild().getType() == TokenTypes.EXPR
-                && objectBlock.findFirstToken(TokenTypes.SEMI) != null;
+                && objectBlock.getFirstChild().getType() == TokenTypes.EXPR;
     }
 
     /**
@@ -242,10 +241,7 @@ public class SimpleAccessorNameNotationCheck extends AbstractCheck {
             else {
                 if (assigningFirstChild.getType() == TokenTypes.DOT) {
 
-                    if (assigningFirstChild.getChildCount() == 2
-                            && "this".equals(assigningFirstChild
-                                    .getFirstChild().getText())
-                            && assigningFirstChild.getLastChild().getType() == TokenTypes.IDENT) {
+                    if ("this".equals(assigningFirstChild.getFirstChild().getText())) {
 
                         nameOfSettingField = assigningFirstChild.getLastChild()
                                 .getText();
@@ -298,8 +294,7 @@ public class SimpleAccessorNameNotationCheck extends AbstractCheck {
     private static boolean isCorrectReturn(DetailAST literalReturn) {
         //two child: EXPR and SEMI
         return literalReturn.getChildCount() == 2
-                && literalReturn.getFirstChild().getType() == TokenTypes.EXPR
-                && literalReturn.getLastChild().getType() == TokenTypes.SEMI;
+                && literalReturn.getFirstChild().getType() == TokenTypes.EXPR;
     }
 
     /**
@@ -324,8 +319,7 @@ public class SimpleAccessorNameNotationCheck extends AbstractCheck {
             else {
                 if (exprFirstChild.getType() == TokenTypes.DOT
                         && exprFirstChild.getChildCount() == 2
-                        && exprFirstChild.getFirstChild().getType() == TokenTypes.LITERAL_THIS
-                        && exprFirstChild.getLastChild().getType() == TokenTypes.IDENT) {
+                        && exprFirstChild.getFirstChild().getType() == TokenTypes.LITERAL_THIS) {
 
                     nameOfGettingField = exprFirstChild.getLastChild().getText();
                 }

--- a/sevntu-checks/src/test/resources/com/github/sevntu/checkstyle/checks/coding/InputSimpleAccessorNameNotation.java
+++ b/sevntu-checks/src/test/resources/com/github/sevntu/checkstyle/checks/coding/InputSimpleAccessorNameNotation.java
@@ -31,4 +31,57 @@ public class InputSimpleAccessorNameNotation {
 	public void setFirst(int mFirst){
 		this.mFirst = mFirst;
 	}
+    public int setFirstAgain(int mFirst){
+        this.mFirst = mFirst;
+        return mFirst;
+    }
+    public void setTest(int mFirst){
+    }
+    public void setTest2(int mFirst){
+        setTest(mFirst);
+    }
+    private java.util.List<String> names;
+    public void setNames(String[] names) {
+        this.names = java.util.Arrays.asList(names);
+    }
+    public void setNamesTwo(String[] names) {
+        if (names == null)
+            this.names = null;
+        if (names != null)
+            this.names = null;
+    }
+    boolean isExpiredToken() {
+        return ((System.currentTimeMillis() - 0) >= 0);
+    }
+    public static boolean isTrue() {
+        return Boolean.TRUE;
+    }
+    private int colors[];
+    private void setColor(int color) {
+        colors[0] = color;
+    }
+    private Object object;
+    public void setInvocation(Object invocation) {
+        this.object = ((Object)invocation);
+    }
+    public void setObject(Object object, Object ignore) {
+        object = object;
+    }
+    public static <T> java.util.function.BinaryOperator<T> getTest() {
+        return (t1, t2) -> {
+            throw new IllegalStateException();
+        };
+    }
+    int getTest2() {
+        return ((java.util.Hashtable[]) object).length;
+    }
+    private static Object sfield;
+    public void setTest3(int test) throws Exception {
+        InputSimpleAccessorNameNotation.sfield = sfield;
+    }
+}
+interface InnerIterface {
+    default void getFoo() {
+        return;
+    }
 }


### PR DESCRIPTION
Issue #520

Regression: http://rveach.no-ip.org/checkstyle/regression/reports/159/

Regression for this check is almost useless because we are looking for methods with specific names. I had to disable those checks to get better results and I still couldn't appease some of the coverage spots.
I did however manage to add a lot more tests than was before.