### PR TITLE
Issue #575: fixed NPE in ForbidWildcardAsReturnTypeCheck

### DIFF
--- a/sevntu-checks/src/test/java/com/github/sevntu/checkstyle/checks/design/ForbidWildcardAsReturnTypeCheckTest.java
+++ b/sevntu-checks/src/test/java/com/github/sevntu/checkstyle/checks/design/ForbidWildcardAsReturnTypeCheckTest.java
@@ -29,6 +29,7 @@ import org.junit.Test;
 
 import com.github.sevntu.checkstyle.BaseCheckTestSupport;
 import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
+import com.puppycrawl.tools.checkstyle.utils.CommonUtils;
 
 /**
  * Test class for ForbidWildcardInReturnTypeCheck.
@@ -420,6 +421,17 @@ public class ForbidWildcardAsReturnTypeCheckTest extends BaseCheckTestSupport {
         verify(checkConfig,
             getPath("InputForbidWildcardAsReturnTypeCheck.java"),
             expected);
+    }
+
+    @Test
+    public final void testFullyQualifiedAnnotation()
+            throws Exception {
+        final DefaultConfiguration checkConfig =
+                createCheckConfig(ForbidWildcardAsReturnTypeCheck.class);
+
+        verify(checkConfig,
+            getPath("InputForbidWildcardAsReturnTypeCheckQualifiedAnnotation.java"),
+            CommonUtils.EMPTY_STRING_ARRAY);
     }
 
     /**

--- a/sevntu-checks/src/test/resources/com/github/sevntu/checkstyle/checks/design/InputForbidWildcardAsReturnTypeCheck.java
+++ b/sevntu-checks/src/test/resources/com/github/sevntu/checkstyle/checks/design/InputForbidWildcardAsReturnTypeCheck.java
@@ -310,8 +310,8 @@ class MethodsWithAnnotations extends SomeClass {
     @SuppressWarnings("unchecked") public List<?> met3() {
         return null;
     }
-    @Deprecated
-    @Override
+    @java.lang.Deprecated
+    @java.lang.Override
     @SuppressWarnings("unused")
     public List<?> met4() {
         return null;

--- a/sevntu-checks/src/test/resources/com/github/sevntu/checkstyle/checks/design/InputForbidWildcardAsReturnTypeCheckQualifiedAnnotation.java
+++ b/sevntu-checks/src/test/resources/com/github/sevntu/checkstyle/checks/design/InputForbidWildcardAsReturnTypeCheckQualifiedAnnotation.java
@@ -1,0 +1,7 @@
+package com.github.sevntu.checkstyle.checks.design;
+
+public class InputForbidWildcardAsReturnTypeCheckQualifiedAnnotation {
+    @org.junit.After
+    public void doAfterTest() {
+    }
+}


### PR DESCRIPTION
Issue #575

Removed `hasAnnotation` for Checkstyle's `AnnotationUtility.containsAnnotation`.
Changed the code to examine fully qualified annotations. Changed existing test to pass code coverage for the new fully qualified annotation check.

Regression to come.