### PR TITLE
Issue #766: remove sevntu-checkstyle-maven-plugin

### DIFF
--- a/index.html
+++ b/index.html
@@ -221,7 +221,6 @@ We do deployment to Maven central -
 <ul>
 <li>sevntu-checks</li>
 <li>sevntu-checkstyle-idea-extension</li>
-<li>sevntu-checkstyle-maven-plugin</li>
 <li>sevntu-checkstyle-sonar-plugin</li>
 </ul>
 </p>

--- a/wercker.yml
+++ b/wercker.yml
@@ -1,0 +1,4 @@
+box: alpine
+
+build:
+  steps:


### PR DESCRIPTION
Issue #766 

- `sevntu-checkstyle-maven-plugin` removed
- dummy wercker config was added to fix ci failure