### PR TITLE
doc: fix javadoc in InputReturnCountExtendedCheckMethodsInMethods.java

### DIFF
--- a/sevntu-checks/src/test/resources/com/github/sevntu/checkstyle/checks/coding/InputReturnCountExtendedCheckMethodsInMethods.java
+++ b/sevntu-checks/src/test/resources/com/github/sevntu/checkstyle/checks/coding/InputReturnCountExtendedCheckMethodsInMethods.java
@@ -4,8 +4,8 @@ package com.github.sevntu.checkstyle.checks.coding;
  * Class represents a part of filters preferences page. It is responsible for building a table, where filters are
  * displayed, and control buttons: Add and Remove to add/remove filters.
  * 
- * @author <a href="mailto:rd.ryly@gmail.com">Ruslan Diachenko</a></br> <a
- *         href="mailto:Daniil.Yaroslavtsev@gmail.com">Daniil Yaroslavtsev</a>
+ * @author <a href="mailto:rd.ryly@gmail.com">Ruslan Diachenko</a>
+ * @author <a href="mailto:Daniil.Yaroslavtsev@gmail.com">Daniil Yaroslavtsev</a>
  */
 public class InputReturnCountExtendedCheckMethodsInMethods {
 


### PR DESCRIPTION
Although the specification allows multiple names per `@author` tag, it is better to have only one name per tag to avoid ambiguities.