### PR TITLE
config: fixed incorrect eclipse-cs version

### DIFF
--- a/sevntu-checks/pom.xml
+++ b/sevntu-checks/pom.xml
@@ -16,7 +16,7 @@
   <properties>
     <project.build.sourceEncoding>iso-8859-1</project.build.sourceEncoding>
     <!-- It is compile dependency to checkstyle, this version has to be the same as eclipse-cs depends on -->
-    <checkstyle.eclipse-cs.version>8.10.1</checkstyle.eclipse-cs.version>
+    <checkstyle.eclipse-cs.version>8.10</checkstyle.eclipse-cs.version>
     <checkstyle.configLocation>https://raw.githubusercontent.com/checkstyle/checkstyle/checkstyle-${checkstyle.eclipse-cs.version}/config/checkstyle_checks.xml</checkstyle.configLocation>
     <checkstyle.plugin.version>2.17</checkstyle.plugin.version>
     <sevntu.maven.plugin>RELEASE</sevntu.maven.plugin>


### PR DESCRIPTION
There is no eclipse-cs version 8.10 .
This value needs to be fixed as it is a requirement for the release process (old and new) to be able to test in eclipse-cs.

I realize this slightly contradicts https://github.com/sevntu-checkstyle/sevntu.checkstyle/issues/705 , but it is not going to be fixed this release, so we should continue with what works for now.