### PR TITLE
Issue #440: remove guava and shade plugin dependencies

### DIFF
--- a/sevntu-checkstyle-sonar-plugin/pom.xml
+++ b/sevntu-checkstyle-sonar-plugin/pom.xml
@@ -48,12 +48,6 @@
         </exclusion>
       </exclusions>
     </dependency>
-
-    <dependency>
-      <groupId>com.google.guava</groupId>
-      <artifactId>guava</artifactId>
-      <version>15.0</version>
-    </dependency>
   </dependencies>
 
   <build>
@@ -141,37 +135,6 @@
           <fromFile>${project.build.directory}/${project.build.finalName}.jar</fromFile>
           <url>file://${deployDir}/sonar/</url>
         </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-shade-plugin</artifactId>
-        <version>2.4.2</version>
-        <executions>
-          <execution>
-            <phase>package</phase>
-            <goals>
-              <goal>shade</goal>
-            </goals>
-            <configuration>
-              <dependencyReducedPomLocation>
-                ${project.build.directory}/dependency-reduced-pom.xml
-              </dependencyReducedPomLocation>
-              <artifactSet>
-                <includes>
-                  <include>com.github.sevntu.checkstyle</include>
-                </includes>
-              </artifactSet>
-              <relocations>
-                <relocation>
-                  <pattern>com.google.common</pattern>
-                  <shadedPattern>
-                    com.puppycrawl.tools.checkstyle.guava
-                  </shadedPattern>
-                </relocation>
-              </relocations>
-            </configuration>
-          </execution>
-        </executions>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
Issue #440 

Both dependencies, guava and maven shade plugin, were removed from sevntu sonar plugin.

Tested with the following:
- sevntu-checks and checkstyle checks are activated in sonarqube quality profile
- analysis is launched on checkstyle sources with `mvn sonar:sonar -Dsonar.host.url=http://localhost:9000/`

| Sonarqube version | Checkstyle sonar plugin version | Checkstyle version | Analysis status |
| ------------------------- | ------------------------------------------ | -------------------------- | -------------------- |
| 7.5 | 4.17 | 8.17 | Passed |
| 7.8 | 4.18 | 8.18 | Passed |
| 7.8 | 4.19 | 8.19 | Passed |
| 7.8 | 4.20 | 8.20 | Passed |

Jar content before removal:
```
$ zipinfo target/sevntu-checkstyle-sonar-plugin-1.34.1.jar | grep 'lib/.*jar'
-rw----     2.0 fat    38806 bl defN 19-Jul-01 22:15 META-INF/lib/annotations-3.0.1.jar
-rw----     2.0 fat    19936 bl defN 19-Jul-01 22:15 META-INF/lib/jsr305-3.0.2.jar
-rw----     2.0 fat  2172168 bl defN 19-Jul-01 22:15 META-INF/lib/guava-15.0.jar
-rw----     2.0 fat   195742 bl defN 19-Jul-01 22:15 META-INF/lib/sevntu-checks-1.34.1.jar
-rw----     2.0 fat     2254 bl defN 19-Jul-01 22:15 META-INF/lib/jcip-annotations-1.0.jar
```
after removal:
```
$ zipinfo target/sevntu-checkstyle-sonar-plugin-1.34.1.jar | grep 'lib/.*jar'
-rw-rw-r--  2.0 unx    38806 b- defN 19-Jul-03 23:29 META-INF/lib/annotations-3.0.1.jar
-rw-rw-r--  2.0 unx    19936 b- defN 19-Jul-03 23:29 META-INF/lib/jsr305-3.0.2.jar
-rw-rw-r--  2.0 unx   195742 b- defN 19-Jul-03 23:29 META-INF/lib/sevntu-checks-1.34.1.jar
-rw-rw-r--  2.0 unx     2254 b- defN 19-Jul-03 23:29 META-INF/lib/jcip-annotations-1.0.jar
```