### PR TITLE
Issue #520 and #552 on ForbidCertainImportsCheck

### DIFF
--- a/sevntu-checks/pom.xml
+++ b/sevntu-checks/pom.xml
@@ -157,7 +157,6 @@
             <regexes>
               <regex><pattern>.*.checks.coding.CustomDeclarationOrderCheck.*</pattern><branchRate>81</branchRate><lineRate>83</lineRate></regex>
               <regex><pattern>.*.checks.coding.EitherLogOrThrowCheck</pattern><branchRate>88</branchRate><lineRate>99</lineRate></regex>
-              <regex><pattern>.*.checks.coding.ForbidCertainImportsCheck</pattern><branchRate>61</branchRate><lineRate>84</lineRate></regex>
               <regex><pattern>.*.checks.coding.ForbidThrowAnonymousExceptionsCheck</pattern><branchRate>81</branchRate><lineRate>97</lineRate></regex>
               <regex><pattern>.*.checks.coding.MapIterationInForEachLoopCheck</pattern><branchRate>90</branchRate><lineRate>98</lineRate></regex>
               <regex><pattern>.*.checks.coding.NoNullForCollectionReturnCheck</pattern><branchRate>85</branchRate><lineRate>96</lineRate></regex>

--- a/sevntu-checks/src/test/resources/com/github/sevntu/checkstyle/checks/coding/InputForbidCertainImportsSinglePackage.java
+++ b/sevntu-checks/src/test/resources/com/github/sevntu/checkstyle/checks/coding/InputForbidCertainImportsSinglePackage.java
@@ -1,0 +1,13 @@
+package sevntu;
+
+import com.puppycrawl.tools.checkstyle.api.AutomaticBean; // forbidden
+
+public class InputForbidCertainImportsSinglePackage
+{
+    public int a()
+    {
+        
+        AutomaticBean smth = new com.puppycrawl.tools.checkstyle.api.AutomaticBean(); // forbidden!
+        return 5;
+    }
+}

--- a/sevntu-checks/src/test/resources/com/github/sevntu/checkstyle/checks/coding/InputForbidsCertainImports.java
+++ b/sevntu-checks/src/test/resources/com/github/sevntu/checkstyle/checks/coding/InputForbidsCertainImports.java
@@ -19,6 +19,7 @@ public class InputForbidsCertainImports extends Check
     {
         
         AutomaticBean smth = new com.puppycrawl.tools.checkstyle.api.AutomaticBean(); // forbidden!
+        Number test = new Integer(0);
         return 5;
     }
 


### PR DESCRIPTION
Issue #520 and #552

Coverage is now 100%. Added some new tests, including one in issue #552.
`getForbiddenImportsExcludesRegexp` was removed as we never use it.
Some conditions were moved from `visit` to other method `isImportForbidden` since it is common there.
`if (parentDotAST != null) {` was removed because we either always have DOT or IDENT as first token.

`getDefaultTokens` was changed for other issue.
Only other change was `(forbiddenImportsExcludesRegexp == null  || !forbiddenImportsExcludesRegexp.matcher(importText).matches());` to make sure no NPE on a null exclude.

Regression to come.