### PR TITLE
Issue #165: change groupId to 'com.github.sevntu-checkstyle'

### DIFF
--- a/eclipse-pom.xml
+++ b/eclipse-pom.xml
@@ -3,7 +3,7 @@
 
   <modelVersion>4.0.0</modelVersion>
 
-  <groupId>com.github.sevntu.checkstyle</groupId>
+  <groupId>com.github.sevntu-checkstyle</groupId>
   <artifactId>parent</artifactId>
   <version>1.23.1</version>
   <packaging>pom</packaging>

--- a/eclipsecs-sevntu-plugin-feature/pom.xml
+++ b/eclipsecs-sevntu-plugin-feature/pom.xml
@@ -5,12 +5,12 @@
 
   <parent>
     <relativePath>../eclipse-pom.xml</relativePath>
-    <groupId>com.github.sevntu.checkstyle</groupId>
+    <groupId>com.github.sevntu-checkstyle</groupId>
     <artifactId>parent</artifactId>
     <version>1.23.1</version>
   </parent>
 
-  <groupId>com.github.sevntu.checkstyle</groupId>
+  <groupId>com.github.sevntu-checkstyle</groupId>
   <artifactId>com.github.sevntu.checkstyle.checks.feature</artifactId>
   <packaging>eclipse-feature</packaging>
   <name>Extension for eclipse-cs Plugin with additional Checks</name>

--- a/eclipsecs-sevntu-plugin/pom.xml
+++ b/eclipsecs-sevntu-plugin/pom.xml
@@ -7,12 +7,12 @@
 
   <parent>
     <relativePath>../eclipse-pom.xml</relativePath>
-    <groupId>com.github.sevntu.checkstyle</groupId>
+    <groupId>com.github.sevntu-checkstyle</groupId>
     <artifactId>parent</artifactId>
     <version>1.23.1</version>
   </parent>
 
-  <groupId>com.github.sevntu.checkstyle</groupId>
+  <groupId>com.github.sevntu-checkstyle</groupId>
   <artifactId>eclipsecs-sevntu-plugin</artifactId>
   <packaging>eclipse-plugin</packaging>
 
@@ -31,7 +31,7 @@
 
   <dependencies>
     <dependency>
-      <groupId>com.github.sevntu.checkstyle</groupId>
+      <groupId>com.github.sevntu-checkstyle</groupId>
       <artifactId>sevntu-checks</artifactId>
       <version>${project.version}</version>
     </dependency>
@@ -85,7 +85,7 @@
             <configuration>
               <artifactItems>
                 <artifactItem>
-                  <groupId>com.github.sevntu.checkstyle</groupId>
+                  <groupId>com.github.sevntu-checkstyle</groupId>
                   <artifactId>sevntu-checks</artifactId>
                   <version>${sevntu.checks.version}</version>
                   <type>jar</type>

--- a/sevntu-checks/pom.xml
+++ b/sevntu-checks/pom.xml
@@ -2,7 +2,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
   <modelVersion>4.0.0</modelVersion>
-  <groupId>com.github.sevntu.checkstyle</groupId>
+  <groupId>com.github.sevntu-checkstyle</groupId>
   <artifactId>sevntu-checks</artifactId>
   <version>1.23.1</version>
 
@@ -70,7 +70,7 @@
 
   <distributionManagement>
     <repository>
-      <id>com.github.sevntu.checkstyle</id>
+      <id>com.github.sevntu-checkstyle</id>
       <name>sevntu-checks</name>
       <url>file://${basedir}/../gh-pages/maven2/</url>
     </repository>
@@ -249,7 +249,7 @@
               </dependency>
               <!-- atention here is self-referencing, so be sure you did "mvn install" before "mvn verify -Pselftesting" -->
               <dependency>
-                <groupId>com.github.sevntu.checkstyle</groupId>
+                <groupId>com.github.sevntu-checkstyle</groupId>
                 <artifactId>sevntu-checks</artifactId>
                 <version>${project.version}</version>
               </dependency>

--- a/sevntu-checkstyle-idea-extension/pom.xml
+++ b/sevntu-checkstyle-idea-extension/pom.xml
@@ -3,7 +3,7 @@
 
   <modelVersion>4.0.0</modelVersion>
 
