### PR TITLE
Issue #746: exclude checkstyle dependency from resulted jar of sevntu-checkstyle-sonar-plugin

### DIFF
--- a/sevntu-checkstyle-sonar-plugin/pom.xml
+++ b/sevntu-checkstyle-sonar-plugin/pom.xml
@@ -41,6 +41,12 @@
       <groupId>com.github.sevntu-checkstyle</groupId>
       <artifactId>sevntu-checks</artifactId>
       <version>${project.version}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>com.puppycrawl.tools</groupId>
+          <artifactId>checkstyle</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
Issue #746

Checkstyle dependency was explicitly excluded from the sevntu-sonar plugin.

Tested with the following:
- sonarqube 7.8
- sevntu-checks and checkstyle checks are activated in sonarqube quality profile
- analysis is launched on checkstyle sources with `mvn sonar:sonar -Dsonar.host.url=http://localhost:9000/`

| Checkstyle sonar plugin version | Checkstyle version | Analysis status |
| ------------------------------------------ | -------------------------- | -------------------- |
| 4.17 | 8.17 | Failed with exception |
| 4.18 | 8.18 | Passed |
| 4.19 | 8.19 | Passed |
| 4.20 | 8.20 | Passed |
| 4.21 | 8.21 | Failed with exception |