### PR TITLE
Issue #572: fixed infinite loop in OverridableMethodInConstructorCheck

### DIFF
--- a/sevntu-checks/pom.xml
+++ b/sevntu-checks/pom.xml
@@ -212,7 +212,7 @@
               <regex><pattern>.*.checks.coding.ForbidThrowAnonymousExceptionsCheck</pattern><branchRate>81</branchRate><lineRate>97</lineRate></regex>
               <regex><pattern>.*.checks.coding.MapIterationInForEachLoopCheck</pattern><branchRate>90</branchRate><lineRate>98</lineRate></regex>
               <regex><pattern>.*.checks.coding.NoNullForCollectionReturnCheck</pattern><branchRate>85</branchRate><lineRate>96</lineRate></regex>
-              <regex><pattern>.*.checks.coding.OverridableMethodInConstructorCheck</pattern><branchRate>88</branchRate><lineRate>99</lineRate></regex>
+              <regex><pattern>.*.checks.coding.OverridableMethodInConstructorCheck</pattern><branchRate>94</branchRate><lineRate>99</lineRate></regex>
               <regex><pattern>.*.checks.design.HideUtilityClassConstructorCheck</pattern><branchRate>94</branchRate><lineRate>100</lineRate></regex>
             </regexes>
           </check>

--- a/sevntu-checks/src/main/java/com/github/sevntu/checkstyle/checks/coding/OverridableMethodInConstructorCheck.java
+++ b/sevntu-checks/src/main/java/com/github/sevntu/checkstyle/checks/coding/OverridableMethodInConstructorCheck.java
@@ -837,7 +837,15 @@ public class OverridableMethodInConstructorCheck extends AbstractCheck {
                 result.add(curClass);
                 baseClassName = getBaseClassName(curClass);
                 if (baseClassName != null) {
-                    curClass = getClassDef(treeRootAST, baseClassName);
+                    final DetailAST nextClass = getClassDef(treeRootAST, baseClassName);
+
+                    // prevent infinite loop with similar named classes
+                    if (nextClass == curClass) {
+                        curClass = null;
+                    }
+                    else {
+                        curClass = nextClass;
+                    }
                 }
                 else {
                     break;

--- a/sevntu-checks/src/test/java/com/github/sevntu/checkstyle/checks/coding/OverridableMethodInConstructorCheckTest.java
+++ b/sevntu-checks/src/test/java/com/github/sevntu/checkstyle/checks/coding/OverridableMethodInConstructorCheckTest.java
@@ -453,4 +453,17 @@ public class OverridableMethodInConstructorCheckTest extends AbstractModuleTestS
         verify(checkConfig, getPath("InputOverridableMethodInConstructorCheck25.java"), expected);
     }
 
+    @Test
+    public final void testExtendsSimilarNamedClass() throws Exception {
+        final DefaultConfiguration checkConfig =
+                createModuleConfig(OverridableMethodInConstructorCheck.class);
+        checkConfig.addAttribute("checkCloneMethod", "true");
+        checkConfig.addAttribute("checkReadObjectMethod", "true");
+        checkConfig.addAttribute("matchMethodsByArgCount", "true");
+
+        final String[] expected = {};
+
+        verify(checkConfig, getPath("InputOverridableMethodInConstructorCheck28.java"), expected);
+    }
+
 }

--- a/sevntu-checks/src/test/resources/com/github/sevntu/checkstyle/checks/coding/InputOverridableMethodInConstructorCheck28.java
+++ b/sevntu-checks/src/test/resources/com/github/sevntu/checkstyle/checks/coding/InputOverridableMethodInConstructorCheck28.java
@@ -1,0 +1,19 @@
+package com.github.sevntu.checkstyle.checks.coding;
+
+import java.io.IOException;
+
+public class InputOverridableMethodInConstructorCheck28 {
+    class InputStream extends java.io.InputStream {
+        InputStream() {
+            method();
+        }
+
+        @Override
+        public int read() throws IOException {
+            return 0;
+        }
+    }
+
+    public void method() {
+    };
+}


### PR DESCRIPTION
Issue #572 

Added fix to prevent infinite loop.

Will provide limited difference regression and no exception report.