-  <groupId>com.github.sevntu.checkstyle</groupId>
+  <groupId>com.github.sevntu-checkstyle</groupId>
   <artifactId>sevntu-checkstyle-idea-extension</artifactId>
   <version>1.23.1</version>
   <packaging>jar</packaging>
@@ -19,7 +19,7 @@
 
   <dependencies>
     <dependency>
-      <groupId>com.github.sevntu.checkstyle</groupId>
+      <groupId>com.github.sevntu-checkstyle</groupId>
       <artifactId>sevntu-checks</artifactId>
       <version>${project.version}</version>
     </dependency>
@@ -27,7 +27,7 @@
 
   <distributionManagement>
     <repository>
-      <id>com.github.sevntu.checkstyle</id>
+      <id>com.github.sevntu-checkstyle</id>
       <name>Sevntu Checkstyle Idea extension</name>
       <url>file://${basedir}/../gh-pages/maven2/</url>
     </repository>
@@ -54,7 +54,7 @@
             <configuration>
               <artifactItems>
                 <artifactItem>
-                  <groupId>com.github.sevntu.checkstyle</groupId>
+                  <groupId>com.github.sevntu-checkstyle</groupId>
                   <artifactId>sevntu-checks</artifactId>
                   <version>${sevntu.checks.version}</version>
                   <type>jar</type>

--- a/sevntu-checkstyle-maven-plugin/pom.xml
+++ b/sevntu-checkstyle-maven-plugin/pom.xml
@@ -2,7 +2,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
   <modelVersion>4.0.0</modelVersion>
-  <groupId>com.github.sevntu.checkstyle</groupId>
+  <groupId>com.github.sevntu-checkstyle</groupId>
   <artifactId>sevntu-checkstyle-maven-plugin</artifactId>
   <name>Sevntu Checkstyle Maven Plugin</name>
   <version>1.23.1</version>
@@ -16,7 +16,7 @@
 
   <dependencies>
     <dependency>
-      <groupId>com.github.sevntu.checkstyle</groupId>
+      <groupId>com.github.sevntu-checkstyle</groupId>
       <artifactId>sevntu-checks</artifactId>
       <version>1.23.1</version>
     </dependency>
@@ -29,7 +29,7 @@
 
   <distributionManagement>
     <repository>
-      <id>com.github.sevntu.checkstyle</id>
+      <id>com.github.sevntu-checkstyle</id>
       <name>Sevntu Checkstyle Maven Plugin</name>
       <url>file://${basedir}/../gh-pages/maven2/</url>
     </repository>

--- a/sevntu-checkstyle-sonar-plugin/pom.xml
+++ b/sevntu-checkstyle-sonar-plugin/pom.xml
@@ -2,7 +2,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
 
   <modelVersion>4.0.0</modelVersion>
-  <groupId>com.github.sevntu.checkstyle</groupId>
+  <groupId>com.github.sevntu-checkstyle</groupId>
   <artifactId>sevntu-checkstyle-sonar-plugin</artifactId>
   <version>1.23.1</version>
   <packaging>sonar-plugin</packaging>
@@ -31,7 +31,7 @@
     </dependency>
 
     <dependency>
-      <groupId>com.github.sevntu.checkstyle</groupId>
+      <groupId>com.github.sevntu-checkstyle</groupId>
       <artifactId>sevntu-checks</artifactId>
       <version>${project.version}</version>
     </dependency>

--- a/update-site/pom.xml
+++ b/update-site/pom.xml
@@ -5,7 +5,7 @@
 
   <parent>
     <relativePath>../eclipse-pom.xml</relativePath>
-    <groupId>com.github.sevntu.checkstyle</groupId>
+    <groupId>com.github.sevntu-checkstyle</groupId>
     <artifactId>parent</artifactId>
     <version>1.23.1</version>
   </parent>


### PR DESCRIPTION
Issue #165

I avoided changes in eclipse related projects so "sevntu.checkstyle" will stay there, it is not required to follow maven rules for naming.

@rnveach , please review.
I did not tested all projects, most likely smth will fail, but could be fixed later, demand for maven central is higher. 