### PR TITLE
minor: rename misleading property

### DIFF
--- a/.ci/travis.sh
+++ b/.ci/travis.sh
@@ -72,7 +72,7 @@ checkstyle-regression)
                    --non-recursive org.codehaus.mojo:exec-maven-plugin:1.3.1:exec)
   echo sevntu version:$SEVNTU_VERSION
   ECLIPSE_CS_VERSION=$(mvn -e -q -Dexec.executable='echo' \
-                   -Dexec.args='${checkstyle.eclipse-cs.version}' \
+                   -Dexec.args='${checkstyle.version}' \
                    --non-recursive org.codehaus.mojo:exec-maven-plugin:1.3.1:exec)
   echo eclipse-cs version:$ECLIPSE_CS_VERSION
   mvn -e install -Pno-validations

--- a/release.sh
+++ b/release.sh
@@ -51,7 +51,7 @@ git clean -f -d
 git checkout origin/master
 
 cd sevntu-checks
-ECLIPSE_CS_VERSION=$(mvn -e -q -Dexec.executable='echo' -Dexec.args='${checkstyle.eclipse-cs.version}' \
+ECLIPSE_CS_VERSION=$(mvn -e -q -Dexec.executable='echo' -Dexec.args='${checkstyle.version}' \
   --non-recursive org.codehaus.mojo:exec-maven-plugin:1.3.1:exec)
 cd ..
 

--- a/sevntu-checks/.ci/wercker.sh
+++ b/sevntu-checks/.ci/wercker.sh
@@ -22,7 +22,7 @@ case $1 in
 
 no-exception-struts)
   CS_POM_VERSION=$(mvn -e -q -Dexec.executable='echo' \
-                     -Dexec.args='${checkstyle.eclipse-cs.version}' \
+                     -Dexec.args='${checkstyle.version}' \
                      --non-recursive org.codehaus.mojo:exec-maven-plugin:1.3.1:exec)
   SEVNTU_POM_VERSION=$(mvn -e -q -Dexec.executable='echo' -Dexec.args='${project.version}' \
                      --non-recursive org.codehaus.mojo:exec-maven-plugin:1.3.1:exec)
@@ -41,7 +41,7 @@ no-exception-struts)
 
 no-exception-guava)
   CS_POM_VERSION=$(mvn -e -q -Dexec.executable='echo' \
-                     -Dexec.args='${checkstyle.eclipse-cs.version}' \
+                     -Dexec.args='${checkstyle.version}' \
                      --non-recursive org.codehaus.mojo:exec-maven-plugin:1.3.1:exec)
   SEVNTU_POM_VERSION=$(mvn -e -q -Dexec.executable='echo' -Dexec.args='${project.version}' \
                      --non-recursive org.codehaus.mojo:exec-maven-plugin:1.3.1:exec)
@@ -60,7 +60,7 @@ no-exception-guava)
 
 no-exception-hibernate-orm)
   CS_POM_VERSION=$(mvn -e -q -Dexec.executable='echo' \
-                     -Dexec.args='${checkstyle.eclipse-cs.version}' \
+                     -Dexec.args='${checkstyle.version}' \
                      --non-recursive org.codehaus.mojo:exec-maven-plugin:1.3.1:exec)
   SEVNTU_POM_VERSION=$(mvn -e -q -Dexec.executable='echo' -Dexec.args='${project.version}' \
                      --non-recursive org.codehaus.mojo:exec-maven-plugin:1.3.1:exec)
@@ -79,7 +79,7 @@ no-exception-hibernate-orm)
 
 no-exception-spotbugs)
   CS_POM_VERSION=$(mvn -e -q -Dexec.executable='echo' \
-                     -Dexec.args='${checkstyle.eclipse-cs.version}' \
+                     -Dexec.args='${checkstyle.version}' \
                      --non-recursive org.codehaus.mojo:exec-maven-plugin:1.3.1:exec)
   SEVNTU_POM_VERSION=$(mvn -e -q -Dexec.executable='echo' -Dexec.args='${project.version}' \
                      --non-recursive org.codehaus.mojo:exec-maven-plugin:1.3.1:exec)
@@ -98,7 +98,7 @@ no-exception-spotbugs)
 
 no-exception-spring-framework)
   CS_POM_VERSION=$(mvn -e -q -Dexec.executable='echo' \
-                     -Dexec.args='${checkstyle.eclipse-cs.version}' \
+                     -Dexec.args='${checkstyle.version}' \
                      --non-recursive org.codehaus.mojo:exec-maven-plugin:1.3.1:exec)
   SEVNTU_POM_VERSION=$(mvn -e -q -Dexec.executable='echo' -Dexec.args='${project.version}' \
                      --non-recursive org.codehaus.mojo:exec-maven-plugin:1.3.1:exec)
