### PR TITLE
Issue #630: use checkstyle's utils instead of copying them

### DIFF
--- a/sevntu-checks/src/test/java/com/github/sevntu/checkstyle/internal/CheckUtil.java
+++ b/sevntu-checks/src/test/java/com/github/sevntu/checkstyle/internal/CheckUtil.java
@@ -22,7 +22,6 @@ package com.github.sevntu.checkstyle.internal;
 import java.io.File;
 import java.io.IOException;
 import java.lang.reflect.Field;
-import java.lang.reflect.Modifier;
 import java.text.MessageFormat;
 import java.util.HashSet;
 import java.util.Properties;
@@ -36,12 +35,8 @@ import org.w3c.dom.Element;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
 
-import com.google.common.collect.ImmutableSet;
-import com.google.common.reflect.ClassPath;
-import com.puppycrawl.tools.checkstyle.api.AbstractCheck;
-import com.puppycrawl.tools.checkstyle.api.AutomaticBean;
-import com.puppycrawl.tools.checkstyle.api.BeforeExecutionFileFilter;
-import com.puppycrawl.tools.checkstyle.api.Filter;
+import com.puppycrawl.tools.checkstyle.PackageNamesLoader;
+import com.puppycrawl.tools.checkstyle.utils.ModuleReflectionUtils;
 
 public final class CheckUtil {
 
@@ -106,23 +101,19 @@ public final class CheckUtil {
     /**
      * Gets the checkstyle's non abstract checks.
      * @return the set of checkstyle's non abstract check classes.
-     * @throws IOException if the attempt to read class path resources failed.
+     * @throws Exception if the attempt to read class path resources failed.
      */
-    public static Set<Class<?>> getCheckstyleChecks() throws IOException {
+    public static Set<Class<?>> getCheckstyleChecks() throws Exception {
         final Set<Class<?>> checkstyleChecks = new HashSet<>();
 
         final ClassLoader loader = Thread.currentThread()
                 .getContextClassLoader();
-        final ClassPath classpath = ClassPath.from(loader);
-        final String packageName = "com.github.sevntu.checkstyle";
-        final ImmutableSet<ClassPath.ClassInfo> checkstyleClasses = classpath
-                .getTopLevelClassesRecursive(packageName);
+        final Set<Class<?>> checkstyleModules = ModuleReflectionUtils.getCheckstyleModules(
+                PackageNamesLoader.getPackageNames(loader), loader);
 
-        for (ClassPath.ClassInfo clazz : checkstyleClasses) {
-            final String className = clazz.getSimpleName();
-            final Class<?> loadedClass = clazz.load();
-            if (isCheckstyleNonAbstractCheck(loadedClass, className)) {
-                checkstyleChecks.add(loadedClass);
+        for (Class<?> clazz : checkstyleModules) {
+            if (ModuleReflectionUtils.isCheckstyleCheck(clazz)) {
+                checkstyleChecks.add(clazz);
             }
         }
         return checkstyleChecks;
@@ -158,24 +149,12 @@ public final class CheckUtil {
      * checkstyle's filters and SuppressWarningsHolder class.
      *
      * @return a set of checkstyle's modules names.
-     * @throws IOException if the attempt to read class path resources failed.
+     * @throws Exception if the attempt to read class path resources failed.
      */
-    public static Set<Class<?>> getCheckstyleModules() throws IOException {
-        final Set<Class<?>> checkstyleModules = new HashSet<>();
-
+    public static Set<Class<?>> getCheckstyleModules() throws Exception {
         final ClassLoader loader = Thread.currentThread().getContextClassLoader();
-        final ClassPath classpath = ClassPath.from(loader);
-        final String packageName = "com.github.sevntu.checkstyle.checks";
-        final ImmutableSet<ClassPath.ClassInfo> checkstyleClasses = classpath
-                .getTopLevelClassesRecursive(packageName);
-
-        for (ClassPath.ClassInfo clazz : checkstyleClasses) {
-            final Class<?> loadedClass = clazz.load();
-            if (isCheckstyleModule(loadedClass)) {
-                checkstyleModules.add(loadedClass);
-            }
-        }
-        return checkstyleModules;
+        return ModuleReflectionUtils.getCheckstyleModules(
+                PackageNamesLoader.getPackageNames(loader), loader);
     }
 
     /**
@@ -204,72 +183,6 @@ public final class CheckUtil {
         }
 
         return checkstyleMessages;
-    }
-
-    /**
-     * Checks whether a class may be considered as the checkstyle module.
-     * Checkstyle's modules are nonabstract classes which names end with
-     * 'Check', do not contain the word 'Input' (are not input files for UTs),
-     * checkstyle's filters, checkstyle's file filters and
-     * SuppressWarningsHolder class.
-     *
-     * @param loadedClass class to check.
-     * @return true if the class may be considered as the checkstyle module.
-     */
-    private static boolean isCheckstyleModule(Class<?> loadedClass) {
-        final String className = loadedClass.getSimpleName();
-        return isCheckstyleNonAbstractCheck(loadedClass, className)
-                || isFilterModule(loadedClass, className)
-                || isFileFilterModule(loadedClass, className)
-                || "SuppressWarningsHolder".equals(className)
-                || "FileContentsHolder".equals(className);
-    }
-
-    /**
-     * Checks whether a class may be considered as the checkstyle check.
-     * Checkstyle's checks are nonabstract classes which names end with 'Check',
-     * do not contain the word 'Input' (are not input files for UTs), and extend
-     * Check.
-     *
-     * @param loadedClass class to check.
-     * @param className class name to check.
-     * @return true if a class may be considered as the checkstyle check.
-     */
-    private static boolean isCheckstyleNonAbstractCheck(Class<?> loadedClass, String className) {
-        return !Modifier.isAbstract(loadedClass.getModifiers()) && className.endsWith("Check")
-                && !className.contains("Input")
-                && AbstractCheck.class.isAssignableFrom(loadedClass);
-    }
-
-    /**
-     * Checks whether a class may be considered as the checkstyle filter.
-     * Checkstyle's filters are classes which are subclasses of AutomaticBean,
-     * implement 'Filter' interface, and which names end with 'Filter'.
-     *
-     * @param loadedClass class to check.
-     * @param className class name to check.
-     * @return true if a class may be considered as the checkstyle filter.
-     */
-    private static boolean isFilterModule(Class<?> loadedClass, String className) {
-        return Filter.class.isAssignableFrom(loadedClass)
-                && AutomaticBean.class.isAssignableFrom(loadedClass)
-                && className.endsWith("Filter");
-    }
-
-    /**
-     * Checks whether a class may be considered as the checkstyle file filter.
-     * Checkstyle's file filters are classes which are subclasses of
-     * AutomaticBean, implement 'BeforeExecutionFileFilter' interface, and which
-     * names end with 'FileFilter'.
-     *
-     * @param loadedClass class to check.
-     * @param className class name to check.
-     * @return true if a class may be considered as the checkstyle file filter.
-     */
-    private static boolean isFileFilterModule(Class<?> loadedClass, String className) {
-        return BeforeExecutionFileFilter.class.isAssignableFrom(loadedClass)
-                && AutomaticBean.class.isAssignableFrom(loadedClass)
-                && className.endsWith("FileFilter");
     }
 
     /**

--- a/sevntu-checks/src/test/java/com/github/sevntu/checkstyle/internal/ChecksTest.java
+++ b/sevntu-checks/src/test/java/com/github/sevntu/checkstyle/internal/ChecksTest.java
@@ -44,6 +44,7 @@ import org.w3c.dom.NodeList;
 import com.puppycrawl.tools.checkstyle.api.AbstractCheck;
 import com.puppycrawl.tools.checkstyle.api.AbstractFileSetCheck;
 import com.puppycrawl.tools.checkstyle.checks.javadoc.AbstractJavadocCheck;
+import com.puppycrawl.tools.checkstyle.internal.utils.XmlUtil;
 
 public final class ChecksTest {
 
@@ -97,7 +98,7 @@ public final class ChecksTest {
             final Node rule = rules.item(position);
             final Set<Node> children = XmlUtil.getChildrenElements(rule);
 
-            final String key = XmlUtil.findElementByTag(children, "key").getTextContent();
+            final String key = SevntuXmlUtil.findElementByTag(children, "key").getTextContent();
 
             final Class<?> module = findModule(modules, key);
             modules.remove(module);
@@ -105,13 +106,13 @@ public final class ChecksTest {
             Assert.assertNotNull("Unknown class found in sonar: " + key, module);
 
             final String moduleName = module.getName();
-            final Node name = XmlUtil.findElementByTag(children, "name");
+            final Node name = SevntuXmlUtil.findElementByTag(children, "name");
 
             Assert.assertNotNull(moduleName + " requires a name in sonar", name);
             Assert.assertFalse(moduleName + " requires a name in sonar", name.getTextContent()
                     .isEmpty());
 
-            final Node categoryNode = XmlUtil.findElementByTag(children, "category");
+            final Node categoryNode = SevntuXmlUtil.findElementByTag(children, "category");
 
             String expectedCategory = module.getCanonicalName();
             final int lastIndex = expectedCategory.lastIndexOf('.');
@@ -127,18 +128,18 @@ public final class ChecksTest {
             Assert.assertEquals(moduleName + " requires a valid category in sonar",
                     expectedCategory, categoryAttribute.getTextContent());
 
-            final Node description = XmlUtil.findElementByTag(children, "description");
+            final Node description = SevntuXmlUtil.findElementByTag(children, "description");
 
             Assert.assertNotNull(moduleName + " requires a description in sonar", description);
 
-            final Node configKey = XmlUtil.findElementByTag(children, "configKey");
+            final Node configKey = SevntuXmlUtil.findElementByTag(children, "configKey");
             final String expectedConfigKey = "Checker/TreeWalker/" + key;
 
             Assert.assertNotNull(moduleName + " requires a configKey in sonar", configKey);
             Assert.assertEquals(moduleName + " requires a valid configKey in sonar",
                     expectedConfigKey, configKey.getTextContent());
 
-            validateSonarProperties(module, XmlUtil.findElementsByTag(children, "param"));
+            validateSonarProperties(module, SevntuXmlUtil.findElementsByTag(children, "param"));
         }
 
         for (Class<?> module : modules) {

--- a/sevntu-checks/src/test/java/com/github/sevntu/checkstyle/internal/SevntuXmlUtil.java
+++ b/sevntu-checks/src/test/java/com/github/sevntu/checkstyle/internal/SevntuXmlUtil.java
@@ -19,57 +19,14 @@
 
 package com.github.sevntu.checkstyle.internal;
 
-import java.io.IOException;
-import java.io.StringReader;
 import java.util.HashSet;
-import java.util.LinkedHashSet;
 import java.util.Set;
 
-import javax.xml.parsers.DocumentBuilder;
-import javax.xml.parsers.DocumentBuilderFactory;
-import javax.xml.parsers.ParserConfigurationException;
-
-import org.junit.Assert;
-import org.w3c.dom.Document;
 import org.w3c.dom.Node;
-import org.xml.sax.InputSource;
-import org.xml.sax.SAXException;
 
-public final class XmlUtil {
+public final class SevntuXmlUtil {
 
-    private XmlUtil() {
-    }
-
-    public static Document getRawXml(String fileName, String code, String unserializedSource)
-            throws ParserConfigurationException {
-        Document rawXml = null;
-        try {
-            final DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
-            factory.setValidating(false);
-            factory.setNamespaceAware(true);
-
-            final DocumentBuilder builder = factory.newDocumentBuilder();
-
-            rawXml = builder.parse(new InputSource(new StringReader(code)));
-        }
-        catch (IOException | SAXException ex) {
-            Assert.fail(fileName + " has invalid xml (" + ex.getMessage() + "): "
-                    + unserializedSource);
-        }
-
-        return rawXml;
-    }
-
-    public static Set<Node> getChildrenElements(Node node) {
-        final Set<Node> result = new LinkedHashSet<>();
-
-        for (Node child = node.getFirstChild(); child != null; child = child.getNextSibling()) {
-            if (child.getNodeType() != Node.TEXT_NODE) {
-                result.add(child);
-            }
-        }
-
-        return result;
+    private SevntuXmlUtil() {
     }
 
     public static Node findElementByTag(Set<Node> nodes, String tag) {


### PR DESCRIPTION
Issue #630 

Removed some duplicated utils from checkstyle.
Renaming of `CheckUtil` will have to wait until a new checkstyle release as there are some changes I need to make in checkstyle to make this util more globally acceptable.