### PR TITLE
Handle lambdas in ForbidCertainMethodCheck

### DIFF
--- a/sevntu-checks/src/main/java/com/github/sevntu/checkstyle/checks/coding/ForbidCertainMethodCheck.java
+++ b/sevntu-checks/src/main/java/com/github/sevntu/checkstyle/checks/coding/ForbidCertainMethodCheck.java
@@ -161,7 +161,7 @@ public class ForbidCertainMethodCheck extends AbstractCheck {
                 else {
                     methodNameInCode = dot.getLastChild().getText();
                 }
-                final int numArgsInCode = dot.getNextSibling().getChildCount(TokenTypes.EXPR);
+                final int numArgsInCode = getMethodCallParameterCount(ast);
                 if (isForbiddenMethod(methodNameInCode, numArgsInCode)) {
                     log(ast, MSG_KEY, methodNameInCode, methodName,
                         numArgsInCode, argumentCount);
@@ -171,6 +171,24 @@ public class ForbidCertainMethodCheck extends AbstractCheck {
                 Utils.reportInvalidToken(ast.getType());
                 break;
         }
+    }
+
+    /**
+     * Count the parameters given to a method call.
+     * @param ast The method call AST.
+     * @return The number of parameters.
+     */
+    private static int getMethodCallParameterCount(DetailAST ast) {
+        int paramCount = 0;
+        final DetailAST expressionList = ast.getFirstChild().getNextSibling();
+        // This works by counting the number of commas separating the
+        // expressions passed to the method, if any
+        if (expressionList.getChildCount() > 0) {
+            // We have at least one parameter, so the total number of
+            // parameters is the number of commas plus one
+            paramCount = expressionList.getChildCount(TokenTypes.COMMA) + 1;
+        }
+        return paramCount;
     }
 
     /**

--- a/sevntu-checks/src/test/java/com/github/sevntu/checkstyle/checks/coding/ForbidCertainMethodCheckTest.java
+++ b/sevntu-checks/src/test/java/com/github/sevntu/checkstyle/checks/coding/ForbidCertainMethodCheckTest.java
@@ -339,6 +339,7 @@ public class ForbidCertainMethodCheckTest extends AbstractModuleTestSupport {
             "52:26: " + getCheckMessage(MSG_KEY, "asList", "asList", 10, "-3, 5-7, 9-"),
             "53:26: " + getCheckMessage(MSG_KEY, "asList", "asList", 11, "-3, 5-7, 9-"),
             "54:26: " + getCheckMessage(MSG_KEY, "asList", "asList", 12, "-3, 5-7, 9-"),
+            "55:64: " + getCheckMessage(MSG_KEY, "asList", "asList", 2, "-3, 5-7, 9-"),
         };
         verify(checkConfig, getPath("InputForbidCertainMethodCheck.java"), expected);
     }

--- a/sevntu-checks/src/test/resources/com/github/sevntu/checkstyle/checks/coding/InputForbidCertainMethodCheck.java
+++ b/sevntu-checks/src/test/resources/com/github/sevntu/checkstyle/checks/coding/InputForbidCertainMethodCheck.java
@@ -52,6 +52,7 @@ class InputForbidCertainMethodCheck
             Arrays.asList(1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
             Arrays.asList(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11);
             Arrays.asList(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12);
+            Arrays.<java.util.function.Supplier<Integer>>asList(() -> 1, () -> 2);
         }
     }
 }


### PR DESCRIPTION
https://github.com/sevntu-checkstyle/sevntu.checkstyle/issues/721

ForbidCertainMethodCheck allows the number of parameters to be used to
specify forbidden methods more precisely than using only their name;
however it counds those parameters by counting EXPR tokens. Lambdas
appear as LAMBDA tokens, not EXPR tokens, so they aren’t counted
towards the real argument count, resulting in false-positives or
false-negatives depending on the test being run.

This patch changes the argument count to count commas instead, all at
the same level just under the ELIST. This ensures that arguments are
counted regardless of their token type.

Signed-off-by: Stephen Kitt <skitt@redhat.com>