@@ -117,7 +117,7 @@ no-exception-spring-framework)
 
 no-exception-hbase)
   CS_POM_VERSION=$(mvn -e -q -Dexec.executable='echo' \
-                     -Dexec.args='${checkstyle.eclipse-cs.version}' \
+                     -Dexec.args='${checkstyle.version}' \
                      --non-recursive org.codehaus.mojo:exec-maven-plugin:1.3.1:exec)
   SEVNTU_POM_VERSION=$(mvn -e -q -Dexec.executable='echo' -Dexec.args='${project.version}' \
                      --non-recursive org.codehaus.mojo:exec-maven-plugin:1.3.1:exec)
@@ -136,7 +136,7 @@ no-exception-hbase)
 
 no-exception-Pmd-elasticsearch-lombok-ast)
   CS_POM_VERSION=$(mvn -e -q -Dexec.executable='echo' \
-                     -Dexec.args='${checkstyle.eclipse-cs.version}' \
+                     -Dexec.args='${checkstyle.version}' \
                      --non-recursive org.codehaus.mojo:exec-maven-plugin:1.3.1:exec)
   SEVNTU_POM_VERSION=$(mvn -e -q -Dexec.executable='echo' -Dexec.args='${project.version}' \
                      --non-recursive org.codehaus.mojo:exec-maven-plugin:1.3.1:exec)
@@ -157,7 +157,7 @@ no-exception-Pmd-elasticsearch-lombok-ast)
 
 no-exception-alot-of-projects)
   CS_POM_VERSION=$(mvn -e -q -Dexec.executable='echo' \
-                     -Dexec.args='${checkstyle.eclipse-cs.version}' \
+                     -Dexec.args='${checkstyle.version}' \
                      --non-recursive org.codehaus.mojo:exec-maven-plugin:1.3.1:exec)
   SEVNTU_POM_VERSION=$(mvn -e -q -Dexec.executable='echo' -Dexec.args='${project.version}' \
                      --non-recursive org.codehaus.mojo:exec-maven-plugin:1.3.1:exec)

--- a/sevntu-checks/pom.xml
+++ b/sevntu-checks/pom.xml
@@ -16,8 +16,8 @@
   <properties>
     <project.build.sourceEncoding>iso-8859-1</project.build.sourceEncoding>
     <!-- It is compile dependency to checkstyle, this version has to be the same as eclipse-cs depends on -->
-    <checkstyle.eclipse-cs.version>8.18</checkstyle.eclipse-cs.version>
-    <checkstyle.configLocation>https://raw.githubusercontent.com/checkstyle/checkstyle/checkstyle-${checkstyle.eclipse-cs.version}/config/checkstyle_checks.xml</checkstyle.configLocation>
+    <checkstyle.version>8.18</checkstyle.version>
+    <checkstyle.configLocation>https://raw.githubusercontent.com/checkstyle/checkstyle/checkstyle-${checkstyle.version}/config/checkstyle_checks.xml</checkstyle.configLocation>
     <checkstyle.plugin.version>3.0.0</checkstyle.plugin.version>
     <sevntu.maven.plugin>RELEASE</sevntu.maven.plugin>
     <maven.pmd.plugin.version>3.11.0</maven.pmd.plugin.version>
@@ -36,7 +36,7 @@
     <dependency>
       <groupId>com.puppycrawl.tools</groupId>
       <artifactId>checkstyle</artifactId>
-      <version>${checkstyle.eclipse-cs.version}</version>
+      <version>${checkstyle.version}</version>
       <scope>provided</scope>
     </dependency>
     <dependency>
@@ -44,7 +44,7 @@
       <artifactId>checkstyle</artifactId>
       <type>test-jar</type>
       <scope>test</scope>
-      <version>${checkstyle.eclipse-cs.version}</version>
+      <version>${checkstyle.version}</version>
     </dependency>
     <!-- required for Jsr305AnnotationsCheck -->
     <dependency>
@@ -239,7 +239,7 @@
           <dependency>
             <groupId>com.puppycrawl.tools</groupId>
             <artifactId>checkstyle</artifactId>
-            <version>${checkstyle.eclipse-cs.version}</version>
+            <version>${checkstyle.version}</version>
           </dependency>
         </dependencies>
         <executions>
@@ -365,7 +365,7 @@
               <classpathScope>test</classpathScope>
               <arguments>
                 <classpath/>
-                <argument>${checkstyle.eclipse-cs.version}</argument>
+                <argument>${checkstyle.version}</argument>
               </arguments>
             </configuration>
           </plugin>
@@ -402,7 +402,7 @@
               <dependency>
                 <groupId>com.puppycrawl.tools</groupId>
                 <artifactId>checkstyle</artifactId>
-                <version>${checkstyle.eclipse-cs.version}</version>
+                <version>${checkstyle.version}</version>
               </dependency>
               <!-- attention here is self-referencing, so be sure you did "mvn install" before "mvn verify -Pselftesting" -->
               <dependency>


### PR DESCRIPTION
As discussed below, I believe this property is used only to control version of CS itself.