### PR TITLE
Issue #662: moved ForbidCCommentsInMethodsCheck to log AST

### DIFF
--- a/sevntu-checks/src/test/java/com/github/sevntu/checkstyle/checks/coding/ForbidCCommentsInMethodsCheckTest.java
+++ b/sevntu-checks/src/test/java/com/github/sevntu/checkstyle/checks/coding/ForbidCCommentsInMethodsCheckTest.java
@@ -41,14 +41,15 @@ public class ForbidCCommentsInMethodsCheckTest extends AbstractModuleTestSupport
         final DefaultConfiguration checkConfig =
                 createModuleConfig(ForbidCCommentsInMethodsCheck.class);
         final String[] expected = {
-            "10: " + warningMessage,
-            "17: " + warningMessage,
-            "26: " + warningMessage,
-            "33: " + warningMessage,
-            "45: " + warningMessage,
-            "52: " + warningMessage,
-            "61: " + warningMessage,
-            "68: " + warningMessage,
+            "10:9: " + warningMessage,
+            "17:9: " + warningMessage,
+            "26:13: " + warningMessage,
+            "33:13: " + warningMessage,
+            "45:9: " + warningMessage,
+            "52:9: " + warningMessage,
+            "61:13: " + warningMessage,
+            "68:13: " + warningMessage,
+            "78:22: " + warningMessage,
         };
         verify(checkConfig, getPath("InputForbidCCommentsInMethodsCheck.java"), expected);
     }

--- a/sevntu-checks/src/test/resources/com/github/sevntu/checkstyle/checks/coding/InputForbidCCommentsInMethodsCheck.java
+++ b/sevntu-checks/src/test/resources/com/github/sevntu/checkstyle/checks/coding/InputForbidCCommentsInMethodsCheck.java
@@ -69,3 +69,26 @@ class InnerInputForbidCCommentsInMethods2
         }
     }
 }
+class InnerInputForbidCCommentsInMethods3 {
+    /* Comment before field. */
+    private int field;
+
+    /* Comment on same line as method. */ void method1() {}
+    void method2() {} /* Comment on same line as method. */
+    void method3() { /* Comment on same line as method but inside. */ }
+
+    void method4() {
+        new innerClass() {
+            /* Comment inside anonymous class. */
+            public void innerMethod() {}
+        };
+    }
+
+    private static void /* Comment insside definition. */ method5() {}
+    /* Comment before native method. */
+    public native void method6();
+
+    private abstract class innerClass {
+        public abstract void innerMethod();
+    }
+}


### PR DESCRIPTION
Issue #662 

I rewrote the check to use `visitToken` and log on the AST instead of relying on `getFileContents()`.
Tests show no differences. I will confirm the same with regression.