### PR TITLE
Issue #559: ignore object blocks for ShortCircuitOperator check

### DIFF
--- a/sevntu-checks/src/main/java/com/github/sevntu/checkstyle/checks/coding/AvoidNotShortCircuitOperatorsForBooleanCheck.java
+++ b/sevntu-checks/src/main/java/com/github/sevntu/checkstyle/checks/coding/AvoidNotShortCircuitOperatorsForBooleanCheck.java
@@ -107,6 +107,10 @@ public class AvoidNotShortCircuitOperatorsForBooleanCheck extends AbstractCheck 
         // look for EXPR which is always around BOR/BAND... operators
         while (currentNode != null && currentNode.getType() != TokenTypes.EXPR) {
             currentNode = currentNode.getParent();
+
+            if (currentNode.getType() == TokenTypes.OBJBLOCK) {
+                currentNode = null;
+            }
         }
 
         if (currentNode != null && isBooleanExpression(currentNode)) {

--- a/sevntu-checks/src/test/resources/com/github/sevntu/checkstyle/checks/coding/InputAvoidNotShortCircuitOperatorsForBooleanCheck.java
+++ b/sevntu-checks/src/test/resources/com/github/sevntu/checkstyle/checks/coding/InputAvoidNotShortCircuitOperatorsForBooleanCheck.java
@@ -160,4 +160,19 @@ class MyConstructor
     {
         boolean x = InputAvoidNotShortCircuitOperatorsForBooleanCheck.x | InputAvoidNotShortCircuitOperatorsForBooleanCheck.x;
     }
+
+    public void test() {
+        new Runnable() {
+            @Override
+            public void run() {
+            }
+            public boolean test() {
+                try {
+                } catch (IllegalArgumentException | NullPointerException e) {
+                    return false;
+                }
+                return true;
+            }
+        };
+    }
 }


### PR DESCRIPTION
Issue #559 

I am looking for object blocks over catch block incase `&` is used in a type parameter of an anonymous class.
Regression will show if there are any cases.