### PR TITLE
Issue #550: added dynamic checkstyle regression

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -58,6 +58,16 @@ matrix:
         - CMD3="&& mvn jacoco:report coveralls:jacoco"
         - CMD=$CMD0$CMD1$CMD2$CMD3
 
+    # regression on checkstyle
+    - jdk: oraclejdk8
+      env:
+        - DESC="checkstyle regression"
+        - CMD0="git clone https://github.com/checkstyle/checkstyle "
+        - CMD1=" && cd sevntu-checks && mvn install -DskipTests -Dcheckstyle.skip=true -Dcobertura.skip=true"
+        - CMD2=" && mvn test -Dtest=CheckstyleRegressionTest#setupFiles -Dregression-path=../"
+        - CMD3=" && cd ../ && cd checkstyle && mvn clean verify -e -DskipTests -DskipITs -Dpmd.skip=true -Dfindbugs.skip=true -Dcobertura.skip=true"
+        - CMD=$CMD0$CMD1$CMD2$CMD3
+
     # testing of PR format
     - env:
         - DESC="test Issue ref in PR description"

--- a/sevntu-checks/src/main/java/com/github/sevntu/checkstyle/checks/design/ConstructorWithoutParamsCheck.java
+++ b/sevntu-checks/src/main/java/com/github/sevntu/checkstyle/checks/design/ConstructorWithoutParamsCheck.java
@@ -149,23 +149,25 @@ public class ConstructorWithoutParamsCheck extends AbstractCheck {
 
     @Override
     public void visitToken(DetailAST ast) {
+        final DetailAST firstChild = ast.getFirstChild();
+        if (firstChild != null) {
+            final String className = firstChild.getText();
 
-        final String className = ast.getFirstChild().getText();
+            // The "new" keyword either creates objects or declares arrays.
+            // In the case of arrays, no objects (array elements) are automatically created,
+            // and this check does not apply.
+            if (regexp.matcher(className).find()
+                && !ignoredRegexp.matcher(className).find()
+                && !ast.branchContains(TokenTypes.ARRAY_DECLARATOR)) {
 
-        // The "new" keyword either creates objects or declares arrays.
-        // In the case of arrays, no objects (array elements) are automatically created,
-        // and this check does not apply.
-        if (regexp.matcher(className).find()
-            && !ignoredRegexp.matcher(className).find()
-            && !ast.branchContains(TokenTypes.ARRAY_DECLARATOR)) {
+                final DetailAST parameterListAST = ast.findFirstToken(TokenTypes.ELIST);
+                final int numberOfParameters = parameterListAST.getChildCount();
 
-            final DetailAST parameterListAST = ast.findFirstToken(TokenTypes.ELIST);
-            final int numberOfParameters = parameterListAST.getChildCount();
+                if (numberOfParameters == 0) {
+                    log(ast, MSG_KEY, className);
+                }
 
-            if (numberOfParameters == 0) {
-                log(ast, MSG_KEY, className);
             }
-
         }
     }
 }

--- a/sevntu-checks/src/test/java/com/github/sevntu/checkstyle/checks/design/ConstructorWithoutParamsCheckTest.java
+++ b/sevntu-checks/src/test/java/com/github/sevntu/checkstyle/checks/design/ConstructorWithoutParamsCheckTest.java
@@ -39,7 +39,7 @@ public class ConstructorWithoutParamsCheckTest extends BaseCheckTestSupport {
 
     @Test
     public void testDefaultConfigProhibitsExceptionsWithoutParams() throws Exception {
-        final String[] expectedViolationMsg = {"30:37: " + getCheckMessage(MSG_KEY, "RuntimeException")};
+        final String[] expectedViolationMsg = {"35:37: " + getCheckMessage(MSG_KEY, "RuntimeException")};
         verify(defaultConfig, getPath("InputConstructorWithoutParamsCheck.java"), expectedViolationMsg);
     }
 
@@ -48,8 +48,8 @@ public class ConstructorWithoutParamsCheckTest extends BaseCheckTestSupport {
         defaultConfig.addAttribute("classNameFormat", "Clazz[1-9]");
         defaultConfig.addAttribute("ignoredClassNameFormat", "Clazz4");
         final String[] expectedViolationMsg = {
-            "64:27: " + getCheckMessage(MSG_KEY, "Clazz1"),
-            "67:27: " + getCheckMessage(MSG_KEY, "Clazz2"),
+            "69:27: " + getCheckMessage(MSG_KEY, "Clazz1"),
+            "72:27: " + getCheckMessage(MSG_KEY, "Clazz2"),
         };
         verify(defaultConfig, getPath("InputConstructorWithoutParamsCheck.java"), expectedViolationMsg);
     }

--- a/sevntu-checks/src/test/java/com/github/sevntu/checkstyle/internal/CheckUtil.java
+++ b/sevntu-checks/src/test/java/com/github/sevntu/checkstyle/internal/CheckUtil.java
@@ -58,7 +58,7 @@ public final class CheckUtil {
      *            file path of checkstyle_checks.xml.
      * @return names of checkstyle's checks which are referenced in checkstyle_checks.xml.
      */
-    private static Set<String> getCheckStyleChecksReferencedInConfig(String configFilePath) {
+    public static Set<String> getCheckStyleChecksReferencedInConfig(String configFilePath) {
         try {
             final DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
 

--- a/sevntu-checks/src/test/java/com/github/sevntu/checkstyle/internal/CheckstyleRegressionTest.java
+++ b/sevntu-checks/src/test/java/com/github/sevntu/checkstyle/internal/CheckstyleRegressionTest.java
@@ -1,0 +1,177 @@
+////////////////////////////////////////////////////////////////////////////////
+// checkstyle: Checks Java source code for adherence to a set of rules.
+// Copyright (C) 2001-2016 the original author or authors.
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+////////////////////////////////////////////////////////////////////////////////
+
+package com.github.sevntu.checkstyle.internal;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+
+import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.StandardOpenOption;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+import java.util.Set;
+
+import org.junit.Test;
+
+public class CheckstyleRegressionTest {
+    /** List of checks to suppress if we dynamically add it to the configuration. */
+    private static final List<String> ADD_CHECK_SUPPRESSIONS = Arrays
+            .asList("ReturnCountExtendedCheck");
+
+    // -@cs[CyclomaticComplexity] Can't split
+    @Test
+    public void setupFiles() throws Exception {
+        final String regressionPath = System.getProperty("regression-path");
+
+        if (regressionPath != null) {
+            final File path = new File(regressionPath);
+
+            if (!path.exists()) {
+                throw new IllegalStateException("Invalid path: " + path.getAbsolutePath());
+            }
+
+            System.out.println("Working Path: " + path.getCanonicalPath());
+
+            final File project = new File(path, "checkstyle");
+
+            if (!project.exists() || !project.isDirectory()) {
+                throw new IllegalStateException("Can't find project: " + project.getAbsolutePath());
+            }
+
+            final File config = new File(project, "config/checkstyle_sevntu_checks.xml");
+
+            if (!config.exists() || !config.isFile() || !config.canRead() || !config.canWrite()) {
+                throw new IllegalStateException("Can't read config: " + config.getAbsolutePath());
+            }
+
+            System.out.println("Config Path: " + config.getCanonicalPath());
+
+            final File suppression = new File(project, "config/sevntu_suppressions.xml");
+
+            if (!suppression.exists() || !suppression.isFile() || !suppression.canRead()
+                    || !suppression.canWrite()) {
+                throw new IllegalStateException("Can't read suppression: "
+                        + suppression.getAbsolutePath());
+            }
+
+            System.out.println("Suppression Path: " + suppression.getCanonicalPath());
+
+            work(config, suppression);
+
+            System.out.println("Done");
+        }
+    }
+
+    private static void work(File config, File suppression) throws Exception {
+        final Set<String> configChecks = CheckUtil.getCheckStyleChecksReferencedInConfig(config
+                .getAbsolutePath());
+        final List<Class<?>> sevntuChecks = new ArrayList<>(CheckUtil.getCheckstyleModules());
+
+        trimSevntuChecksNotReferenced(configChecks, sevntuChecks);
+
+        String configContents = new String(Files.readAllBytes(config.toPath()), UTF_8);
+        String suppressionContents = new String(Files.readAllBytes(suppression.toPath()), UTF_8);
+
+        if (sevntuChecks.size() > 0) {
+            System.out.println("Adding " + sevntuChecks.size() + " missing check(s)");
+
+            String configAdditions = "";
+            String suppressionAdditions = "";
+
+            for (Class<?> sevntuCheck : sevntuChecks) {
+                final String name = sevntuCheck.getName();
+                final String simpleName = sevntuCheck.getSimpleName();
+
+                System.out.println("-- Adding Check: " + name);
+
+                configAdditions += "<module name=\"" + name + "\"></module>\r\n";
+
+                if (ADD_CHECK_SUPPRESSIONS.contains(simpleName)) {
+                    System.out.println("-- Adding Suppression: " + simpleName);
+
+                    suppressionAdditions += "<suppress checks=\"" + simpleName
+                            + "\" files=\".*\"/>\r\n";
+                }
+            }
+
+            int treeWalkerPosition = configContents.lastIndexOf("<module name=\"TreeWalker\">");
+            treeWalkerPosition = configContents.indexOf('\n', treeWalkerPosition) + 1;
+
+            configContents = configContents.substring(0, treeWalkerPosition) + configAdditions
+                    + configContents.substring(treeWalkerPosition);
+
+            Files.write(config.toPath(), configContents.getBytes(UTF_8), StandardOpenOption.CREATE);
+
+            if (!suppressionAdditions.isEmpty()) {
+                final int position = suppressionContents.lastIndexOf("</suppressions");
+
+                suppressionContents = suppressionContents.substring(0, position)
+                        + suppressionAdditions + suppressionContents.substring(position);
+
+                Files.write(suppression.toPath(), suppressionContents.getBytes(UTF_8),
+                        StandardOpenOption.CREATE);
+            }
+        }
+        else {
+            System.out.println("All sevntu checks listed in config");
+        }
+    }
+
+    private static void trimSevntuChecksNotReferenced(Set<String> configChecks,
+            List<Class<?>> sevntuChecks) {
+        for (String configCheck : configChecks) {
+            final int position = findCheck(sevntuChecks, configCheck);
+
+            if (position == -1) {
+                System.err.println("Found module not in sevntu: " + configCheck);
+            }
+            else {
+                sevntuChecks.remove(position);
+            }
+        }
+    }
+
+    // -@cs[ReturnCount] Not simple to reduce returns
+    private static int findCheck(Collection<Class<?>> checks, String findCheck) {
+        int position = 0;
+
+        for (Class<?> check : checks) {
+            final String simpleName = check.getSimpleName();
+
+            if (findCheck.endsWith("Check")) {
+                if (simpleName.equals(findCheck) || check.getName().equals(findCheck)) {
+                    return position;
+                }
+            }
+            else {
+                if (simpleName.replaceAll("Check$", "").equals(findCheck)
+                        || check.getName().replaceAll("Check$", "").equals(findCheck)) {
+                    return position;
+                }
+            }
+
+            position++;
+        }
+
+        return -1;
+    }
+}

--- a/sevntu-checks/src/test/resources/com/github/sevntu/checkstyle/checks/design/InputConstructorWithoutParamsCheck.java
+++ b/sevntu-checks/src/test/resources/com/github/sevntu/checkstyle/checks/design/InputConstructorWithoutParamsCheck.java
@@ -20,7 +20,12 @@
 package com.github.sevntu.checkstyle.checks.design;
 
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
+import java.util.Set;
+import java.util.TreeSet;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 public class InputConstructorWithoutParamsCheck {
 
@@ -111,4 +116,6 @@ public class InputConstructorWithoutParamsCheck {
 
     }
 
+    private static final Set<String> TEST = Collections.unmodifiableSortedSet(Stream.of("test")
+            .collect(Collectors.toCollection(TreeSet::new)));
 }


### PR DESCRIPTION
Issue #550

Idea is:
New test will scan checkstyle's sevntu config and add missing checks on the fly, especially new ones from PR.
Will run checkstyle on checkstyle project and expect no violations.

Future enhancements could include ability to specify non-default configuration of checks.
Could be made as a groovy script, but will have to be able to tell what checks are available.