### PR TITLE
config: upgrade maven-checkstyle-plugin to 3.1.1

### DIFF
--- a/sevntu-checks/pom.xml
+++ b/sevntu-checks/pom.xml
@@ -20,7 +20,7 @@
     <!-- verify time version -->
     <checkstyle.version>8.30</checkstyle.version>
     <checkstyle.configLocation>https://raw.githubusercontent.com/checkstyle/checkstyle/checkstyle-${checkstyle.version}/config/checkstyle_checks.xml</checkstyle.configLocation>
-    <checkstyle.plugin.version>3.1.0</checkstyle.plugin.version>
+    <checkstyle.plugin.version>3.1.1</checkstyle.plugin.version>
     <sevntu.maven.plugin>RELEASE</sevntu.maven.plugin>
     <maven.pmd.plugin.version>3.11.0</maven.pmd.plugin.version>
     <pmd.version>6.13.0</pmd.version>


### PR DESCRIPTION
Checkstyle is looking to remove some deprecated methods and CI noticed that you are not on the latest maven-checkstyle-plugin which is still using some deprecated methods. 

Issue: checkstyle/checkstyle/issues/7190
PR: checkstyle/checkstyle#7778