### PR TITLE
Issue #758: make checkstyle dependency as provided in sevntu-checks

### DIFF
--- a/sevntu-checks/pom.xml
+++ b/sevntu-checks/pom.xml
@@ -37,6 +37,7 @@
       <groupId>com.puppycrawl.tools</groupId>
       <artifactId>checkstyle</artifactId>
       <version>${checkstyle.eclipse-cs.version}</version>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>com.puppycrawl.tools</groupId>

--- a/sevntu-checkstyle-sonar-plugin/pom.xml
+++ b/sevntu-checkstyle-sonar-plugin/pom.xml
@@ -41,12 +41,6 @@
       <groupId>com.github.sevntu-checkstyle</groupId>
       <artifactId>sevntu-checks</artifactId>
       <version>${project.version}</version>
-      <exclusions>
-        <exclusion>
-          <groupId>com.puppycrawl.tools</groupId>
-          <artifactId>checkstyle</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
   </dependencies>
 


### PR DESCRIPTION
Issue #758.

Checkstyle dependency was marked as provided in sevntu-checks module. Redundant exclusion was removed from sevntu-sonar plugin.

See comments about checking other extensions: [sevntu-checkstyle-idea-extension](https://github.com/sevntu-checkstyle/sevntu.checkstyle/issues/758#issuecomment-509392019), [sevntu-checkstyle-maven-plugin](https://github.com/sevntu-checkstyle/sevntu.checkstyle/issues/758#issuecomment-509404538), [eclipsecs-sevntu-plugin](https://github.com/sevntu-checkstyle/sevntu.checkstyle/issues/758#issuecomment-509401382).