### PR TITLE
ghpages: update jquery

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width,initial-scale=1.0, minimum-scale=1.0">
     <meta http-equiv="X-UA-Compatible" content="ie=edge">
 	<title>sevntu-checkstyle/sevntu.checkstyle @ GitHub</title>
-    <script type="text/Javascript" src="//ajax.googleapis.com/ajax/libs/jquery/3.2.1/jquery.min.js"></script>
+    <script type="text/Javascript" src="https://ajax.googleapis.com/ajax/libs/jquery/3.2.1/jquery.min.js"></script>
 
 <style type="text/css">
 body {

--- a/index.html
+++ b/index.html
@@ -168,13 +168,13 @@ img.darkShadowed {
 	</script>
 
 <body>
-  <a href="http://github.com/sevntu-checkstyle/sevntu.checkstyle">
-   <img style="position: absolute; top: 0; right: 0; border: 0;" src="http://s3.amazonaws.com/github/ribbons/forkme_right_darkblue_121621.png" alt="Fork me on GitHub" />
+  <a href="https://github.com/sevntu-checkstyle/sevntu.checkstyle">
+   <img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_darkblue_121621.png" alt="Fork me on GitHub" />
   </a>
 
   <div id="container">
 
-    <h1><a href="http://github.com/sevntu-checkstyle/sevntu.checkstyle">Sevntu-Checkstyle</a></h1>
+    <h1><a href="https://github.com/sevntu-checkstyle/sevntu.checkstyle">Sevntu-Checkstyle</a></h1>
       <p><span class="small">By students from around the world.
       <br/>
 	Licence is <a href="https://www.gnu.org/licenses/lgpl-2.1.en.html">GNU LESSER GENERAL PUBLIC LICENSE Version 2.1.</a>
@@ -183,7 +183,7 @@ img.darkShadowed {
     <h2>Description</h2>
 
     <div class="description">
-      Main idea of <a href="http://checkstyle.sourceforge.net/">Checkstyle</a> project is to automate and to ease code-review process; to assist developers in complying with the company's Code-standard, and allow them to fix and eliminate any minor problem upon just saving the file.
+      Main idea of <a href="https://checkstyle.sourceforge.net/">Checkstyle</a> project is to automate and to ease code-review process; to assist developers in complying with the company's Code-standard, and allow them to fix and eliminate any minor problem upon just saving the file.
 We are strongly convinced that it is much more easier and convenient to catch minor traps in code during writing than after committing/pushing. This project contains a number of Checks that can help program engineers to write code in a uniform style, which makes it easier for the whole team of programmers to review the code, also significantly improves the low threshold of understanding for new developers.
       <br/>
       <br/>
@@ -209,10 +209,10 @@ See <a href="apidocs/index.html">Javadoc pages</a> for documentation of Check op
 			<br/>
 		</p>
     <h2>Discussion group</h2>
-	      <p> Homepage:	 	<a href="http://groups.google.com/group/sevntu-checkstyle?hl=en">discussion group</a> <br/></p>
+	      <p> Homepage:	 	<a href="https://groups.google.com/group/sevntu-checkstyle?hl=en">discussion group</a> <br/></p>
         <p> Group email:	 	sevntu-checkstyle[ a ]googlegroups.com</p>
     <h2>IRC</h2>
-        <p> <a href="http://webchat.freenode.net/?channels=#sevntu.checkstyle">#sevntu.checkstyle on Freenode</a></p>
+        <p> <a href="https://webchat.freenode.net/?channels=#sevntu.checkstyle">#sevntu.checkstyle on Freenode</a></p>
 
 <h2 id="distribution">Distribution</h2>
 <p>
@@ -226,17 +226,17 @@ We do deployment to Maven central -
 </ul>
 </p>
 <p>
-<span id="checkstyle-maven">- extension to <a href="http://maven.apache.org/plugins/maven-checkstyle-plugin/">maven-checkstyle-plugin</a> (how to use: <a href="http://maven.apache.org/plugins/maven-checkstyle-plugin/examples/custom-developed-checkstyle.html">in general</a>, <a href="https://github.com/sevntu-checkstyle/checkstyle-samples/tree/master/maven-project">maven example</a>, <a href="https://github.com/sevntu-checkstyle/checkstyle-samples/tree/master/ant-project">ant example</a>).</span><br>
-<span id="checkstyle-sonar">- extension to <a href="http://docs.codehaus.org/display/SONAR/Checkstyle+Plugin">Sonar Checkstyle Plugin</a> (how to use: <a href="https://github.com/sevntu-checkstyle/sevntu.checkstyle/wiki/How-to-integrate-sevntu-checks-into-SonarQubeTM-%28user%27s-guide%29">in general</a>).</span><br>
-<span id="checkstyle-idea">- extension to <a href="http://plugins.jetbrains.com/plugin/1065">CheckStyle-IDEA</a> (how to use: <a href="https://github.com/sevntu-checkstyle/sevntu.checkstyle/wiki/How-to-use-SevNTU-Checkstyle-in-Intellij-IDEA">in general</a>).</span><br>
-<span id="eclipsecs-update-site">- extension to <a href="http://eclipse-cs.sourceforge.net/">Checkstyle Eclipse plugin</a> how to use: install from EclipseCS “update site” or use our update site http://sevntu-checkstyle.github.com/sevntu.checkstyle/update-site/ (do not use this link in Browser, it will return 404 code, it is expected, but it will work well through Eclipse menu "Help"->"Install New Software ...") </span>
+<span id="checkstyle-maven">- extension to <a href="https://maven.apache.org/plugins/maven-checkstyle-plugin/">maven-checkstyle-plugin</a> (how to use: <a href="https://maven.apache.org/plugins/maven-checkstyle-plugin/examples/custom-developed-checkstyle.html">in general</a>, <a href="https://github.com/sevntu-checkstyle/checkstyle-samples/tree/master/maven-project">maven example</a>, <a href="https://github.com/sevntu-checkstyle/checkstyle-samples/tree/master/ant-project">ant example</a>).</span><br>
+<span id="checkstyle-sonar">- extension to <a href="https://docs.codehaus.org/display/SONAR/Checkstyle+Plugin">Sonar Checkstyle Plugin</a> (how to use: <a href="https://github.com/sevntu-checkstyle/sevntu.checkstyle/wiki/How-to-integrate-sevntu-checks-into-SonarQubeTM-%28user%27s-guide%29">in general</a>).</span><br>
+<span id="checkstyle-idea">- extension to <a href="https://plugins.jetbrains.com/plugin/1065">CheckStyle-IDEA</a> (how to use: <a href="https://github.com/sevntu-checkstyle/sevntu.checkstyle/wiki/How-to-use-SevNTU-Checkstyle-in-Intellij-IDEA">in general</a>).</span><br>
+<span id="eclipsecs-update-site">- extension to <a href="https://eclipse-cs.sourceforge.net/">Checkstyle Eclipse plugin</a> how to use: install from EclipseCS “update site” or use our update site https://sevntu-checkstyle.github.com/sevntu.checkstyle/update-site/ (do not use this link in Browser, it will return 404 code, it is expected, but it will work well through Eclipse menu "Help"->"Install New Software ...") </span>
 </p>
 
 <h2 id="ExamplesOfUsage">Examples of usage</h2>
 <p>
 Full list of Checks and examples of usage could be found at
 <a href="https://github.com/checkstyle/checkstyle/blob/master/config/checkstyle_sevntu_checks.xml">cofig</a>
- that <a href="http://checkstyle.sourceforge.net/">checkstyle</a> project use.
+ that <a href="https://checkstyle.sourceforge.net/">checkstyle</a> project use.
 </p>
 
 <h2> New and noteworthy</h2>
@@ -808,7 +808,7 @@ Full list of Checks and examples of usage could be found at
    <br/>
 
    <br/>
-     <b>PublicReferenceToPrivateTypeCheck</b> -&nbsp; This Check warns on propagation of inner private types to outer classes:<br>- Externally accessible method if it returns private inner type.<br>- Externally accessible field if it's type is a private inner type.<br>These types could be <a href='http://docs.oracle.com/javase/tutorial/java/javaOO/nested.html'>private inner classes</a>, interfaces or enumerations. Done by Alexey Nesterenko.
+     <b>PublicReferenceToPrivateTypeCheck</b> -&nbsp; This Check warns on propagation of inner private types to outer classes:<br>- Externally accessible method if it returns private inner type.<br>- Externally accessible field if it's type is a private inner type.<br>These types could be <a href='https://docs.oracle.com/javase/tutorial/java/javaOO/nested.html'>private inner classes</a>, interfaces or enumerations. Done by Alexey Nesterenko.
      <a href="https://github.com/sevntu-checkstyle/sevntu.checkstyle/pull/201">More</a>
    <br/>
    <br/>
@@ -882,11 +882,11 @@ macros for "main()" method. Done by Baratali Izmailov.
 <div class="name"><span><h3>Release 1.10.0 (24/Nov/2013)</h3></span></div>
 <div class="text">
   <br/>
-     <span style="color: red;">New project!</span> <b>sevntu-checkstyle-sonar-plugin</b> - &nbsp;Project was created as extension to <a href="http://docs.codehaus.org/display/SONAR/Checkstyle+Plugin" target="_blank">Sonar Checkstyle Plugin</a>&nbsp;for <a href="http://www.sonarqube.org/" target="_blank">SonarQube&trade;</a>, How to use it is described <a href="https://github.com/sevntu-checkstyle/sevntu.checkstyle/wiki/How-to-integrate-sevntu-checks-into-SonarQubeTM-%28user%27s-guide%29" target="_blank">here</a> in detail and pictures, Done by Ruslan Diachenko. <a href="https://github.com/sevntu-checkstyle/sevntu.checkstyle/issues/113" target="_blank">More</a>.
+     <span style="color: red;">New project!</span> <b>sevntu-checkstyle-sonar-plugin</b> - &nbsp;Project was created as extension to <a href="https://docs.codehaus.org/display/SONAR/Checkstyle+Plugin" target="_blank">Sonar Checkstyle Plugin</a>&nbsp;for <a href="https://www.sonarqube.org/" target="_blank">SonarQube&trade;</a>, How to use it is described <a href="https://github.com/sevntu-checkstyle/sevntu.checkstyle/wiki/How-to-integrate-sevntu-checks-into-SonarQubeTM-%28user%27s-guide%29" target="_blank">here</a> in detail and pictures, Done by Ruslan Diachenko. <a href="https://github.com/sevntu-checkstyle/sevntu.checkstyle/issues/113" target="_blank">More</a>.
    <br/>
    <br/>
   <br/>
-     <span style="color: red;">New project!</span> <b>sevntu-checkstyle-idea-extension</b> - &nbsp;Project was created as extension for <a href="http://plugins.jetbrains.com/plugin/1065" target="_blank">Checkstyle IDEA</a> plugin for <a href="http://www.jetbrains.com/idea/" target="_blank">IntelliJ IDEA</a>, How to use it is described <a href="https://github.com/sevntu-checkstyle/sevntu.checkstyle/wiki/How-to-use-SevNTU-Checkstyle-in-Intellij-IDEA" target="_blank">here</a> in details and pictures, Done by Vadim Panasiuk. <a href="https://github.com/sevntu-checkstyle/sevntu.checkstyle/issues/114" target="_blank">More</a>.
+     <span style="color: red;">New project!</span> <b>sevntu-checkstyle-idea-extension</b> - &nbsp;Project was created as extension for <a href="https://plugins.jetbrains.com/plugin/1065" target="_blank">Checkstyle IDEA</a> plugin for <a href="https://www.jetbrains.com/idea/" target="_blank">IntelliJ IDEA</a>, How to use it is described <a href="https://github.com/sevntu-checkstyle/sevntu.checkstyle/wiki/How-to-use-SevNTU-Checkstyle-in-Intellij-IDEA" target="_blank">here</a> in details and pictures, Done by Vadim Panasiuk. <a href="https://github.com/sevntu-checkstyle/sevntu.checkstyle/issues/114" target="_blank">More</a>.
    <br/>
    <br/>
   <br/>
@@ -976,7 +976,7 @@ macros for "main()" method. Done by Baratali Izmailov.
      <br/>Done by Vadim Panasiuk.&nbsp;
      <a href="https://github.com/sevntu-checkstyle/sevntu.checkstyle/pull/90">More</a>.
      <br/>
-     Examples of usage and all options description is <a href="http://roman-ivanov.blogspot.com/2014/01/confusing-condition-check-examples.html">here</a>.
+     Examples of usage and all options description is <a href="https://roman-ivanov.blogspot.com/2014/01/confusing-condition-check-examples.html">here</a>.
    <br/>
    <br/>
    <br/>
@@ -1072,14 +1072,14 @@ macros for "main()" method. Done by Baratali Izmailov.
 <div class="name"><span><h3>Release 1.6.0 (21/Oct/2012)</h3></span></div>
 <div class="text">
     <b>LogicConditionNeedOptimizationCheck</b> -&nbsp; This check prevents the placement of local variables and fields after calling
-methods in '&&' and '||' conditions. Done by Ilja Dubinin.&nbsp;<a href="http://sourceforge.net/p/checkstyle/patches/232/">Patch</a>.
+methods in '&&' and '||' conditions. Done by Ilja Dubinin.&nbsp;<a href="https://sourceforge.net/p/checkstyle/patches/232/">Patch</a>.
     <br/>
     <br/>
-    <b>ForbidCCommentsInMetods</b> -&nbsp; Check prevents usage of C-style (/* ... */) comments inside method body. If you have class declaration inside method body with JavaDoc you will get error too. Done by Ilja Dubinin.&nbsp;<a href="http://sourceforge.net/p/checkstyle/patches/231/">Patch</a>.
+    <b>ForbidCCommentsInMetods</b> -&nbsp; Check prevents usage of C-style (/* ... */) comments inside method body. If you have class declaration inside method body with JavaDoc you will get error too. Done by Ilja Dubinin.&nbsp;<a href="https://sourceforge.net/p/checkstyle/patches/231/">Patch</a>.
     <br/>
     <br/>
     <b>InterfaceTypeParameterNameCheck</b> -&nbsp; Checks that interface type parameter(for template) names conform to a format specified
-by the format property. Default format is ^[A-Z]$. Done by Dmitry Gridyushko.&nbsp;<a href="http://sourceforge.net/p/checkstyle/patches/227/">Patch</a>.
+by the format property. Default format is ^[A-Z]$. Done by Dmitry Gridyushko.&nbsp;<a href="https://sourceforge.net/p/checkstyle/patches/227/">Patch</a>.
     <br/>
     <br/>
 </div>
@@ -1100,7 +1100,7 @@ main project and ease code managment and ease new developers unserstanding of pr
  inner classes (Serializable interface are default if methods readObject() or writeObject() are not override in class). Check has option, that allow
  implementation only one method, if it true, but if it false - class must implement both methods. For more information read
  "Effective Java (2nd edition)" chapter 11, item 74, page 294. Done by Ilia Dubinin.&nbsp;
-<a href="http://sourceforge.net/tracker/?func=detail&aid=3413512&group_id=29721&atid=397081">issue</a>
+<a href="https://sourceforge.net/tracker/?func=detail&aid=3413512&group_id=29721&atid=397081">issue</a>
 <br/>
 <br/>
     <b>IllegalCatchCheck</b> -&nbsp;Minor fix for default values. Done by Daniil Yaroslavtsev.&nbsp;
@@ -1146,7 +1146,7 @@ main project and ease code managment and ease new developers unserstanding of pr
 <br/>
     <b>AbbreviationAsWordInNameCheck</b> -&nbsp;XMLReader should be names like XmlReader.
 		    Issue for ignoring methods with annotation @Override was fixed. Done by Daniil Yaroslavtsev.&nbsp;
-<a href="http://sourceforge.net/tracker/index.php?func=detail&aid=3300836&group_id=29721&atid=397081">issue</a>
+<a href="https://sourceforge.net/tracker/index.php?func=detail&aid=3300836&group_id=29721&atid=397081">issue</a>
 <br/>
 <br/>
     </div>
@@ -1157,7 +1157,7 @@ main project and ease code managment and ease new developers unserstanding of pr
 <div class="text">
 <b>ForbidAnnotationCheck</b> -&nbsp;Forbid specific annotation for field/method, e.g. forbid @Autowired
 annotation for private field. Done by&nbsp;Victor Hidoyatov.&nbsp;
-<a href="http://sourceforge.net/tracker/index.php?func=detail&amp;aid=3165196&amp;group_id=29721&amp;atid=397081">issue</a>
+<a href="https://sourceforge.net/tracker/index.php?func=detail&amp;aid=3165196&amp;group_id=29721&amp;atid=397081">issue</a>
 <br/>
 <br/>
 <b>AvoidConstantsInInterfacesCheck</b> - avoid declaration of constants in interfaces. Done by&nbsp;Vladimir Svikhunov.
@@ -1181,7 +1181,7 @@ Done by Daniil Yaroslavtsev.&nbsp;
 <br/>
 <b>OverridableMethodInConstructorCheck</b> -&nbsp;Do not use protected/public method in C-tor.
 Use only private and final.&nbsp;Check all call hierarchy from c-tor to avoid: c-tor -&gt; private -&gt; public/protected.
-Done by Daniil Yaroslavtsev. (<a href="http://sourceforge.net/tracker/?func=detail&amp;aid=3103877&amp;group_id=29721&amp;atid=397081">issue</a>.
+Done by Daniil Yaroslavtsev. (<a href="https://sourceforge.net/tracker/?func=detail&amp;aid=3103877&amp;group_id=29721&amp;atid=397081">issue</a>.
 <br/>
 <br/>
 <b>ReturnBooleanFromTernary</b> -&nbsp;It is a bad practice to return boolean values from ternary operations.
@@ -1191,7 +1191,7 @@ Just use the value inside branch instead. Done by Ivan Sopov.
 <b>ReturnNullInsteadOfBoolean</b> - Arguably it is the matter of style to use Boolean for ternary logic or enum.
 And since all the information is in the single file and even in the single method,
 I think that checkstyle is capable of doing this. Done by Ivan Sopov.
-(<a href="http://sourceforge.net/tracker/?func=detail&amp;aid=3189246&amp;group_id=29721&amp;atid=397081">issue</a>)
+(<a href="https://sourceforge.net/tracker/?func=detail&amp;aid=3189246&amp;group_id=29721&amp;atid=397081">issue</a>)
 <br/>
 <br/>
 <b>VariableDeclarationUsageDistanceCheck</b> - check distance between declaration of variable
@@ -1202,7 +1202,7 @@ Done by Ruslan Diachenko.&nbsp;
 <br/>
 <b>AbbreviationAsWordInNameCheck</b> -&nbsp;XMLReader should be names like XmlReader.
 Checks names for fields, methods , ....... . Few ignore options. Done by Roman Ivanov.
-(<a href="http://sourceforge.net/tracker/?func=detail&amp;aid=3300836&amp;group_id=29721&amp;atid=397081">issue</a>).
+(<a href="https://sourceforge.net/tracker/?func=detail&amp;aid=3300836&amp;group_id=29721&amp;atid=397081">issue</a>).
 <br/>
 </div>
 </div>
@@ -1212,20 +1212,20 @@ Checks names for fields, methods , ....... . Few ignore options. Done by Roman I
 <div class="text">
 AvoidNotShortCircuitOperatorsForBooleanCheck - check to force user not to use ShortCircuit operators ("|", "&" for boolean calculations)
 . Done by Daniil Yaroslavtsev.
-<a href="http://sourceforge.net/tracker/?func=detail&aid=3197134&group_id=29721&atid=397080">patch</a>
+<a href="https://sourceforge.net/tracker/?func=detail&aid=3197134&group_id=29721&atid=397080">patch</a>
 <br/>
 <br/>
 MultipleStringLiteralsExtendedCheck - extension of the standart check, newoption was added to highlight all duplicated. Done by Yury Balahonov.
-<a href="http://sourceforge.net/tracker/?func=detail&aid=3184230&group_id=29721&atid=397080">patch</a>
+<a href="https://sourceforge.net/tracker/?func=detail&aid=3184230&group_id=29721&atid=397080">patch</a>
 <br/>
 <br/>
 MultipleVariableDeclarationsExtendedCheck - stndard check + option to ignore while/for. Done by Daniil Yaroslavtsev.
-<a href="http://sourceforge.net/tracker/?func=detail&aid=3146159&group_id=29721&atid=397080">patch</a>
+<a href="https://sourceforge.net/tracker/?func=detail&aid=3146159&group_id=29721&atid=397080">patch</a>
 
 <br/>
 <br/>
 UnnecessaryParenthesesExtendedCheck - standart check + option to ignore some arguable cases. Dmitriy Antonenko.
-<a href="http://sourceforge.net/tracker/?func=detail&aid=3211385&group_id=29721&atid=397080">patch</a>
+<a href="https://sourceforge.net/tracker/?func=detail&aid=3211385&group_id=29721&atid=397080">patch</a>
 </div>
 </div>
 
@@ -1233,40 +1233,40 @@ UnnecessaryParenthesesExtendedCheck - standart check + option to ignore some arg
 <div class="name"><span><h3>Release 1.0.1 (21/Sept/2010)</h3></span></div>
 <div class="text">
 CustomDeclarationOrderCheck - check to adjust class structure to make it more predictable.
-Done by Danil Lopatin. <a href="http://habrahabr.ru/blogs/java/111739/">acticle in russian</a>
-<a href="http://sourceforge.net/tracker/?func=detail&aid=3044455&group_id=29721&atid=397080">patch and example of config</a>
+Done by Danil Lopatin. <a href="https://habrahabr.ru/blogs/java/111739/">acticle in russian</a>
+<a href="https://sourceforge.net/tracker/?func=detail&aid=3044455&group_id=29721&atid=397080">patch and example of config</a>
 <br/>
 <br/>
 InnerClassCheck - force user to place inner classes at the bottom ofthe class. Done by Ruslan Dyachenko.
-<a href="http://sourceforge.net/tracker/?func=detail&aid=3027391&group_id=29721&atid=397080">patch</a>
+<a href="https://sourceforge.net/tracker/?func=detail&aid=3027391&group_id=29721&atid=397080">patch</a>
 <br/>
 <br/>
 AbstractClassNameExtendedCheck - extension to check if you named class AbstractXXXXXX then force user to keep it "abstract". Done by Danil Lopatin.
-<a href="http://sourceforge.net/tracker/?func=detail&aid=3043752&group_id=29721&atid=397080">patch</a>
+<a href="https://sourceforge.net/tracker/?func=detail&aid=3043752&group_id=29721&atid=397080">patch</a>
 <br/>
 <br/>
 LineLengthExtendedCheck - extension of standard check with a lot of ignore option. Done by Ruslan Dyachenko.
-<a href="http://sourceforge.net/tracker/?func=detail&aid=3044164&group_id=29721&atid=397080">patch</a>
+<a href="https://sourceforge.net/tracker/?func=detail&aid=3044164&group_id=29721&atid=397080">patch</a>
 </div>
 </div>
 
 	<h2>Examples and ideas</h2>
 	Examples of how to use SevNTU-Checkstyle with Maven, Ant or Gradle you can find at <a href="https://github.com/sevntu-checkstyle/checkstyle-samples">checkstyle-samples</a> repo.
-    <p><a href="http://sevntu-checkstyle.github.com/sevntu.checkstyle/gsoc-2013-ideas.html">GSOC 2013 ideas</a>
+    <p><a href="https://sevntu-checkstyle.github.com/sevntu.checkstyle/gsoc-2013-ideas.html">GSOC 2013 ideas</a>
 
     <h2>Download</h2>
     <p>
       You can download this project in either
-      <a href="http://github.com/sevntu-checkstyle/sevntu.checkstyle/zipball/master">zip</a> or
-      <a href="http://github.com/sevntu-checkstyle/sevntu.checkstyle/tarball/master">tar</a> formats.
+      <a href="https://github.com/sevntu-checkstyle/sevntu.checkstyle/zipball/master">zip</a> or
+      <a href="https://github.com/sevntu-checkstyle/sevntu.checkstyle/tarball/master">tar</a> formats.
     </p>
-    <p>You can also clone the project with <a href="http://git-scm.com">Git</a>
+    <p>You can also clone the project with <a href="https://git-scm.com">Git</a>
       by running:
       <pre style="border-bottom-style: dashed; border-top-style: dashed; border-left-color: #E8F2FC; border-top-color: #E8F2FC; border-left-style: dashed; border-right-color: #E8F2FC; border-right-style: dashed; border-bottom-color: #E8F2FC; border-bottom-width: medium; border-right-width: medium; border-left-width: medium; border-top-width: medium; width:85%;">$ git clone git://github.com/sevntu-checkstyle/sevntu.checkstyle</pre>
     </p>
 
     <div class="footer">
-      Get the source code on GitHub : <a href="http://github.com/sevntu-checkstyle/sevntu.checkstyle">sevntu-checkstyle/sevntu.checkstyle</a>
+      Get the source code on GitHub : <a href="https://github.com/sevntu-checkstyle/sevntu.checkstyle">sevntu-checkstyle/sevntu.checkstyle</a>
     </div>
     <br/>
   </div>

--- a/index.html
+++ b/index.html
@@ -1,12 +1,10 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN"
-	"http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-
-<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+<!doctype html>
+<html lang="en">
 <head>
-	<meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
-
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width,initial-scale=1.0, minimum-scale=1.0">
+    <meta http-equiv="X-UA-Compatible" content="ie=edge">
 	<title>sevntu-checkstyle/sevntu.checkstyle @ GitHub</title>
-
     <script type="text/Javascript" src="//ajax.googleapis.com/ajax/libs/jquery/3.2.1/jquery.min.js"></script>
 
 <style type="text/css">

--- a/index.html
+++ b/index.html
@@ -13,7 +13,7 @@
 body {
   margin-top: 1.0em;
   background-color: #E8F2FC;
-  font-family: Helvetica, Arial, FreeSans, san-serif;
+    font-family: Helvetica, Arial, FreeSans, sans-serif;
   color: #000;
 }
 

--- a/index.html
+++ b/index.html
@@ -7,7 +7,7 @@
 
 	<title>sevntu-checkstyle/sevntu.checkstyle @ GitHub</title>
 
-	<script type="text/Javascript" src="http://ajax.googleapis.com/ajax/libs/jquery/1.3.2/jquery.min.js"></script>
+    <script type="text/Javascript" src="//ajax.googleapis.com/ajax/libs/jquery/3.2.1/jquery.min.js"></script>
 
 <style type="text/css">
 body {
@@ -90,6 +90,10 @@ hr {
   font-style: italic;
 }
 
+.spoiler:hover h3{
+    color: #1D4875;
+}
+
 div.spoiler div.name {
 	cursor: pointer;
     height:auto;
@@ -134,52 +138,35 @@ img.darkShadowed {
 
   (function() {
     var ga = document.createElement('script'); ga.type = 'text/javascript'; ga.async = true;
-    ga.src = ('https:' == document.location.protocol ? 'https://ssl' : 'http://www') + '.google-analytics.com/ga.js';
+    ga.src = 'https://ssl.google-analytics.com/ga.js';
     var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(ga, s);
   })();
 
 </script>
 
 <script type="text/Javascript">
-		$(document).ready(function() {
+  $(function () {
+    // Configure spoilers. Spoilers are configured by their classes:
+    // openOnHover color_on_hover pre_opened_spoiler
+    var fadeTime = 300;
 
-			// Configure spoilers. Spoilers are configured by their classes:
-			// openOnHover color_on_hover pre_opened_spoiler
-			var fadeTime = 300;
+    // Set the toggle operarions (spoilers fading)
+    var spoilers = $("div.spoiler div.name span");
+    var flag = false;
+    spoilers.on('click', function () {
+      var elementToToggle = $(this).parent("div.name").parent("div.spoiler").children("div.text");
+      if (flag === false) {
+        elementToToggle.fadeIn(fadeTime);
+      } else {
+        elementToToggle.fadeOut(fadeTime);
+      }
+      flag = !flag;
+    });
 
-			// Set the toggle operarions (spoilers fading)
-			$("div.spoiler div.name span").toggle(
-			function() {
-				$(this).parent("div.name").parent("div.spoiler").children("div.text").fadeIn(fadeTime);
-			}
-			,function() {
-				$(this).parent("div.name").parent("div.spoiler").children("div.text").fadeOut(fadeTime);
-			});
-
-			// Set mouseOver operations (coloring/opening on hover)
-			$("div.spoiler div.name span").mouseover(function() {
-
-			    var openOnHover = $(this).parent("div.name").parent("div.spoiler").hasClass("openOnHower");
-		        var color_on_hover = $(this).parent("div.name").parent("div.spoiler").hasClass("color_on_hover");
-
-				if (color_on_hover) {
-				    $(this).children().css("color", "#1D4875");
-			    }
-				if (openOnHover) {
-					 $(this).parent("div.name").parent("div.spoiler").children("div.text").fadeIn(fadeTime);
-				}
-
-			}).mouseout(function() {
-				var color_on_hover = $(this).parent("div.name").parent("div.spoiler").hasClass("color_on_hover");
-				if (color_on_hover) {
-					$(this).children().css("color", "#242630");
-	 		    }
-			});
-
-		    // Open spoilers with 'pre-opened' class
-			$(".pre_opened_spoiler").children("div.text").fadeIn(fadeTime);
-			// End configure spoilers
-		});
+    // Open spoilers with 'pre-opened' class
+    $(".pre_opened_spoiler").children("div.text").fadeIn(fadeTime);
+    // End configure spoilers
+  });
 	</script>
 
 <body>
@@ -256,7 +243,7 @@ Full list of Checks and examples of usage could be found at
 
 <h2> New and noteworthy</h2>
 <!--
-<div id="X.Y.Z" class="spoiler color_on_hover pre_opened_spoiler">
+<div id="X.Y.Z" class="spoiler pre_opened_spoiler">
 <div class="name"><span><h3>Release X.Y.Z (9/Oct/2014)</h3></span></div>
 <div class="text">
      <b>new FooBarCheck</b> -&nbsp; %DESCRIPTION%. Done by %AUTHOR%.
@@ -266,7 +253,7 @@ Full list of Checks and examples of usage could be found at
 </div>
 </div>
 -->
-<div id="1.24.2" class="spoiler color_on_hover pre_opened_spoiler">
+      <div id="1.24.2" class="spoiler pre_opened_spoiler">
 <div class="name"><span><h3>Release 1.24.2 (20/July/2017)</h3></span></div>
 <div class="text">
      <b>internal updates</b> update to IllegalCatchExtendedCheck and NestedSwitchCheck to avoid usage of deprecated parent class. Done by rnveach.
@@ -275,7 +262,7 @@ Full list of Checks and examples of usage could be found at
 </div>
 </div>
 
-<div id="1.24.1" class="spoiler color_on_hover pre_opened_spoiler">
+      <div id="1.24.1" class="spoiler pre_opened_spoiler">
 <div class="name"><span><h3>Release 1.24.1 (2/July/2017)</h3></span></div>
 <div class="text">
      <b>bug</b> -&nbsp; added get acceptable and required tokens in all checks. Done by rnveach. <a href="https://github.com/sevntu-checkstyle/sevntu.checkstyle/issues/595">More</a>
@@ -289,7 +276,7 @@ Full list of Checks and examples of usage could be found at
 </div>
 </div>
 
-<div id="1.24.0" class="spoiler color_on_hover pre_opened_spoiler">
+      <div id="1.24.0" class="spoiler pre_opened_spoiler">
 <div class="name"><span><h3>Release 1.24.0 (27/May/2017)</h3></span></div>
 
 <div class="text">
@@ -369,7 +356,7 @@ Full list of Checks and examples of usage could be found at
 </div>
 </div>
 
-<div id="1.23.1" class="spoiler color_on_hover pre_opened_spoiler">
+      <div id="1.23.1" class="spoiler pre_opened_spoiler">
 <div class="name"><span><h3>Release 1.23.1 (25/Feb/2017)</h3></span></div>
 <div class="text">
      <b>internal updates</b> config: define license version in pom.xml as LGPL-2.1+;
@@ -381,7 +368,7 @@ Full list of Checks and examples of usage could be found at
 </div>
 </div>
 
-<div id="1.23.0" class="spoiler color_on_hover pre_opened_spoiler">
+      <div id="1.23.0" class="spoiler pre_opened_spoiler">
 <div class="name"><span><h3>Release 1.23.0 (10/Dec/2016)</h3></span></div>
 <div class="text">
      <b>bug</b> -&nbsp; ForbidCertainImportsCheck: null excludes gives no violations. Done by rnveach. <a href="https://github.com/sevntu-checkstyle/sevntu.checkstyle/issues/552">More</a>
@@ -428,7 +415,7 @@ Full list of Checks and examples of usage could be found at
 </div>
 </div>
 
-<div id="1.22.0" class="spoiler color_on_hover pre_opened_spoiler">
+      <div id="1.22.0" class="spoiler pre_opened_spoiler">
 <div class="name"><span><h3>Release 1.22.0 (19/Nov/2016)</h3></span></div>
 <div class="text">
      <b>new ForbidAnnotationElementValueCheck</b> -&nbsp; Forbids specific element value for specific annotation. Done by rnveach. <a href="https://github.com/sevntu-checkstyle/sevntu.checkstyle/issues/108">More</a>
@@ -457,7 +444,7 @@ Full list of Checks and examples of usage could be found at
 </div>
 </div>
 
-<div id="1.21.1" class="spoiler color_on_hover pre_opened_spoiler">
+      <div id="1.21.1" class="spoiler pre_opened_spoiler">
 <div class="name"><span><h3>Release 1.21.1 (15/Oct/2016)</h3></span></div>
 <div class="text">
      <b>update for sevntu-checkstyle-idea-extension</b> -&nbsp; Idea Extension is incorrectly build by maven. Done by KTannenberg. <a href="https://github.com/sevntu-checkstyle/sevntu.checkstyle/issues/468">More</a>
@@ -471,7 +458,7 @@ Full list of Checks and examples of usage could be found at
 </div>
 </div>
 
-<div id="1.21.0" class="spoiler color_on_hover pre_opened_spoiler">
+      <div id="1.21.0" class="spoiler pre_opened_spoiler">
 <div class="name"><span><h3>Release 1.21.0 (08/June/2016)</h3></span></div>
 <div class="text">
      <b>new UniformEnumValueCheck</b> -&nbsp; Check forces enum values to match one of the specified patterns and forces all the values to follow only one of the specified patterns.
@@ -491,7 +478,7 @@ Full list of Checks and examples of usage could be found at
 </div>
 </div>
 
-<div id="1.20.0" class="spoiler color_on_hover pre_opened_spoiler">
+      <div id="1.20.0" class="spoiler pre_opened_spoiler">
 <div class="name"><span><h3>Release 1.20.0 (25/March/2016)</h3></span></div>
 <div class="text">
      <b>new ConstructorWithoutParamsCheck</b> -&nbsp; This check prohibits usage of parameterless constructors, including the default ones. Rationale: constructors of certain classes must always take arguments to properly instantiate objects. Done by Sergey Dudoladov. <a href="https://github.com/sevntu-checkstyle/sevntu.checkstyle/issues/412">More</a>
@@ -505,7 +492,7 @@ Full list of Checks and examples of usage could be found at
 </div>
 </div>
 
-<div id="1.19.2" class="spoiler color_on_hover pre_opened_spoiler">
+      <div id="1.19.2" class="spoiler pre_opened_spoiler">
 <div class="name"><span><h3>Release 1.19.2 (20/March/2016)</h3></span></div>
 <div class="text">
      <b>bug</b> -&nbsp; False positive in DiamondOperatorForVariableDefinitionCheck . Done by Vladislav Lisetskiy. <a href="https://github.com/sevntu-checkstyle/sevntu.checkstyle/issues/430">More</a>
@@ -514,7 +501,7 @@ Full list of Checks and examples of usage could be found at
 </div>
 </div>
 
-<div id="1.19.1" class="spoiler color_on_hover pre_opened_spoiler">
+      <div id="1.19.1" class="spoiler pre_opened_spoiler">
 <div class="name"><span><h3>Release 1.19.1 (10/March/2016)</h3></span></div>
 <div class="text">
      <b>bug </b> -&nbsp; Sevntu Sonar plugin 1.19.0 does not work with Sonar 5.3. Done by Charlie Pai. <a href="https://github.com/sevntu-checkstyle/sevntu.checkstyle/issues/436">More</a>
@@ -528,7 +515,7 @@ Full list of Checks and examples of usage could be found at
 </div>
 </div>
 
-<div id="1.19.0" class="spoiler color_on_hover pre_opened_spoiler">
+      <div id="1.19.0" class="spoiler pre_opened_spoiler">
 <div class="name"><span><h3>Release 1.19.0 (8/March/2016)</h3></span></div>
 <div class="text">
      <b>bug </b> -&nbsp; NumericLiteralNeedsUnderscore: New option to skip fields by regexp. Done by Charlie Pai. <a href="https://github.com/sevntu-checkstyle/sevntu.checkstyle/issues/425">More</a>
@@ -542,7 +529,7 @@ Full list of Checks and examples of usage could be found at
 </div>
 </div>
 
-<div id="1.18.0" class="spoiler color_on_hover pre_opened_spoiler">
+      <div id="1.18.0" class="spoiler pre_opened_spoiler">
 <div class="name"><span><h3>Release 1.18.0 (17/January/2016)</h3></span></div>
 <div class="text">
      <b>new SingleBreakOrContinue</b> -&nbsp; This check restricts the number of break and continue statements inside cycle body (only one is allowed). Done by Yasser Aziza. <a href="https://github.com/sevntu-checkstyle/sevntu.checkstyle/issues/374">More</a>
@@ -561,7 +548,7 @@ Full list of Checks and examples of usage could be found at
 </div>
 </div>
 
-<div id="1.17.1" class="spoiler color_on_hover pre_opened_spoiler">
+      <div id="1.17.1" class="spoiler pre_opened_spoiler">
 <div class="name"><span><h3>Release 1.17.1 (14/December/2015)</h3></span></div>
 <div class="text">
      <b> bug </b> -&nbsp; Fix false-positive on methods called from 'super' at StaticMethodCandidateCheck. Done by Vladislav Lisetskiy.
@@ -584,7 +571,7 @@ Full list of Checks and examples of usage could be found at
 
 </div>
 
-<div id="1.17.0" class="spoiler color_on_hover pre_opened_spoiler">
+      <div id="1.17.0" class="spoiler pre_opened_spoiler">
 <div class="name"><span><h3>Release 1.17.0 (8/November/2015)</h3></span></div>
 <div class="text">
      <b>new StaticMethodCandidateCheck </b> -&nbsp; Checks whether private methods can be declared as static. Done by Vladislav Lisetskiy. <a href="https://github.com/sevntu-checkstyle/sevntu.checkstyle/issues/339">More</a>
@@ -599,7 +586,7 @@ Full list of Checks and examples of usage could be found at
 </div>
 </div>
 
-<div id="1.16.1" class="spoiler color_on_hover pre_opened_spoiler">
+      <div id="1.16.1" class="spoiler pre_opened_spoiler">
 <div class="name"><span><h3>Release 1.16.1 (28/October/2015)</h3></span></div>
 <div class="text">
      <b> bug </b> -&nbsp; Cannot initialize module SingleSpaceSeparator. Done by Roman Ivanov. <a href="https://github.com/sevntu-checkstyle/sevntu.checkstyle/issues/385">More</a>
@@ -608,7 +595,7 @@ Full list of Checks and examples of usage could be found at
 </div>
 </div>
 
-<div id="1.16.0" class="spoiler color_on_hover pre_opened_spoiler">
+      <div id="1.16.0" class="spoiler pre_opened_spoiler">
 <div class="name"><span><h3>Release 1.16.0 (25/October/2015)</h3></span></div>
 <div class="text">
      <b> new SingleSpaceSeparatorCheck </b> -&nbsp; Checks that if tokens are separated by whitespaces, it has to be a single space. Done by Robert Whitebit.
@@ -622,7 +609,7 @@ Full list of Checks and examples of usage could be found at
 </div>
 </div>
 
-<div id="1.15.0" class="spoiler color_on_hover pre_opened_spoiler">
+      <div id="1.15.0" class="spoiler pre_opened_spoiler">
 <div class="name"><span><h3>Release 1.15.0 (8/October/2015)</h3></span></div>
 <div class="text">
      <b> version bump </b> -&nbsp; Version bump to Eclipse-CS 6.11.0 . Done by David Ignjić.
@@ -641,7 +628,7 @@ Full list of Checks and examples of usage could be found at
 </div>
 </div>
 
-<div id="1.14.0" class="spoiler color_on_hover pre_opened_spoiler">
+      <div id="1.14.0" class="spoiler pre_opened_spoiler">
 <div class="name"><span><h3>Release 1.14.0 (26/September/2015)</h3></span></div>
 <div class="text">
      <b> version bump </b> -&nbsp; Version bump to Eclipse-CS 6.9.0 . Done by Roman Ivanov.
@@ -650,7 +637,7 @@ Full list of Checks and examples of usage could be found at
 </div>
 </div>
 
-<div id="1.13.6" class="spoiler color_on_hover pre_opened_spoiler">
+      <div id="1.13.6" class="spoiler pre_opened_spoiler">
 <div class="name"><span><h3>Release 1.13.6 (7/September/2015)</h3></span></div>
 <div class="text">
      <b> bug </b> -&nbsp;  LogicConditionNeedOptimizationCheck doesn't give violation when it is expected. Done by Vadim Panasiuk.
@@ -672,7 +659,7 @@ Full list of Checks and examples of usage could be found at
 </div>
 </div>
 
-<div id="1.13.5" class="spoiler color_on_hover pre_opened_spoiler">
+      <div id="1.13.5" class="spoiler pre_opened_spoiler">
 <div class="name"><span><h3>Release 1.13.5 (23/June/2015)</h3></span></div>
 <div class="text">
      <b> bug </b> -&nbsp;  sevntu-checks are failed within Sonar because of the outdated checkstyle-extensions.xml. Done by Ruslan Diachenko.
@@ -682,7 +669,7 @@ Full list of Checks and examples of usage could be found at
 </div>
 </div>
 
-<div id="1.13.4" class="spoiler color_on_hover pre_opened_spoiler">
+      <div id="1.13.4" class="spoiler pre_opened_spoiler">
 <div class="name"><span><h3>Release 1.13.4 (21/June/2015)</h3></span></div>
 <div class="text">
      <b> bug </b> -&nbsp; Sonar fails to start with 'Extension to Sonar Checkstyle Plugin 1.13.3'. Done by Ruslan Diachenko.
@@ -692,7 +679,7 @@ Full list of Checks and examples of usage could be found at
 </div>
 </div>
 
-<div id="1.13.3" class="spoiler color_on_hover pre_opened_spoiler">
+      <div id="1.13.3" class="spoiler pre_opened_spoiler">
 <div class="name"><span><h3>Release 1.13.3 (7/June/2015)</h3></span></div>
 <div class="text">
      <b> bug </b> -&nbsp; ReturnNullInsteadOfBoolean:   Remove FastStack reference that was removed from checkstyle 6.7. Done by Roman Ivanov.
@@ -702,7 +689,7 @@ Full list of Checks and examples of usage could be found at
 </div>
 </div>
 
-<div id="1.13.2" class="spoiler color_on_hover pre_opened_spoiler">
+      <div id="1.13.2" class="spoiler pre_opened_spoiler">
 <div class="name"><span><h3>Release 1.13.2 (7/June/2015)</h3></span></div>
 <div class="text">
      <b> bug </b> -&nbsp;  DiamondOperatorForVariableDefinitionCheck throws NullPointerException. Done by Roman Ivanov.
@@ -712,7 +699,7 @@ Full list of Checks and examples of usage could be found at
 </div>
 </div>
 
-<div id="1.13.1" class="spoiler color_on_hover pre_opened_spoiler">
+      <div id="1.13.1" class="spoiler pre_opened_spoiler">
 <div class="name"><span><h3>Release 1.13.1 (6/June/2015)</h3></span></div>
 <div class="text">
      <b> bug </b> -&nbsp; PublicReferenceToPrivateTypeCheck fails on all files in eclipse-cs. Done by Roman Ivanov.
@@ -722,7 +709,7 @@ Full list of Checks and examples of usage could be found at
 </div>
 </div>
 
-<div id="1.13.0" class="spoiler color_on_hover pre_opened_spoiler">
+      <div id="1.13.0" class="spoiler pre_opened_spoiler">
 <div class="name"><span><h3>Release 1.13.0 (16/May/2015)</h3></span></div>
 <div class="text">
      <b>VariableDeclarationUsageDistanceCheck</b> -&nbsp; was moved to Checkstyle library. Done by Roamn Ivanov.
@@ -796,7 +783,7 @@ Full list of Checks and examples of usage could be found at
 </div>
 </div>
 
-<div id="1.12.0" class="spoiler color_on_hover pre_opened_spoiler">
+      <div id="1.12.0" class="spoiler pre_opened_spoiler">
 <div class="name"><span><h3>Release 1.12.0 (9/Oct/2014)</h3></span></div>
 <div class="text">
      <b>Update in Redundant Return Check</b> -&nbsp; Redundant Return Check was retested and fixed. Done by Alexey Nesterenko.


### PR DESCRIPTION
Updates jQuery from the ancient 1.3.2 version to the latest one. I've also replace a jQuery hover effect with a CSS version.

Another change is that _all_ resources are loaded via HTTPS. (This was an issue with the current version: Chrome for example blocks jQuery (loaded via HTTP) when opening the site via HTTPS.)

I've also changed to DocType from XHTML 1.0 to HTML 5.