### PR TITLE
minor: Fix UnnecessarySemicolonInEnumeration violation

### DIFF
--- a/sevntu-checks/src/main/java/com/github/sevntu/checkstyle/checks/coding/NumericLiteralNeedsUnderscoreCheck.java
+++ b/sevntu-checks/src/main/java/com/github/sevntu/checkstyle/checks/coding/NumericLiteralNeedsUnderscoreCheck.java
@@ -166,7 +166,7 @@ public class NumericLiteralNeedsUnderscoreCheck extends AbstractCheck {
         /**
          * Denotes a binary literal. For example, 0b0011
          */
-        BINARY;
+        BINARY
 
     }
 


### PR DESCRIPTION
```
[ERROR] src/main/java/com/github/sevntu/checkstyle/checks/coding/NumericLiteralNeedsUnderscoreCheck.java:[169,15] (coding) UnnecessarySemicolonInEnumeration: Unnecessary semicolon
```
