### PR TITLE
config: allowed overriding checkstyle configuration for snapshots

### DIFF
--- a/sevntu-checks/pom.xml
+++ b/sevntu-checks/pom.xml
@@ -17,6 +17,7 @@
     <project.build.sourceEncoding>iso-8859-1</project.build.sourceEncoding>
     <!-- it is not compile dependency to checkstyle, this version is only for maven plugins -->
     <checkstyle.version>7.8</checkstyle.version>
+    <checkstyle.configLocation>https://raw.githubusercontent.com/checkstyle/checkstyle/checkstyle-${checkstyle.version}/config/checkstyle_checks.xml</checkstyle.configLocation>
     <!-- It is compile dependency to checkstyle, this version has to be the same as eclispe-cs depends on -->
     <checkstyle.eclipse-cs.version>7.6</checkstyle.eclipse-cs.version>
     <checkstyle.plugin.version>2.17</checkstyle.plugin.version>
@@ -184,7 +185,7 @@
               <goal>check</goal>
             </goals>
             <configuration>
-              <configLocation>https://raw.githubusercontent.com/checkstyle/checkstyle/checkstyle-${checkstyle.version}/config/checkstyle_checks.xml</configLocation>
+              <configLocation>${checkstyle.configLocation}</configLocation>
               <failOnViolation>true</failOnViolation>
               <linkXRef>false</linkXRef>
               <propertiesLocation>checkstyle.properties</propertiesLocation>


### PR DESCRIPTION
These are changes needed for no error testing from main checkstyle project as talked about at https://github.com/checkstyle/checkstyle/issues/4387#issuecomment-305205047 .

We could already override the checkstyle version number, but the configuration is based on that version number. If CS version is switched to a SNAPSHOT, it will try to load that from github but SNAPSHOT configurations don't exist there. Instead with new changes, wercker will override and give it the PR's configuration location.

One Question, will this be no exception testing (not using `launch.groovy`) or no error testing?
No error testing would be more thorough, and thats what it should be with current changes.
No exception testing would require us to be able to override `failOnViolation` to turn it off, which would be another change in this PR.