### PR TITLE
Remove usages of DetailAST::getNumberOfChildren

### DIFF
--- a/sevntu-checks/src/main/java/com/github/sevntu/checkstyle/checks/coding/AvoidHidingCauseExceptionCheck.java
+++ b/sevntu-checks/src/main/java/com/github/sevntu/checkstyle/checks/coding/AvoidHidingCauseExceptionCheck.java
@@ -149,7 +149,7 @@ public class AvoidHidingCauseExceptionCheck extends AbstractCheck {
 
             if (currentNode.getType() != TokenTypes.PARAMETER_DEF
                     && currentNode.getType() != TokenTypes.LITERAL_TRY
-                    && currentNode.getNumberOfChildren() > 0) {
+                    && currentNode.getFirstChild() != null) {
                 buildThrowParamNamesList(currentNode, paramNamesAST);
             }
         }
@@ -174,7 +174,7 @@ public class AvoidHidingCauseExceptionCheck extends AbstractCheck {
             if (currentNode.getType() != TokenTypes.PARAMETER_DEF
                     && currentNode.getType() != TokenTypes.LITERAL_THROW
                     && currentNode.getType() != TokenTypes.LITERAL_TRY
-                    && currentNode.getNumberOfChildren() > 0) {
+                    && currentNode.getFirstChild() != null) {
                 throwList.addAll(makeThrowList(currentNode));
             }
         }
@@ -222,7 +222,7 @@ public class AvoidHidingCauseExceptionCheck extends AbstractCheck {
             }
 
             if (currentNode.getType() != TokenTypes.PARAMETER_DEF
-                    && currentNode.getNumberOfChildren() > 0) {
+                    && currentNode.getFirstChild() != null) {
                 wrapExcNames.addAll(makeExceptionsList(currentCatchAST,
                         currentNode, currentExcName));
             }

--- a/sevntu-checks/src/main/java/com/github/sevntu/checkstyle/checks/coding/AvoidNotShortCircuitOperatorsForBooleanCheck.java
+++ b/sevntu-checks/src/main/java/com/github/sevntu/checkstyle/checks/coding/AvoidNotShortCircuitOperatorsForBooleanCheck.java
@@ -196,7 +196,7 @@ public class AvoidNotShortCircuitOperatorsForBooleanCheck extends AbstractCheck 
     public final List<String> getSupportedOperandsNames(
             final DetailAST exprParentAST) {
         for (DetailAST currentNode : getChildren(exprParentAST)) {
-            if (currentNode.getNumberOfChildren() > 0
+            if (currentNode.getFirstChild() != null
                     && currentNode.getType() != TokenTypes.METHOD_CALL) {
                 getSupportedOperandsNames(currentNode);
             }
@@ -218,7 +218,7 @@ public class AvoidNotShortCircuitOperatorsForBooleanCheck extends AbstractCheck 
      */
     public final boolean hasTrueOrFalseLiteral(final DetailAST parentAST) {
         for (DetailAST currentNode : getChildren(parentAST)) {
-            if (currentNode.getNumberOfChildren() > 0) {
+            if (currentNode.getFirstChild() != null) {
                 hasTrueOrFalseLiteral(currentNode);
             }
 

--- a/sevntu-checks/src/main/java/com/github/sevntu/checkstyle/checks/coding/IllegalCatchExtendedCheck.java
+++ b/sevntu-checks/src/main/java/com/github/sevntu/checkstyle/checks/coding/IllegalCatchExtendedCheck.java
@@ -158,7 +158,7 @@ public final class IllegalCatchExtendedCheck extends AbstractCheck {
 
         for (DetailAST currentNode : asts) {
             if (currentNode.getType() != TokenTypes.PARAMETER_DEF
-                    && currentNode.getNumberOfChildren() > 0) {
+                    && currentNode.getFirstChild() != null) {
                 result = getThrowAST(currentNode);
             }
             if (currentNode.getType() == TokenTypes.LITERAL_THROW) {
@@ -181,7 +181,7 @@ public final class IllegalCatchExtendedCheck extends AbstractCheck {
 
         DetailAST currNode = node.getFirstChild();
 
-        for (int i = 0; i < node.getNumberOfChildren(); i++) {
+        for (int i = 0; i < result.length; i++) {
             result[i] = currNode;
             currNode = currNode.getNextSibling();
         }

--- a/sevntu-checks/src/main/java/com/github/sevntu/checkstyle/checks/coding/OverridableMethodInConstructorCheck.java
+++ b/sevntu-checks/src/main/java/com/github/sevntu/checkstyle/checks/coding/OverridableMethodInConstructorCheck.java
@@ -416,7 +416,7 @@ public class OverridableMethodInConstructorCheck extends AbstractCheck {
         final List<DetailAST> result = new LinkedList<>();
 
         for (DetailAST curNode : getChildren(parentAST)) {
-            if (curNode.getNumberOfChildren() > 0) {
+            if (curNode.getFirstChild() != null) {
                 if (curNode.getType() == TokenTypes.METHOD_CALL) {
                     result.add(curNode);
                 }
@@ -554,7 +554,7 @@ public class OverridableMethodInConstructorCheck extends AbstractCheck {
         List<DetailAST> definitionsList = new LinkedList<>();
 
         for (DetailAST curNode : getChildren(parentAST)) {
-            if (curNode.getNumberOfChildren() > 0) {
+            if (curNode.getFirstChild() != null) {
                 if (curNode.getType() == TokenTypes.METHOD_DEF) {
                     final String curMethodName = curNode.findFirstToken(
                             TokenTypes.IDENT).getText();


### PR DESCRIPTION
Issue #793

Usages of `node.getNumberOfChildren() > 0` replaced with `node.getFirstChild() != null`.
This is less readable, may be there should be method
```java
default boolean hasChildren() {
    return firstChild != null;
}
```
in the DetailAst interface?