### PR TITLE
minor: fix violations from RequireEmptyLineBeforeAtClauseBlock

### DIFF
--- a/sevntu-checks/src/main/java/com/github/sevntu/checkstyle/SevntuUtil.java
+++ b/sevntu-checks/src/main/java/com/github/sevntu/checkstyle/SevntuUtil.java
@@ -39,6 +39,7 @@ public final class SevntuUtil {
      * This utility method if used to mark that token passed to
      * {@link AbstractCheck#visitToken(com.puppycrawl.tools.checkstyle.api.DetailAST)} is not
      * supported by this method.
+     *
      * @param token
      *        token/type that is not supported
      * @throws IllegalArgumentException

--- a/sevntu-checks/src/main/java/com/github/sevntu/checkstyle/checks/annotation/ForbidAnnotationCheck.java
+++ b/sevntu-checks/src/main/java/com/github/sevntu/checkstyle/checks/annotation/ForbidAnnotationCheck.java
@@ -37,6 +37,7 @@ import com.puppycrawl.tools.checkstyle.utils.TokenUtil;
  * value="XXX"/&gt; &lt;property name="annotationTargets"
  * value="METHOD_DEF,CLASS_DEF"/&gt; &lt;/module&gt;
  * </pre>
+ *
  * @author <a href="mailto:hidoyatov.v.i@gmail.com">Hidoyatov Victor</a>
  * @since 1.12.0
  */
@@ -59,6 +60,7 @@ public class ForbidAnnotationCheck extends AbstractCheck {
 
     /**
      * Setter for annotationNames.
+     *
      * @param names - array of annotation's names
      */
     public void setAnnotationNames(final String... names) {
@@ -71,6 +73,7 @@ public class ForbidAnnotationCheck extends AbstractCheck {
 
     /**
      * Getter for annotationNames.
+     *
      * @param targets - array of type's names
      */
     public void setAnnotationTargets(String... targets) {
@@ -138,6 +141,7 @@ public class ForbidAnnotationCheck extends AbstractCheck {
 
     /**
      * Return true if mAnnotationNames contains aAnnotationName.
+     *
      * @param annotationName - name of current annotation
      * @return boolean
      */
@@ -147,6 +151,7 @@ public class ForbidAnnotationCheck extends AbstractCheck {
 
     /**
      * Return true if mAnnotationTargets contains aTargetType.
+     *
      * @param targetType - type of current annotation
      * @return boolean
      */

--- a/sevntu-checks/src/main/java/com/github/sevntu/checkstyle/checks/annotation/RequiredParameterForAnnotationCheck.java
+++ b/sevntu-checks/src/main/java/com/github/sevntu/checkstyle/checks/annotation/RequiredParameterForAnnotationCheck.java
@@ -117,6 +117,7 @@ public class RequiredParameterForAnnotationCheck extends AbstractCheck {
 
     /**
      * The annotation name we are interested in.
+     *
      * @param annotationName set annotation name
      */
     public void setAnnotationName(String annotationName) {
@@ -125,6 +126,7 @@ public class RequiredParameterForAnnotationCheck extends AbstractCheck {
 
     /**
      * The required list of parameters we have to use.
+     *
      * @param requiredPropertiesParameter set required list of parameters
      */
     public void setRequiredParameters(String... requiredPropertiesParameter) {
@@ -169,6 +171,7 @@ public class RequiredParameterForAnnotationCheck extends AbstractCheck {
 
     /**
      * Returns full name of an annotation.
+     *
      * @param annotationNode The node to examine.
      * @return name of an annotation.
      */
@@ -194,6 +197,7 @@ public class RequiredParameterForAnnotationCheck extends AbstractCheck {
 
     /**
      * Returns the name of annotations properties.
+     *
      * @param annotationNode The node to examine.
      * @return name of annotation properties.
      */

--- a/sevntu-checks/src/main/java/com/github/sevntu/checkstyle/checks/coding/AvoidDefaultSerializableInInnerClassesCheck.java
+++ b/sevntu-checks/src/main/java/com/github/sevntu/checkstyle/checks/coding/AvoidDefaultSerializableInInnerClassesCheck.java
@@ -32,6 +32,7 @@ import com.puppycrawl.tools.checkstyle.api.TokenTypes;
  * implement both methods. For more information read
  * "Effective Java (2nd edition)" chapter 11, item 74, page 294.
  * </p>
+ *
  * @author <a href="mailto:IliaDubinin91@gmail.com">Ilia Dubinin</a>
  * @since 1.8.0
  */
@@ -54,6 +55,7 @@ public class AvoidDefaultSerializableInInnerClassesCheck extends AbstractCheck {
      * <p>
      * Set allow partly implementation serializable interface.
      * </p>
+     *
      * @param allow - Option, that allow partial implementation
      *        of serializable interface.
      */
@@ -94,6 +96,7 @@ public class AvoidDefaultSerializableInInnerClassesCheck extends AbstractCheck {
      * Return true if it is nested class. Terminology is here :
      * http://download.oracle.com/javase/tutorial/java/javaOO/nested.html
      * </p>
+     *
      * @param classNode - class node
      * @return - boolean variable
      */
@@ -147,6 +150,7 @@ public class AvoidDefaultSerializableInInnerClassesCheck extends AbstractCheck {
      * Return true, if methods readObject() and writeObject() have correct
      * modifiers.
      * </p>
+     *
      * @param methodNode
      *        - current method node;
      * @return boolean value;
@@ -166,6 +170,7 @@ public class AvoidDefaultSerializableInInnerClassesCheck extends AbstractCheck {
      * <p>
      * Return true, if method has void type.
      * </p>
+     *
      * @param methodNode - method node
      * @return boolean variable
      */
@@ -180,6 +185,7 @@ public class AvoidDefaultSerializableInInnerClassesCheck extends AbstractCheck {
      * Return true, if method has correct parameters (ObjectInputStream for
      * readObject() and ObjectOutputStream for writeObject()).
      * </p>
+     *
      * @param methodNode - method node.
      * @param parameterText - correct parameter text.
      * @return boolean variable.
@@ -240,6 +246,7 @@ public class AvoidDefaultSerializableInInnerClassesCheck extends AbstractCheck {
         * <b>
         * Children Iterator constructor.
         * </b>
+        *
         * @param parent - child parent.
         */
         /* package */ SiblingIterator(DetailAST parent) {
@@ -250,6 +257,7 @@ public class AvoidDefaultSerializableInInnerClassesCheck extends AbstractCheck {
         * <b>
         * Return boolean value, if has next element.
         * </b>
+        *
         * @return boolean value
         */
         public boolean hasNextSibling() {
@@ -260,6 +268,7 @@ public class AvoidDefaultSerializableInInnerClassesCheck extends AbstractCheck {
         * <b>
         * Return next DetailAST element.
         * </b>
+        *
         * @return next DetailAST.
         */
 

--- a/sevntu-checks/src/main/java/com/github/sevntu/checkstyle/checks/coding/AvoidHidingCauseExceptionCheck.java
+++ b/sevntu-checks/src/main/java/com/github/sevntu/checkstyle/checks/coding/AvoidHidingCauseExceptionCheck.java
@@ -60,6 +60,7 @@ import com.puppycrawl.tools.checkstyle.api.TokenTypes;
  *        throw new RuntimeException("Runtime Exception!");
  *      }
  * </pre>
+ *
  * @author <a href="mailto:Daniil.Yaroslavtsev@gmail.com"> Daniil
  *         Yaroslavtsev</a>
  * @author <a href="mailto:IliaDubinin91@gmail.com">Ilja Dubinin</a>
@@ -114,6 +115,7 @@ public class AvoidHidingCauseExceptionCheck extends AbstractCheck {
 
     /**
      * Returns true when aThrowParamNamesList contains caught exception.
+     *
      * @param throwParamNamesList List of throw parameter names.
      * @param wrapExcNames List of caught exception names.
      * @return true when aThrowParamNamesList contains caught exception
@@ -134,6 +136,7 @@ public class AvoidHidingCauseExceptionCheck extends AbstractCheck {
     /**
      * Returns a List of<code>DetailAST</code> that contains the names of
      * parameters  for current "throw" keyword.
+     *
      * @param startNode The start node for exception name searching.
      * @param paramNamesAST The list, that will be contain names of the
      *     parameters
@@ -160,6 +163,7 @@ public class AvoidHidingCauseExceptionCheck extends AbstractCheck {
      * Recursive method which searches for the <code>LITERAL_THROW</code>
      * DetailASTs all levels below on the current <code>aParentAST</code> node
      * without entering into nested try/catch blocks.
+     *
      * @param parentAST A start node for "throw" keyword <code>DetailASTs
      * </code> searching.
      * @return null-safe list of <code>LITERAL_THROW</code> literals
@@ -184,6 +188,7 @@ public class AvoidHidingCauseExceptionCheck extends AbstractCheck {
     /**
      * Searches for all exceptions that wraps the original exception
      * object (only in current "catch" block).
+     *
      * @param currentCatchAST A LITERAL_CATCH node of the
      *     current "catch" block.
      * @param parentAST Current parent node to start search.
@@ -232,6 +237,7 @@ public class AvoidHidingCauseExceptionCheck extends AbstractCheck {
 
     /**
      * Gets all the children one level below on the current parent node.
+     *
      * @param node Current parent node.
      * @return List of children one level below on the current
      *         parent node (aNode).

--- a/sevntu-checks/src/main/java/com/github/sevntu/checkstyle/checks/coding/AvoidModifiersForTypesCheck.java
+++ b/sevntu-checks/src/main/java/com/github/sevntu/checkstyle/checks/coding/AvoidModifiersForTypesCheck.java
@@ -214,6 +214,7 @@ public class AvoidModifiersForTypesCheck extends AbstractCheck {
     /**
      * Sets the regexp for the names of classes, that could not have 'annotation'
      * modifier.
+     *
      * @param forbiddenClassesRegexpAnnotation
      *        String contains the regex to set for the names of classes, that
      *        could not have 'annotation' modifier.
@@ -234,6 +235,7 @@ public class AvoidModifiersForTypesCheck extends AbstractCheck {
     /**
      * Sets the regexp for the names of classes, that could not have 'final'
      * modifier.
+     *
      * @param forbiddenClassesRegexpFinal
      *        String contains the regex to set for the names of classes, that
      *        could not have 'final' modifier.
@@ -254,6 +256,7 @@ public class AvoidModifiersForTypesCheck extends AbstractCheck {
     /**
      * Sets the regexp for the names of classes, that could not have 'static'
      * modifier.
+     *
      * @param forbiddenClassesRegexpStatic
      *        String contains the regex to set for the names of classes, that
      *        could not have 'static' modifier.
@@ -274,6 +277,7 @@ public class AvoidModifiersForTypesCheck extends AbstractCheck {
     /**
      * Sets the regexp for the names of classes, that could not have 'transient'
      * modifier.
+     *
      * @param forbiddenClassesRegexpTransient
      *        String contains the regex to set for the names of classes, that
      *        could not have 'transient' modifier.
@@ -294,6 +298,7 @@ public class AvoidModifiersForTypesCheck extends AbstractCheck {
     /**
      * Sets the regexp for the names of classes, that could not have 'volatile'
      * modifier.
+     *
      * @param forbiddenClassesRegexpVolatile
      *        String contains the regex to set for the names of classes, that
      *        could not have 'volatile' modifier.
@@ -314,6 +319,7 @@ public class AvoidModifiersForTypesCheck extends AbstractCheck {
     /**
      * Sets the regexp for the names of classes, that could not have 'private'
      * modifier.
+     *
      * @param forbiddenClassesRegexpPrivate
      *        String contains the regex to set for the names of classes, that
      *        could not have 'private' modifier.
@@ -334,6 +340,7 @@ public class AvoidModifiersForTypesCheck extends AbstractCheck {
     /**
      * Sets the regexp for the names of classes, that could not have no modifier
      * ('package-private').
+     *
      * @param forbiddenClassesRegexpPackagePrivate
      *        String contains the regex to set for the names of classes, that
      *        could not have no modifier ('package-private').
@@ -355,6 +362,7 @@ public class AvoidModifiersForTypesCheck extends AbstractCheck {
     /**
      * Sets the regexp for the names of classes, that could not have 'protected'
      * modifier.
+     *
      * @param forbiddenClassesRegexpProtected
      *        String contains the regex to set for the names of classes, that
      *        could not have 'protected' modifier.
@@ -375,6 +383,7 @@ public class AvoidModifiersForTypesCheck extends AbstractCheck {
     /**
      * Sets the regexp for the names of classes, that could not have 'public'
      * modifier.
+     *
      * @param forbiddenClassesRegexpPublic
      *        String contains the regex to set for the names of classes, that
      *        could not have 'public' modifier.
@@ -440,6 +449,7 @@ public class AvoidModifiersForTypesCheck extends AbstractCheck {
     /**
      * Checks whether a specific Java modifier is used in a given class with
      * the specified regular expression.
+     *
      * @param modifierType the modifier type
      * @param className the class name
      * @return either <code>true</code> if the regexp match the className,
@@ -452,6 +462,7 @@ public class AvoidModifiersForTypesCheck extends AbstractCheck {
 
     /**
      * Maps the modifierType to a regular expression.
+     *
      * @param modifierType the modifier type
      * @return the Pattern object storing the regexp for the names of classes,
      *     that must not have the modifierType.
@@ -494,6 +505,7 @@ public class AvoidModifiersForTypesCheck extends AbstractCheck {
 
     /**
      * Gets the full className of the defined variable.
+     *
      * @param variableDefNode
      *        A DetailAST node is related to variable definition (VARIABLE_DEF
      *        node type).
@@ -525,6 +537,7 @@ public class AvoidModifiersForTypesCheck extends AbstractCheck {
 
     /**
      * Gets the class name from full (dotted) classPath.
+     *
      * @param classNameAndPath
      *        - the full (dotted) classPath. Must not be null.
      * @return the name of the class is specified by the current full name&path.
@@ -537,6 +550,7 @@ public class AvoidModifiersForTypesCheck extends AbstractCheck {
     /**
      * Gets the modifiers of the defined variable (annotation, public, private, final, static,
      * transient or volatile).
+     *
      * @param variableDefAst
      *        A DetailAST node is related to the variable definition
      *        (VARIABLE_DEF type)
@@ -556,6 +570,7 @@ public class AvoidModifiersForTypesCheck extends AbstractCheck {
     /**
      * Gets all the children which are one level below on the current DetailAST
      * parent node.
+     *
      * @param node
      *        The parent node.
      * @return The list of children one level below on the current parent node.

--- a/sevntu-checks/src/main/java/com/github/sevntu/checkstyle/checks/coding/AvoidNotShortCircuitOperatorsForBooleanCheck.java
+++ b/sevntu-checks/src/main/java/com/github/sevntu/checkstyle/checks/coding/AvoidNotShortCircuitOperatorsForBooleanCheck.java
@@ -67,6 +67,7 @@ import com.puppycrawl.tools.checkstyle.utils.CheckUtil;
  *             || isModifier() &amp;&amp; isNotTrue();
  * }
  * </pre>
+ *
  * @author <a href="mailto:Daniil.Yaroslavtsev@gmail.com"> Daniil
  *         Yaroslavtsev</a>
  * @since 1.8.0
@@ -134,6 +135,7 @@ public class AvoidNotShortCircuitOperatorsForBooleanCheck extends AbstractCheck 
     /**
      * Checks whether the current method/variable definition type
      * is "Boolean".
+     *
      * @param node - current method or variable definition node.
      * @return "true" if current method or variable has a Boolean type.
      */
@@ -145,6 +147,7 @@ public class AvoidNotShortCircuitOperatorsForBooleanCheck extends AbstractCheck 
     /**
      * Checks that current expression is calculated using "|", "&amp;", "|=", "&amp;="
      * operators contains at least one Boolean operand.
+     *
      * @param node - current TokenTypes.EXPR node to check.
      * @return "true" if current expression is calculated using "|", "&amp;",
      *     "|=". "&amp;=" operators contains at least one Boolean operand or false
@@ -190,6 +193,7 @@ public class AvoidNotShortCircuitOperatorsForBooleanCheck extends AbstractCheck 
      * Searches for all supported operands names in current expression.
      * When checking, treatments to external class variables, method calls,
      * etc are not considered as expression operands.
+     *
      * @param exprParentAST - the current TokenTypes.EXPR parent node.
      * @return List of supported operands contained in current expression.
      */
@@ -212,6 +216,7 @@ public class AvoidNotShortCircuitOperatorsForBooleanCheck extends AbstractCheck 
     /**
      * Checks is the current expression has
      * keywords "true" or "false".
+     *
      * @param parentAST - the current TokenTypes.EXPR parent node.
      * @return true if the current processed expression contains
      *     "true" or "false" keywords and false otherwise.
@@ -237,6 +242,7 @@ public class AvoidNotShortCircuitOperatorsForBooleanCheck extends AbstractCheck 
 
     /**
      * Gets all the children one level below on the current top node.
+     *
      * @param node - current parent node.
      * @return an array of children one level below on the current parent node
      *         aNode.

--- a/sevntu-checks/src/main/java/com/github/sevntu/checkstyle/checks/coding/ConfusingConditionCheck.java
+++ b/sevntu-checks/src/main/java/com/github/sevntu/checkstyle/checks/coding/ConfusingConditionCheck.java
@@ -181,6 +181,7 @@ public class ConfusingConditionCheck extends AbstractCheck {
 
     /**
      * Checks if the given AST can be ignored.
+     *
      * @param literalIf The AST to check.
      * @return {@code true} if it can be ignored.
      */
@@ -286,6 +287,7 @@ public class ConfusingConditionCheck extends AbstractCheck {
 
     /**
      * Retrieves the first, opening brace of an {@code if} or {@code else} statement.
+     *
      * @param detailAST The token to examine.
      * @return The opening brace token or {@code null} if it doesn't exist.
      */

--- a/sevntu-checks/src/main/java/com/github/sevntu/checkstyle/checks/coding/CustomDeclarationOrderCheck.java
+++ b/sevntu-checks/src/main/java/com/github/sevntu/checkstyle/checks/coding/CustomDeclarationOrderCheck.java
@@ -305,6 +305,7 @@ public class CustomDeclarationOrderCheck extends AbstractCheck {
 
     /**
      * Set prefix of class fields.
+     *
      * @param fieldPrefix string
      */
     public void setFieldPrefix(String fieldPrefix) {
@@ -495,6 +496,7 @@ public class CustomDeclarationOrderCheck extends AbstractCheck {
 
     /**
      * Verify that class definition is in method definition.
+     *
      * @param classDef
      *        DetailAST of CLASS_DEF.
      * @return true if class definition is in method definition.
@@ -514,6 +516,7 @@ public class CustomDeclarationOrderCheck extends AbstractCheck {
 
     /**
      * Logs wrong ordered element.
+     *
      * @param ast DetailAST of any class element.
      * @param position Position in the custom order declaration.
      */
@@ -552,6 +555,7 @@ public class CustomDeclarationOrderCheck extends AbstractCheck {
 
     /**
      * Check that position is wrong in custom declaration order.
+     *
      * @param position position of class member.
      * @return true if position is wrong.
      */
@@ -567,6 +571,7 @@ public class CustomDeclarationOrderCheck extends AbstractCheck {
 
     /**
      * Log wrong ordered setters.
+     *
      * @param gettersSetters map that has getter as key and setter as value.
      */
     private void logWrongOrderedSetters(Map<DetailAST, DetailAST> gettersSetters) {
@@ -584,6 +589,7 @@ public class CustomDeclarationOrderCheck extends AbstractCheck {
     /**
      * If method definition is getter or setter,
      * then adds this method to collection.
+     *
      * @param methodDefAst DetailAST of method definition.
      */
     private void collectGetterSetter(DetailAST methodDefAst) {
@@ -648,6 +654,7 @@ public class CustomDeclarationOrderCheck extends AbstractCheck {
     /**
      * Verify that there is anonymous class in variable definition and this
      * variable is a field.
+     *
      * @param varDefinitionAst
      *        DetailAST of variable definition.
      * @return true if there is anonymous class in variable definition and this
@@ -672,6 +679,7 @@ public class CustomDeclarationOrderCheck extends AbstractCheck {
 
     /**
      * Verify that method name starts with getter prefix (get).
+     *
      * @param methodName method name
      * @return true if method name starts with getter prefix.
      */
@@ -681,6 +689,7 @@ public class CustomDeclarationOrderCheck extends AbstractCheck {
 
     /**
      * Verify that method name starts with boolean getter prefix (is).
+     *
      * @param methodName method name
      * @return true if method name starts with boolean getter prefix.
      */
@@ -690,6 +699,7 @@ public class CustomDeclarationOrderCheck extends AbstractCheck {
 
     /**
      * Verify that method name starts with setter prefix (set).
+     *
      * @param methodName method name
      * @return true if method name starts with setter prefix.
      */
@@ -700,6 +710,7 @@ public class CustomDeclarationOrderCheck extends AbstractCheck {
     /**
      * Returns true when getter is correct. Correct getter is method that has no parameters,
      * returns class field and has name 'get<i>FieldName</i>'.
+     *
      * @param methodDef
      *        - DetailAST contains method definition.
      * @param methodPrefix
@@ -738,6 +749,7 @@ public class CustomDeclarationOrderCheck extends AbstractCheck {
 
     /**
      * Checks if a local variable hides a field.
+     *
      * @param slist The token to examine.
      * @param fieldName The name of the field.
      * @return true if the local variable is hidden from a field.
@@ -760,6 +772,7 @@ public class CustomDeclarationOrderCheck extends AbstractCheck {
     /**
      * Returns true when setter is correct. Correct setter is method that has one parameter,
      * assigns this parameter to class field and has name 'set<i>FieldName</i>'.
+     *
      * @param methodDefAst
      *        - DetailAST contains method definition.
      * @param methodPrefix
@@ -786,6 +799,7 @@ public class CustomDeclarationOrderCheck extends AbstractCheck {
 
     /**
      * Verify that expression is anonymous class.
+     *
      * @param expressionAst
      *        DetailAST of expression.
      * @return true if expression is anonymous class.
@@ -864,6 +878,7 @@ public class CustomDeclarationOrderCheck extends AbstractCheck {
 
     /**
      * Get name without prefix.
+     *
      * @param name name
      * @param prefix prefix
      * @return name without prefix or null if name does not have such prefix.
@@ -880,6 +895,7 @@ public class CustomDeclarationOrderCheck extends AbstractCheck {
     /**
      * Get identifier of AST. These can be names of types, subpackages,
      * fields, methods, parameters, and local variables.
+     *
      * @param ast
      *        DetailAST instance
      * @return identifier of AST, null if AST does not have name.
@@ -895,6 +911,7 @@ public class CustomDeclarationOrderCheck extends AbstractCheck {
 
     /**
      * Verify that exists updating of a field.
+     *
      * @param statementsAst DetailAST of statements (SLIST).
      * @param fieldName name of target field.
      * @return true if there is updating of aFieldName in aStatementsAst.
@@ -935,6 +952,7 @@ public class CustomDeclarationOrderCheck extends AbstractCheck {
      * <p>
      * Return name of the field, that was assigned in current setter.
      * </p>
+     *
      * @param assignAst
      *        - DetailAST contains ASSIGN from EXPR of the setter.
      * @return name of field, that use in setter.
@@ -959,6 +977,7 @@ public class CustomDeclarationOrderCheck extends AbstractCheck {
      * <p>
      * Return name of the field of a super class, that was assigned in setter.
      * </p>
+     *
      * @param methodCallAst
      *        - DetailAST contains METHOD_CALL from EXPR of the setter.
      * @return name of field, that used in setter.
@@ -996,6 +1015,7 @@ public class CustomDeclarationOrderCheck extends AbstractCheck {
      * Compare name of the field and part of name of the method. Return true
      * when they are different.
      * </p>
+     *
      * @param fieldName
      *        - name of the field.
      * @param methodName
@@ -1011,6 +1031,7 @@ public class CustomDeclarationOrderCheck extends AbstractCheck {
      * <p>
      * Return name of the field, that use in the getter.
      * </p>
+     *
      * @param expr
      *        - DetailAST contains expression from getter.
      * @return name of the field, that use in getter.
@@ -1037,6 +1058,7 @@ public class CustomDeclarationOrderCheck extends AbstractCheck {
 
     /**
      * Verifies that the given DetailAST is a main method.
+     *
      * @param methodAST
      *        DetailAST instance.
      * @return true if aMethodAST is a main method, false otherwise.
@@ -1057,6 +1079,7 @@ public class CustomDeclarationOrderCheck extends AbstractCheck {
 
     /**
      * Verifies that given AST has appropriate modifiers for main method.
+     *
      * @param methodAST
      *        DetailAST instance.
      * @return true if aMethodAST has (public & static & !abstract) modifiers,
@@ -1075,6 +1098,7 @@ public class CustomDeclarationOrderCheck extends AbstractCheck {
 
     /**
      * Verifies that given AST has type and this type is void.
+     *
      * @param methodAST
      *        DetailAST instance.
      * @return true if AST's type void, false otherwise.
@@ -1090,6 +1114,7 @@ public class CustomDeclarationOrderCheck extends AbstractCheck {
 
     /**
      * Verifies that given AST has appropriate for main method parameters.
+     *
      * @param methodAST
      *        instance of a method
      * @return true if parameters of aMethodAST are appropriate for main method,
@@ -1105,6 +1130,7 @@ public class CustomDeclarationOrderCheck extends AbstractCheck {
     /**
      * Return true if AST of method parameters has String[] parameter child
      * token.
+     *
      * @param parametersAST
      *        DetailAST of method parameters.
      * @return true if AST has String[] parameter child token, false otherwise.
@@ -1137,6 +1163,7 @@ public class CustomDeclarationOrderCheck extends AbstractCheck {
     /**
      * Return true if AST of method parameters has String... parameter child
      * token.
+     *
      * @param parametersAST
      *        DetailAST of method parameters.
      * @return true if aParametersAST has String... parameter child token, false
@@ -1167,6 +1194,7 @@ public class CustomDeclarationOrderCheck extends AbstractCheck {
 
     /**
      * Return true if aAST has token of aTokenType type.
+     *
      * @param ast
      *        DetailAST instance.
      * @param tokenType
@@ -1205,6 +1233,7 @@ public class CustomDeclarationOrderCheck extends AbstractCheck {
 
         /**
          * Getter for the regexp field.
+         *
          * @return the RegExp to match against
          */
         public Pattern getRegexp() {
@@ -1213,6 +1242,7 @@ public class CustomDeclarationOrderCheck extends AbstractCheck {
 
         /**
          * Getter for the rule field.
+         *
          * @return the original immutable input rule
          */
         public String getRule() {
@@ -1221,6 +1251,7 @@ public class CustomDeclarationOrderCheck extends AbstractCheck {
 
         /**
          * Getter for the class member field.
+         *
          * @return the Class Member
          */
         public int getClassMember() {
@@ -1256,6 +1287,7 @@ public class CustomDeclarationOrderCheck extends AbstractCheck {
 
         /**
          * Check that format matcher contains rule.
+         *
          * @param ruleCheck string
          * @return true if format matcher contains rule.
          */
@@ -1298,6 +1330,7 @@ public class CustomDeclarationOrderCheck extends AbstractCheck {
 
         /**
          * Add getter.
+         *
          * @param getterAst DetailAST of getter.
          */
         public void addGetter(DetailAST getterAst) {
@@ -1306,6 +1339,7 @@ public class CustomDeclarationOrderCheck extends AbstractCheck {
 
         /**
          * Add setter.
+         *
          * @param setterAst DetailAST of setter.
          */
         public void addSetter(DetailAST setterAst) {
@@ -1315,6 +1349,7 @@ public class CustomDeclarationOrderCheck extends AbstractCheck {
         /**
          * Compare order of getters and setters. Order should be like "getX; setX; getY; setY; ...".
          * If it is wrong order, then wrong ordered setters and getters will be returned as map.
+         *
          * @return Map with setter AST as key and getter AST as value.
          */
         public Map<DetailAST, DetailAST> getWrongOrderedGettersSetters() {
@@ -1336,6 +1371,7 @@ public class CustomDeclarationOrderCheck extends AbstractCheck {
         /**
          * Compare order of getters and setters. Order should be like "getX; setX; getY; setY; ...".
          * If it is wrong order, then wrong ordered setters and getters will be returned as map.
+         *
          * @param allGettersSetters collection of all getter and setters
          * @param index index from upper loo
          * @return Map with setter AST as key and getter AST as value.
@@ -1380,6 +1416,7 @@ public class CustomDeclarationOrderCheck extends AbstractCheck {
 
         /**
          * Verify that specified method was saved as getter.
+         *
          * @param methodName name of method.
          * @return true if specified method was saved as getter.
          */
@@ -1396,6 +1433,7 @@ public class CustomDeclarationOrderCheck extends AbstractCheck {
 
         /**
          * Verify that specified method was saved as setter.
+         *
          * @param methodName name of method.
          * @return true if specified method was saved as setter.
          */

--- a/sevntu-checks/src/main/java/com/github/sevntu/checkstyle/checks/coding/DiamondOperatorForVariableDefinitionCheck.java
+++ b/sevntu-checks/src/main/java/com/github/sevntu/checkstyle/checks/coding/DiamondOperatorForVariableDefinitionCheck.java
@@ -40,6 +40,7 @@ import com.puppycrawl.tools.checkstyle.api.TokenTypes;
  * Map&lt;String, Map&lt;String, Integer&gt;&gt; someMap = new HashMap&lt;&gt;();
  * </code>
  * </p>
+ *
  * @author <a href="mailto:nesterenko-aleksey@list.ru">Aleksey Nesterenko</a>
  * @since 1.12.0
  */
@@ -93,6 +94,7 @@ public class DiamondOperatorForVariableDefinitionCheck extends AbstractCheck {
 
     /**
      * Get first occurrence of TYPE_ARGUMENTS if exists.
+     *
      * @param rootToken the token to start search from.
      * @return TYPE_ARGUMENTS token if found.
      */
@@ -115,6 +117,7 @@ public class DiamondOperatorForVariableDefinitionCheck extends AbstractCheck {
 
     /**
      * Checks if the 2 given trees have the same children, type, and text.
+     *
      * @param left One of the trees to compare.
      * @param right The other tree to compare.
      * @return {@code true} if the trees are equal.
@@ -147,6 +150,7 @@ public class DiamondOperatorForVariableDefinitionCheck extends AbstractCheck {
 
     /**
      * Checks if the 2 given ASTs have the same type and text.
+     *
      * @param left One of the ASTs to compare.
      * @param right The other AST to compare.
      * @return {@code true} if the ASTs are equal.

--- a/sevntu-checks/src/main/java/com/github/sevntu/checkstyle/checks/coding/EitherLogOrThrowCheck.java
+++ b/sevntu-checks/src/main/java/com/github/sevntu/checkstyle/checks/coding/EitherLogOrThrowCheck.java
@@ -117,6 +117,7 @@ import com.puppycrawl.tools.checkstyle.api.TokenTypes;
  * Note that check works with only one logger type. If you have multiple
  * different loggers, then create another instance of this check.
  * </p>
+ *
  * @author <a href="mailto:barataliba@gmail.com">Baratali Izmailov</a>
  * @since 1.9.0
  */
@@ -177,6 +178,7 @@ public class EitherLogOrThrowCheck extends AbstractCheck {
 
     /**
      * Set logger full class name and logger simple class name.
+     *
      * @param loggerFullyQualifiedClassName
      *        Logger full class name. Example: org.slf4j.Logger.
      */
@@ -194,6 +196,7 @@ public class EitherLogOrThrowCheck extends AbstractCheck {
 
     /**
      * Set logging method names.
+     *
      * @param loggingMethodNames Logger method names.
      */
     public void setLoggingMethodNames(String... loggingMethodNames) {
@@ -263,6 +266,7 @@ public class EitherLogOrThrowCheck extends AbstractCheck {
 
     /**
      * Checks if AST object is logger import.
+     *
      * @param importAst
      *        DetailAST of import statement.
      * @return true if import equals logger full class name.
@@ -275,6 +279,7 @@ public class EitherLogOrThrowCheck extends AbstractCheck {
 
     /**
      * Verify that class is inner.
+     *
      * @param classDefAst
      *        DetailAST of class definition.
      * @return true if class is inner, false otherwise.
@@ -294,6 +299,7 @@ public class EitherLogOrThrowCheck extends AbstractCheck {
 
     /**
      * Save names of parameters which have logger type.
+     *
      * @param parametersAst
      *        DetailAST of parameters.
      */
@@ -314,6 +320,7 @@ public class EitherLogOrThrowCheck extends AbstractCheck {
 
     /**
      * Verify that method's parent is class, stored in mCurrentClassDefAst.
+     *
      * @param methodDefAst DetailAST of METHOD_DEF.
      * @return true if method's parent is class, stored in mCurrentClassDefAst.
      */
@@ -324,6 +331,7 @@ public class EitherLogOrThrowCheck extends AbstractCheck {
 
     /**
      * Find all logger fields in aClassDefAst and save them.
+     *
      * @param classDefAst
      *        DetailAST of class definition.
      */
@@ -345,6 +353,7 @@ public class EitherLogOrThrowCheck extends AbstractCheck {
      * Look at the each statement of catch block to find logging and throwing.
      * If same exception is being logged and throwed, then prints warning
      * message.
+     *
      * @param catchAst
      *        DetailAST of catch block.
      */
@@ -409,6 +418,7 @@ public class EitherLogOrThrowCheck extends AbstractCheck {
 
     /**
      * Verify that aVariableDefAst is variable of logger type.
+     *
      * @param variableDefAst
      *        DetailAST of variable definition.
      * @return true if variable is of logger type.
@@ -423,6 +433,7 @@ public class EitherLogOrThrowCheck extends AbstractCheck {
 
     /**
      * Verify that aClassName is class name of logger type.
+     *
      * @param className name of checked class.
      * @return true aClassName is class name of logger type.
      */
@@ -434,6 +445,7 @@ public class EitherLogOrThrowCheck extends AbstractCheck {
 
     /**
      * Get parameter name of catch block.
+     *
      * @param catchAst
      *        DetailAST of catch block.
      * @return name of parameter.
@@ -447,6 +459,7 @@ public class EitherLogOrThrowCheck extends AbstractCheck {
     /**
      * Get identifier of AST. These can be names of types, subpackages, fields,
      * methods, parameters, and local variables.
+     *
      * @param ast
      *        DetailAST instance
      * @return identifier of AST, null if AST does not have name.
@@ -465,6 +478,7 @@ public class EitherLogOrThrowCheck extends AbstractCheck {
     /**
      * Verify that expression is creating instance. And this instance is created
      * with exception argument. Example: new MyException("message", exception).
+     *
      * @param expressionAst
      *        DetailAST of expression.
      * @param exceptionArgumentName
@@ -490,6 +504,7 @@ public class EitherLogOrThrowCheck extends AbstractCheck {
 
     /**
      * Verify that expression is logging exception.
+     *
      * @param expressionAst DetailAST of expression(EXPR).
      * @param exceptionVariableName name of exception variable.
      * @return true if expression is logging exception.
@@ -510,6 +525,7 @@ public class EitherLogOrThrowCheck extends AbstractCheck {
 
     /**
      * Verify that aExpressionAst is a logging expression.
+     *
      * @param expressionAst
      *        DetailAST of expression.
      * @return true if aExpressionAst is a logging expression.
@@ -535,6 +551,7 @@ public class EitherLogOrThrowCheck extends AbstractCheck {
 
     /**
      * Verify that aExceptionVariableName is in aParametersAst.
+     *
      * @param parametersAst
      *            DetailAST of expression list(ELIST).
      * @param exceptionVariableName
@@ -562,6 +579,7 @@ public class EitherLogOrThrowCheck extends AbstractCheck {
 
     /**
      * Verify that expression is call of exception's printStackTrace method.
+     *
      * @param expressionAst
      *        DetailAST of expression.
      * @param exceptionVariableName
@@ -584,6 +602,7 @@ public class EitherLogOrThrowCheck extends AbstractCheck {
 
     /**
      * Verify that method is invoked on aUsedInstanceName.
+     *
      * @param usedInstanceName name of instance.
      * @param methodCallAst DetailAST of METHOD_CALL.
      * @return true if method is invoked on aUsedInstanceName.
@@ -609,6 +628,7 @@ public class EitherLogOrThrowCheck extends AbstractCheck {
 
     /**
      * Return true if aAST has token of aTokenType type.
+     *
      * @param ast
      *        DetailAST instance.
      * @param tokenType

--- a/sevntu-checks/src/main/java/com/github/sevntu/checkstyle/checks/coding/EmptyPublicCtorInClassCheck.java
+++ b/sevntu-checks/src/main/java/com/github/sevntu/checkstyle/checks/coding/EmptyPublicCtorInClassCheck.java
@@ -140,6 +140,7 @@ public class EmptyPublicCtorInClassCheck extends AbstractCheck {
     /**
      * Sets regex which matches names of class annotations which require class to have public
      * no-argument ctor.
+     *
      * @param regex
      *        regex to match annotation names.
      */
@@ -154,6 +155,7 @@ public class EmptyPublicCtorInClassCheck extends AbstractCheck {
 
     /**
      * Sets regex which matches names of ctor annotations which make empty public ctor essential.
+     *
      * @param regex
      *        regex to match annotation names.
      */
@@ -231,6 +233,7 @@ public class EmptyPublicCtorInClassCheck extends AbstractCheck {
 
     /**
      * Calculates constructor count for class.
+     *
      * @param classDefNode
      *        a class definition node.
      * @return ctor count for given class definition.
@@ -241,6 +244,7 @@ public class EmptyPublicCtorInClassCheck extends AbstractCheck {
 
     /**
      * Gets first constructor definition for class.
+     *
      * @param classDefNode
      *        a class definition node.
      * @return first ctor definition node for class or null if class has no ctor.
@@ -253,6 +257,7 @@ public class EmptyPublicCtorInClassCheck extends AbstractCheck {
 
     /**
      * Checks whether constructor is public.
+     *
      * @param ctorDefNode
      *        a ctor definition node(TokenTypes.CTOR_DEF).
      * @return true, if given ctor is public.
@@ -265,6 +270,7 @@ public class EmptyPublicCtorInClassCheck extends AbstractCheck {
 
     /**
      * Checks whether ctor has no parameters.
+     *
      * @param ctorDefNode
      *        a ctor definition node(TokenTypes.CTOR_DEF).
      * @return true, if ctor has no parameters.
@@ -275,6 +281,7 @@ public class EmptyPublicCtorInClassCheck extends AbstractCheck {
 
     /**
      * Checks whether ctor body has no statements.
+     *
      * @param ctorDefNode
      *        a ctor definition node(TokenTypes.CTOR_DEF).
      * @return true if ctor body has no statements.
@@ -286,6 +293,7 @@ public class EmptyPublicCtorInClassCheck extends AbstractCheck {
     /**
      * Checks whether class definition has annotation with name specified in
      * {@link #classAnnotationNames} regexp.
+     *
      * @param classDefNode
      *        the node of type TokenTypes.CLASS_DEF.
      * @return true, if class definition has annotation with name specified in regexp.
@@ -298,6 +306,7 @@ public class EmptyPublicCtorInClassCheck extends AbstractCheck {
     /**
      * Checks whether ctor definition has annotation with name specified in
      * {@link #ctorAnnotationNames} regexp.
+     *
      * @param ctorDefNode
      *        the node of type TokenTypes.CTOR_DEF.
      * @return true, if ctor definition has annotation with name specified in regexp.
@@ -309,6 +318,7 @@ public class EmptyPublicCtorInClassCheck extends AbstractCheck {
 
     /**
      * Checks whether any name from the list matches regex.
+     *
      * @param annotationNames
      *        annotation names to match against regex.
      * @param pattern
@@ -333,6 +343,7 @@ public class EmptyPublicCtorInClassCheck extends AbstractCheck {
 
     /**
      * Returns canonical names of annotations for given node.
+     *
      * @param node
      *        annotated node.
      * @return list of canonical annotation names for given node.
@@ -362,6 +373,7 @@ public class EmptyPublicCtorInClassCheck extends AbstractCheck {
 
     /**
      * Checks whether import is on demand import(one that imports entire package).
+     *
      * @param importTargetName
      *        target of import statement.
      * @return true, if import is on demand import import.
@@ -374,6 +386,7 @@ public class EmptyPublicCtorInClassCheck extends AbstractCheck {
      * <p>
      * Generates possible canonical annotation names.
      * </p>
+     *
      * @param annotationName
      *        simple annotation name.
      * @return list of possible canonical annotation names.
@@ -416,6 +429,7 @@ public class EmptyPublicCtorInClassCheck extends AbstractCheck {
      * "package.Person", joinMemberImportWithIdentifier("package.Person","Person.Name") returns
      * "package.Person.Name".
      * </p>
+     *
      * @param importEntry
      *        single type import entry for join.
      * @param identifierName
@@ -447,6 +461,7 @@ public class EmptyPublicCtorInClassCheck extends AbstractCheck {
      * For example: joinWildcardImportWithIdentifier("package.*","Person") returns "package.Person",
      * joinWildcardImportWithIdentifier("package.*","Person.Name") returns "package.Person.Name".
      * </p>
+     *
      * @param importEntry
      *        on demand import entry for join.
      * @param identifierName
@@ -466,6 +481,7 @@ public class EmptyPublicCtorInClassCheck extends AbstractCheck {
      * For example: joinFilePackageNameWithIdentifier("com.example","Person") returns
      * "com.example.Person".
      * </p>
+     *
      * @param packageName
      *        package name to use for join.
      * @param identifierName
@@ -479,6 +495,7 @@ public class EmptyPublicCtorInClassCheck extends AbstractCheck {
 
     /**
      * Returns first part of identifier name.
+     *
      * @param canonicalName
      *        identifier name.
      * @return first part of identifier name if name is qualified, otherwise returns identifier name
@@ -505,6 +522,7 @@ public class EmptyPublicCtorInClassCheck extends AbstractCheck {
      * <p>
      * For example: If method called for name "com.example.company.Person" it will return "Person".
      * </p>
+     *
      * @param qualifiedName
      *        qualified identifier name.
      * @return simple identifier name.
@@ -515,6 +533,7 @@ public class EmptyPublicCtorInClassCheck extends AbstractCheck {
 
     /**
      * Returns name of identifier contained in specified node.
+     *
      * @param identifierNode
      *        a node containing identifier or qualified identifier.
      * @return identifier name for specified node. If node contains qualified name then method

--- a/sevntu-checks/src/main/java/com/github/sevntu/checkstyle/checks/coding/FinalizeImplementationCheck.java
+++ b/sevntu-checks/src/main/java/com/github/sevntu/checkstyle/checks/coding/FinalizeImplementationCheck.java
@@ -117,6 +117,7 @@ public class FinalizeImplementationCheck extends AbstractCheck {
     /**
      * Checks, if finalize implementation is correct. If implementation is bad,
      * this method will call log() with suitable warning message.
+     *
      * @param finalizeMethodToken
      *        current finalize() token
      * @return warning message or null, if all is well.
@@ -153,6 +154,7 @@ public class FinalizeImplementationCheck extends AbstractCheck {
 
     /**
      * Checks, if current method is finalize().
+     *
      * @param methodDefToken
      *        current method definition.
      * @return true, if method is finalize() method.
@@ -165,6 +167,7 @@ public class FinalizeImplementationCheck extends AbstractCheck {
 
     /**
      * Checks, if finalize() has "static" access modifier.
+     *
      * @param modifierType
      *        modifier type.
      * @param methodToken
@@ -178,6 +181,7 @@ public class FinalizeImplementationCheck extends AbstractCheck {
 
     /**
      * Checks, if current method name is "finalize".
+     *
      * @param methodDefToken
      *        method definition Token.
      * @return true, if current method name is "finalize".
@@ -189,6 +193,7 @@ public class FinalizeImplementationCheck extends AbstractCheck {
 
     /**
      * Checks, if method is void.
+     *
      * @param methodDefToken
      *        method definition Token.
      * @return true, if method is void.
@@ -200,6 +205,7 @@ public class FinalizeImplementationCheck extends AbstractCheck {
 
     /**
      * Counts number of parameters.
+     *
      * @param methodDefToken
      *        method definition Token.
      * @return number of parameters.
@@ -210,6 +216,7 @@ public class FinalizeImplementationCheck extends AbstractCheck {
 
     /**
      * Checks, if current method has super.finalize() call.
+     *
      * @param openingBrace
      *        current method definition.
      * @return true, if method has super.finalize() call.

--- a/sevntu-checks/src/main/java/com/github/sevntu/checkstyle/checks/coding/ForbidCCommentsInMethodsCheck.java
+++ b/sevntu-checks/src/main/java/com/github/sevntu/checkstyle/checks/coding/ForbidCCommentsInMethodsCheck.java
@@ -31,6 +31,7 @@ import com.puppycrawl.tools.checkstyle.api.TokenTypes;
  * This check forbid to use C style comments into the method body. If you use
  * class declaration into the method body you will get an error.
  * </p>
+ *
  * @author <a href="mailto:IliaDubinin91@gmail.com">Ilia Dubinin</a>
  * @since 1.6.0
  */

--- a/sevntu-checks/src/main/java/com/github/sevntu/checkstyle/checks/coding/ForbidCertainImportsCheck.java
+++ b/sevntu-checks/src/main/java/com/github/sevntu/checkstyle/checks/coding/ForbidCertainImportsCheck.java
@@ -54,6 +54,7 @@ import com.puppycrawl.tools.checkstyle.api.TokenTypes;
  * <p>
  * You can cover more sophisticated rules by means of few check instances.
  * </p>
+ *
  * @author <a href="mailto:Daniil.Yaroslavtsev@gmail.com"> Daniil
  *         Yaroslavtsev</a>
  * @since 1.8.0
@@ -90,6 +91,7 @@ public class ForbidCertainImportsCheck extends AbstractCheck {
 
     /**
      * Sets the regexp for matching package fully qualified name.
+     *
      * @param packageNameRegexp
      *        regexp for package fully qualified name matching.
      */
@@ -101,6 +103,7 @@ public class ForbidCertainImportsCheck extends AbstractCheck {
 
     /**
      * Gets the regexp is used for matching forbidden imports.
+     *
      * @return regexp for forbidden imports matching.
      */
     public String getForbiddenImportRegexp() {
@@ -109,6 +112,7 @@ public class ForbidCertainImportsCheck extends AbstractCheck {
 
     /**
      * Sets the regexp for matching forbidden imports.
+     *
      * @param forbiddenImportsRegexp
      *        regexp for matching forbidden imports.
      */
@@ -120,6 +124,7 @@ public class ForbidCertainImportsCheck extends AbstractCheck {
 
     /**
      * Sets the regexp for excluding imports from checking.
+     *
      * @param forbiddenImportsExcludesRegexp
      *        String contains a regexp for excluding imports from checking.
      */
@@ -187,6 +192,7 @@ public class ForbidCertainImportsCheck extends AbstractCheck {
 
     /**
      * Checks if given import both matches 'include' and not matches 'exclude' patterns.
+     *
      * @param importText package fully qualified name
      * @return true is given import is forbidden in current
      *     classes package, false otherwise
@@ -201,6 +207,7 @@ public class ForbidCertainImportsCheck extends AbstractCheck {
 
     /**
      * Logs message on the part of code.
+     *
      * @param nodeToWarn
      *        A DetailAST node is pointing to the part of code to warn on.
      * @param importText
@@ -213,6 +220,7 @@ public class ForbidCertainImportsCheck extends AbstractCheck {
 
     /**
      * Gets package/import text representation from node of PACKAGE_DEF or IMPORT type.
+     *
      * @param packageDefOrImportNode
      *        - DetailAST node is pointing to package or import definition
      *        (should be a PACKAGE_DEF or IMPORT type).

--- a/sevntu-checks/src/main/java/com/github/sevntu/checkstyle/checks/coding/ForbidCertainMethodCheck.java
+++ b/sevntu-checks/src/main/java/com/github/sevntu/checkstyle/checks/coding/ForbidCertainMethodCheck.java
@@ -103,6 +103,7 @@ public class ForbidCertainMethodCheck extends AbstractCheck {
 
     /**
      * Set method name regex for the forbidden method.
+     *
      * @param methodName regex for the method name
      */
     public void setMethodName(String methodName) {
@@ -112,6 +113,7 @@ public class ForbidCertainMethodCheck extends AbstractCheck {
     /**
      * Set number or range to match number of arguments of the forbidden method.
      * Multiple values must be comma separated.
+     *
      * @param argumentCount range for matching number of arguments
      * @throws CheckstyleException when argumentCount is not a valid range
      */
@@ -172,6 +174,7 @@ public class ForbidCertainMethodCheck extends AbstractCheck {
 
     /**
      * Count the parameters given to a method call.
+     *
      * @param ast The method call AST.
      * @return The number of parameters.
      */
@@ -190,6 +193,7 @@ public class ForbidCertainMethodCheck extends AbstractCheck {
 
     /**
      * Check if the method/constructor call against defined rules.
+     *
      * @param name ruleName of the the method
      * @param argCount number of arguments of the method
      * @return true if method name and argument matches, false otherwise.
@@ -231,6 +235,7 @@ public class ForbidCertainMethodCheck extends AbstractCheck {
 
         /**
          * Initialize IntRange object with a lower limit and an upper limit.
+         *
          * @param lowerLimit lower limit of the range, must be >= 0, null is equivalent to 0
          * @param upperLimit upper limit of the range, null is equivalent to infinity
          */
@@ -241,6 +246,7 @@ public class ForbidCertainMethodCheck extends AbstractCheck {
 
         /**
          * Create a range object corresponding to it string representation.
+         *
          * @param range string representation of the range
          * @return IntRange object for the string
          *
@@ -281,6 +287,7 @@ public class ForbidCertainMethodCheck extends AbstractCheck {
         /**
          * Check if range contain given number. Range is closed.
          * If lower/upper bound is absent, it is considered unbounded on lower/upper side.
+         *
          * @param num the number to be checked
          * @return true if number is contained in the range, false otherwise
          */

--- a/sevntu-checks/src/main/java/com/github/sevntu/checkstyle/checks/coding/ForbidInstantiationCheck.java
+++ b/sevntu-checks/src/main/java/com/github/sevntu/checkstyle/checks/coding/ForbidInstantiationCheck.java
@@ -40,6 +40,7 @@ import com.puppycrawl.tools.checkstyle.api.TokenTypes;
  * Note: className should to be full: use "java.lang.NullPointerException"
  * instead of "NullpointerException".
  * </p>
+ *
  * @author <a href="mailto:Daniil.Yaroslavtsev@gmail.com"> Daniil
  *         Yaroslavtsev</a>
  * @since 1.8.0
@@ -76,6 +77,7 @@ public class ForbidInstantiationCheck extends AbstractCheck {
 
     /**
      * Sets a classNames&amp;Paths for objects that are forbidden to instantiate.
+     *
      * @param classNames
      *        - the list of classNames separated by a comma. ClassName should be
      *        full, such as "java.lang.NullpointerException", do not use short
@@ -157,6 +159,7 @@ public class ForbidInstantiationCheck extends AbstractCheck {
     /**
      * Checks that the class with given className is visible because of the
      * forbidden import.
+     *
      * @param className
      *        - the name of the class to check.
      * @param forbiddenClassNameAndPath
@@ -223,6 +226,7 @@ public class ForbidInstantiationCheck extends AbstractCheck {
 
     /**
      * Gets the class name from full (dotted) classPath.
+     *
      * @param classNameAndPath
      *        - the full (dotted) classPath
      * @return the name of the class is specified by the current full name&path.
@@ -233,6 +237,7 @@ public class ForbidInstantiationCheck extends AbstractCheck {
 
     /**
      * Gets the text representation from the given DetailAST node.
+     *
      * @param ast
      *        - DetailAST node is pointing to import definition or to the "new"
      *        literal node ("IMPORT" or "LITERAL_NEW" node types).

--- a/sevntu-checks/src/main/java/com/github/sevntu/checkstyle/checks/coding/ForbidReturnInFinallyBlockCheck.java
+++ b/sevntu-checks/src/main/java/com/github/sevntu/checkstyle/checks/coding/ForbidReturnInFinallyBlockCheck.java
@@ -98,6 +98,7 @@ public class ForbidReturnInFinallyBlockCheck extends AbstractCheck {
 
     /**
      * Checks if there is a method definition in the node.
+     *
      * @param returnNode The token to examine.
      * @return true if a method definition was found.
      */

--- a/sevntu-checks/src/main/java/com/github/sevntu/checkstyle/checks/coding/ForbidThrowAnonymousExceptionsCheck.java
+++ b/sevntu-checks/src/main/java/com/github/sevntu/checkstyle/checks/coding/ForbidThrowAnonymousExceptionsCheck.java
@@ -56,6 +56,7 @@ import com.puppycrawl.tools.checkstyle.api.TokenTypes;
  * In that case, after literal new, there would be an expression type finishing
  * with and ObjBlock.<br>
  * <br>
+ *
  * @author <a href="mailto:nesterenko-aleksey@list.ru">Aleksey Nesterenko</a>
  * @author <a href="mailto:maxvetrenko2241@gmail.com">Max Vetrenko</a>
  * @since 1.11.0
@@ -78,6 +79,7 @@ public class ForbidThrowAnonymousExceptionsCheck extends AbstractCheck {
 
     /**
      * Setter for pattern.
+     *
      * @param exceptionClassNameRegex The regular expression to set.
      */
     public void setExceptionClassNameRegex(String exceptionClassNameRegex) {
@@ -119,6 +121,7 @@ public class ForbidThrowAnonymousExceptionsCheck extends AbstractCheck {
 
     /**
      * Warns on throwing anonymous exception.
+     *
      * @param throwDefAst The token to examine.
      */
     private void identifyThrowingAnonymousException(DetailAST throwDefAst) {
@@ -142,6 +145,7 @@ public class ForbidThrowAnonymousExceptionsCheck extends AbstractCheck {
     /**
      * Analyzes variable definition for anonymous exception definition. if found
      * - adds it to list of anonymous exceptions
+     *
      * @param variableDefAst The token to examine.
      */
     private void
@@ -170,6 +174,7 @@ public class ForbidThrowAnonymousExceptionsCheck extends AbstractCheck {
 
     /**
      * Gets the literal new node from variable definition node or throw node.
+     *
      * @param literalThrowOrVariableDefAst The token to examine.
      * @return the specified node.
      */
@@ -181,6 +186,7 @@ public class ForbidThrowAnonymousExceptionsCheck extends AbstractCheck {
 
     /**
      * Retrieves the AST node which contains the name of throwing exception.
+     *
      * @param expressionAst The token to examine.
      * @return the specified node.
      */
@@ -191,6 +197,7 @@ public class ForbidThrowAnonymousExceptionsCheck extends AbstractCheck {
 
     /**
      * Checks if definition with a literal new has an ObjBlock.
+     *
      * @param literalNewAst The token to examine.
      * @return true if the new has an object block.
      */
@@ -201,6 +208,7 @@ public class ForbidThrowAnonymousExceptionsCheck extends AbstractCheck {
     /**
      * Checks if variable name is definitely an exception name. It is so if
      * variable type ends with "Exception" suffix
+     *
      * @param variableNameAst The token to examine.
      * @return true if the name is an exception.
      */

--- a/sevntu-checks/src/main/java/com/github/sevntu/checkstyle/checks/coding/IllegalCatchExtendedCheck.java
+++ b/sevntu-checks/src/main/java/com/github/sevntu/checkstyle/checks/coding/IllegalCatchExtendedCheck.java
@@ -32,6 +32,7 @@ import com.puppycrawl.tools.checkstyle.utils.CheckUtil;
 /**
  * Catching java.lang.Exception, java.lang.Error or java.lang.RuntimeException
  * is almost never acceptable.
+ *
  * @author <a href="mailto:simon@redhillconsulting.com.au">Simon Harris</a>
  * @since 1.8.0
  */
@@ -83,6 +84,7 @@ public final class IllegalCatchExtendedCheck extends AbstractCheck {
     /**
      * Enable(false) | Disable(true) warnings for "catch" blocks containing
      * throwing an exception.
+     *
      * @param value Disable warning for throwing
      */
     public void setAllowThrow(final boolean value) {
@@ -92,6 +94,7 @@ public final class IllegalCatchExtendedCheck extends AbstractCheck {
     /**
      * Enable(false) | Disable(true) warnings for "catch" blocks containing
      * rethrowing an exception.
+     *
      * @param value Disable warnings for rethrowing
      */
     public void setAllowRethrow(final boolean value) {
@@ -148,6 +151,7 @@ public final class IllegalCatchExtendedCheck extends AbstractCheck {
 
     /**
      * Looking for the keyword "throw" among current (aParentAST) node childs.
+     *
      * @param parentAST - the current parent node.
      * @return null if the "throw" keyword was not found
      *     or the LITERAL_THROW DetailAST otherwise
@@ -173,6 +177,7 @@ public final class IllegalCatchExtendedCheck extends AbstractCheck {
 
     /**
      * Gets all the children one level below on the current top node.
+     *
      * @param node - current parent node.
      * @return an array of childs one level below
      *     on the current parent node aNode. */

--- a/sevntu-checks/src/main/java/com/github/sevntu/checkstyle/checks/coding/Jsr305AnnotationsCheck.java
+++ b/sevntu-checks/src/main/java/com/github/sevntu/checkstyle/checks/coding/Jsr305AnnotationsCheck.java
@@ -303,6 +303,7 @@ public class Jsr305AnnotationsCheck extends AbstractCheck {
 
         /**
          * Constructor.
+         *
          * @param annotationName
          *        the annotation's name
          * @param packageName
@@ -375,6 +376,7 @@ public class Jsr305AnnotationsCheck extends AbstractCheck {
 
     /**
      * Sets the included packages property.
+     *
      * @param packageNames
      *        the package names, comma separated
      */
@@ -384,6 +386,7 @@ public class Jsr305AnnotationsCheck extends AbstractCheck {
 
     /**
      * Sets the excluded packages property.
+     *
      * @param packageNames
      *        the package names, comma separated
      */
@@ -393,6 +396,7 @@ public class Jsr305AnnotationsCheck extends AbstractCheck {
 
     /**
      * Sets the property for allowing overriding return values.
+     *
      * @param newAllowOverridingReturnValue
      *        true if yes
      */
@@ -402,6 +406,7 @@ public class Jsr305AnnotationsCheck extends AbstractCheck {
 
     /**
      * Sets the property for allowing overriding parameters.
+     *
      * @param newAllowOverridingParameter
      *        true if yes
      */
@@ -411,6 +416,7 @@ public class Jsr305AnnotationsCheck extends AbstractCheck {
 
     /**
      * Maps annotations to their respective names.
+     *
      * @return the map
      */
     private static Map<String, NullnessAnnotation> createString2AnnotationMap() {
@@ -426,6 +432,7 @@ public class Jsr305AnnotationsCheck extends AbstractCheck {
 
     /**
      * Removes duplicates from an array of strings.
+     *
      * @param input
      *        the array
      * @return a new, duplicate-free array
@@ -437,6 +444,7 @@ public class Jsr305AnnotationsCheck extends AbstractCheck {
 
     /**
      * Checks whether a package is excluded.
+     *
      * @param fullIdent
      *        the identifier
      * @return true if yes
@@ -504,6 +512,7 @@ public class Jsr305AnnotationsCheck extends AbstractCheck {
 
     /**
      * Find the nullness annotations.
+     *
      * @param ast
      *        the ast
      * @return the annotations.
@@ -524,6 +533,7 @@ public class Jsr305AnnotationsCheck extends AbstractCheck {
 
     /**
      * Adds the nullness annotation from the argument's first token if any.
+     *
      * @param result
      *        the result
      * @param ast
@@ -543,6 +553,7 @@ public class Jsr305AnnotationsCheck extends AbstractCheck {
 
     /**
      * Is the current symbol a primitive type.
+     *
      * @param ast
      *        the ast
      * @return true if yes
@@ -594,6 +605,7 @@ public class Jsr305AnnotationsCheck extends AbstractCheck {
 
     /**
      * Is the current symbol of void type.
+     *
      * @param ast
      *        the ast
      * @return true if yes
@@ -613,6 +625,7 @@ public class Jsr305AnnotationsCheck extends AbstractCheck {
 
         /**
          * Constructor.
+         *
          * @param ast
          *        the ast
          */
@@ -642,6 +655,7 @@ public class Jsr305AnnotationsCheck extends AbstractCheck {
 
         /**
          * Constructor.
+         *
          * @param ast
          *        the ast
          */
@@ -713,6 +727,7 @@ public class Jsr305AnnotationsCheck extends AbstractCheck {
 
         /**
          * Constructor.
+         *
          * @param ast
          *        the ast
          */
@@ -745,6 +760,7 @@ public class Jsr305AnnotationsCheck extends AbstractCheck {
 
         /**
          * Constructor.
+         *
          * @param ast
          *        the ast
          */
@@ -820,6 +836,7 @@ public class Jsr305AnnotationsCheck extends AbstractCheck {
 
         /**
          * Constructor.
+         *
          * @param ast
          *        the ast
          */
@@ -860,6 +877,7 @@ public class Jsr305AnnotationsCheck extends AbstractCheck {
 
         /**
          * Construtor.
+         *
          * @param ast
          *        the ast
          */
@@ -892,6 +910,7 @@ public class Jsr305AnnotationsCheck extends AbstractCheck {
 
         /**
          * Emits a violation if any of the given annotations are found.
+         *
          * @param msg
          *        the violation message to emit
          * @param search
@@ -905,6 +924,7 @@ public class Jsr305AnnotationsCheck extends AbstractCheck {
 
         /**
          * Check whether any of the given annotations are found.
+         *
          * @param search
          *        the annotations to look for
          * @return true if yes
@@ -924,6 +944,7 @@ public class Jsr305AnnotationsCheck extends AbstractCheck {
 
         /**
          * Emits a violation if all given annotations are found.
+         *
          * @param msg
          *        the violation message to emit
          * @param search
@@ -937,6 +958,7 @@ public class Jsr305AnnotationsCheck extends AbstractCheck {
 
         /**
          * Emits a violation if both this and the parent class have redundant nullness annotations.
+         *
          * @param msg
          *        the violation message to emit
          * @param search
@@ -959,6 +981,7 @@ public class Jsr305AnnotationsCheck extends AbstractCheck {
 
         /**
          * Check whether all the given annotations are present.
+         *
          * @param search
          *        the annotations to look for
          * @return true if yes
@@ -982,6 +1005,7 @@ public class Jsr305AnnotationsCheck extends AbstractCheck {
 
         /**
          * Make sure that none of the given annotations are present.
+         *
          * @param msg
          *        the violation message to emit if one of the given annotations was found
          * @param search
@@ -1007,6 +1031,7 @@ public class Jsr305AnnotationsCheck extends AbstractCheck {
 
         /**
          * Gets the nullness annotation for the parent method or class.
+         *
          * @param annotationsToLookFor
          *        the annotations to look for.
          * @return the annotation or null if none was found
@@ -1044,6 +1069,7 @@ public class Jsr305AnnotationsCheck extends AbstractCheck {
 
         /**
          * Is the current tokenType a possible type for nullness annotations.
+         *
          * @param tokenType the token type
          * @return true if yes
          */
@@ -1055,6 +1081,7 @@ public class Jsr305AnnotationsCheck extends AbstractCheck {
 
         /**
          * Extracts all given annotations from the current ast.
+         *
          * @param current the current ast
          * @param annotationsToLookFor the annotations we are looking for
          * @return the annotations
@@ -1073,6 +1100,7 @@ public class Jsr305AnnotationsCheck extends AbstractCheck {
 
         /**
          * Is the current method overridden.
+         *
          * @return true if yes
          */
         protected boolean isMethodOverridden() {

--- a/sevntu-checks/src/main/java/com/github/sevntu/checkstyle/checks/coding/LogicConditionNeedOptimizationCheck.java
+++ b/sevntu-checks/src/main/java/com/github/sevntu/checkstyle/checks/coding/LogicConditionNeedOptimizationCheck.java
@@ -32,6 +32,7 @@ import com.puppycrawl.tools.checkstyle.api.TokenTypes;
  * For example: if(getProperty() &amp;&amp; property) ==&gt; if(property &amp;&amp; getProperty()),
  * and similarly for any expression.
  * </p>
+ *
  * @author <a href="mailto:IliaDubinin91@gmail.com">Ilia Dubinin</a>
  * @since 1.8.0
  */
@@ -76,6 +77,7 @@ public class LogicConditionNeedOptimizationCheck extends AbstractCheck {
      * <p>
      * Return true, if current expression part need optimization.
      * </p>
+     *
      * @param logicNode
      *        - current logic operator node
      * @return - boolean variable
@@ -103,6 +105,7 @@ public class LogicConditionNeedOptimizationCheck extends AbstractCheck {
      * <p>
      * Return operands of current logic operator.
      * </p>
+     *
      * @param logicNode - current logic operator
      * @return operands
      */
@@ -141,6 +144,7 @@ public class LogicConditionNeedOptimizationCheck extends AbstractCheck {
 
     /**
      * Checks if the node range contains a token of the provided type.
+     *
      * @param operands the list operands in order of start and stop
      * @param setNumber to retrieve the 1st or 2nd operand
      * @param type a TokenType
@@ -162,6 +166,7 @@ public class LogicConditionNeedOptimizationCheck extends AbstractCheck {
 
     /**
      * Checks if the node range contains a token of the provided type.
+     *
      * @param start the token to start checking with (inclusive)
      * @param end the token to end with (inclusive)
      * @param type a TokenType

--- a/sevntu-checks/src/main/java/com/github/sevntu/checkstyle/checks/coding/MapIterationInForEachLoopCheck.java
+++ b/sevntu-checks/src/main/java/com/github/sevntu/checkstyle/checks/coding/MapIterationInForEachLoopCheck.java
@@ -121,6 +121,7 @@ import com.puppycrawl.tools.checkstyle.api.TokenTypes;
  *     System.out.println(entry.getValue() + "   " + entry.getKey());
  * }
  * </pre>
+ *
  * @author <a href="mailto:maxvetrenko2241@gmail.com">Max Vetrenko</a>
  * @since 1.11.0
  */
@@ -222,6 +223,7 @@ public class MapIterationInForEachLoopCheck extends AbstractCheck {
      * Set user's map implementations. It must state the full paths of imported
      * classes. Import paths must be separated by commas. For example:
      * java.util.Map, java.util.HashMap.
+     *
      * @param setSupportedMapImplQualifiedNames
      *        User's set of map implementations.
      */
@@ -241,6 +243,7 @@ public class MapIterationInForEachLoopCheck extends AbstractCheck {
     /**
      * Set aProcessingValue. If value is true, Check will process cases, where
      * values() method will be suitable.
+     *
      * @param proposeValuesUsage
      *        User's value of mProcessingValue.
      */
@@ -252,6 +255,7 @@ public class MapIterationInForEachLoopCheck extends AbstractCheck {
     /**
      * Set aProcessingKeySet. If value is true, Check will process cases, where
      * keySet() method will be suitable.
+     *
      * @param proposeKeySetUsage
      *        User's value of mIsCheckKeySetProcessingEnabled.
      */
@@ -263,6 +267,7 @@ public class MapIterationInForEachLoopCheck extends AbstractCheck {
     /**
      * Set aProcessingEntrySet. If value is true, Check will process cases,
      * where entrySet() method will be suitable.
+     *
      * @param proposeEntrySetUsage
      *        User's value of mIsCheckEntrySetProcessingEnabled.
      */
@@ -333,6 +338,7 @@ public class MapIterationInForEachLoopCheck extends AbstractCheck {
      * Processes "for-each" loop.
      * It searches for keySet() or entrySet() nodes,
      * iterated maps, keys or entries.
+     *
      * @param forLiteralNode
      *        DetailAST of literal for.
      * @return warning message key.
@@ -380,6 +386,7 @@ public class MapIterationInForEachLoopCheck extends AbstractCheck {
 
     /**
      * Checks if the not is a for each.
+     *
      * @param forNode The token to examine.
      * @return true if is for each.
      */
@@ -389,6 +396,7 @@ public class MapIterationInForEachLoopCheck extends AbstractCheck {
 
     /**
      * Searches for keySet() or entrySet() node.
+     *
      * @param forEachNode
      *        Contains current for node.
      * @return keySet() or entrySet() node. If such node didn't found, method
@@ -439,6 +447,7 @@ public class MapIterationInForEachLoopCheck extends AbstractCheck {
     /**
      * Returns true, if any method call inside for loop contains map
      * object as parameter.
+     *
      * @param forEachOpeningBraceNode
      *        List with subtree IDENT nodes.
      * @return true, if any Method Call contains Map Parameter.
@@ -458,6 +467,7 @@ public class MapIterationInForEachLoopCheck extends AbstractCheck {
 
     /**
      * Checks is map instance passed into method call, or not.
+     *
      * @param methodCallNode
      *        DetailAST node of Method Call.
      * @return return true, if method call contain map as parameter.
@@ -479,6 +489,7 @@ public class MapIterationInForEachLoopCheck extends AbstractCheck {
 
     /**
      * Searches for wrong ketSet() usage into for cycles.
+     *
      * @param forEachOpeningBraceNode
      *        For-each opening brace.
      * @param keyName
@@ -528,6 +539,7 @@ public class MapIterationInForEachLoopCheck extends AbstractCheck {
 
     /**
      * Counts the getter methods called inside the if statement.
+     *
      * @param identAndLiteralIfNodesList the nodes to examine.
      * @param mapName Current map name.
      * @param isMapClassField if the map is a class field.
@@ -596,6 +608,7 @@ public class MapIterationInForEachLoopCheck extends AbstractCheck {
 
     /**
      * Checks if the new variable is Map object, or not.
+     *
      * @param variableDefNode
      *        DetailAST node of Variable Definition.
      * @return true, if the new variable is Map object.
@@ -615,6 +628,7 @@ public class MapIterationInForEachLoopCheck extends AbstractCheck {
 
     /**
      * Checks, is current class a Map implementation or not.
+     *
      * @param className
      *        Current class's name.
      * @return true, if current class is contained inside mQualifiedImportList.
@@ -627,6 +641,7 @@ public class MapIterationInForEachLoopCheck extends AbstractCheck {
     /**
      * Checks, is mSupportedMapImplQualifiedNames List contains
      * current class.
+     *
      * @param className
      *        current class name.
      * @return true, if List contains current class.
@@ -650,6 +665,7 @@ public class MapIterationInForEachLoopCheck extends AbstractCheck {
     /**
      * Checks, is mQualifiedImportList contains
      * current class.
+     *
      * @param className
      *        current class name.
      * @return true, if List contains current class.
@@ -667,6 +683,7 @@ public class MapIterationInForEachLoopCheck extends AbstractCheck {
 
     /**
      * Returns the instance's class name.
+     *
      * @param literalNewNodesList
      *        This list contains "new" literals.
      * @return object's class name,
@@ -687,6 +704,7 @@ public class MapIterationInForEachLoopCheck extends AbstractCheck {
     /**
      * Searches the first specific
      * DetailAST node inside List.
+     *
      * @param nodesList
      *        DetailAST List witch maybe contains specific token.
      * @param aSpecificType
@@ -708,6 +726,7 @@ public class MapIterationInForEachLoopCheck extends AbstractCheck {
     /**
      * Returns full path of map implementation. If path doesn't
      * contain full map implementation path, null will be returned.
+     *
      * @param importNode
      *        Import node.
      * @return full path of map implementation or null.
@@ -727,6 +746,7 @@ public class MapIterationInForEachLoopCheck extends AbstractCheck {
 
     /**
      * Searches over subtree for all tokens of necessary types.
+     *
      * @param rootNode
      *        The root of subtree.
      * @param tokenTypes

--- a/sevntu-checks/src/main/java/com/github/sevntu/checkstyle/checks/coding/NameConventionForJunit4TestClassesCheck.java
+++ b/sevntu-checks/src/main/java/com/github/sevntu/checkstyle/checks/coding/NameConventionForJunit4TestClassesCheck.java
@@ -153,6 +153,7 @@ public class NameConventionForJunit4TestClassesCheck extends AbstractCheck {
 
     /**
      * Sets regexp to match 'expected' class names for JUnit tests.
+     *
      * @param expectedClassNameRegex
      *        regexp to match 'correct' JUnit test class names.
      */
@@ -167,6 +168,7 @@ public class NameConventionForJunit4TestClassesCheck extends AbstractCheck {
 
     /**
      * Sets class test annotation name regexp for JUnit tests.
+     *
      * @param annotationNameRegex
      *        regexp to match annotations for unit test classes.
      */
@@ -181,6 +183,7 @@ public class NameConventionForJunit4TestClassesCheck extends AbstractCheck {
 
     /**
      * Sets method test annotation name regexp for JUnit tests.
+     *
      * @param annotationNameRegex
      *        regexp to match annotations for unit test classes.
      */
@@ -220,6 +223,7 @@ public class NameConventionForJunit4TestClassesCheck extends AbstractCheck {
 
     /**
      * Checks whether class definition annotated with user defined annotation.
+     *
      * @param classDefNode
      *        a class definition node
      * @return true, if class definition annotated with user defined annotation
@@ -231,6 +235,7 @@ public class NameConventionForJunit4TestClassesCheck extends AbstractCheck {
     /**
      * Checks whether class contains at least one method annotated with user
      * defined annotation.
+     *
      * @param classDefNode
      *        a class definition node
      * @return true, if class contains at least one method annotated with user
@@ -256,6 +261,7 @@ public class NameConventionForJunit4TestClassesCheck extends AbstractCheck {
 
     /**
      * Returns true, if class has unexpected name.
+     *
      * @param classDefNode
      *        a class definition node
      * @return true, if class has unexpected name
@@ -268,6 +274,7 @@ public class NameConventionForJunit4TestClassesCheck extends AbstractCheck {
     /**
      * Returns true, if class or method has annotation with name specified in
      * regexp.
+     *
      * @param methodOrClassDefNode
      *        the node of type TokenTypes.METHOD_DEF or TokenTypes.CLASS_DEF
      * @param annotationNamesRegexp
@@ -300,6 +307,7 @@ public class NameConventionForJunit4TestClassesCheck extends AbstractCheck {
 
     /**
      * Logs unexpected class name.
+     *
      * @param classDef
      *        the node of type TokenTypes.CLASS_DEF
      */
@@ -309,6 +317,7 @@ public class NameConventionForJunit4TestClassesCheck extends AbstractCheck {
 
     /**
      * Returns name of identifier contained in specified node.
+     *
      * @param identifierNode
      *        a node containing identifier or qualified identifier.
      * @return identifier name for specified node. If node contains qualified
@@ -340,6 +349,7 @@ public class NameConventionForJunit4TestClassesCheck extends AbstractCheck {
 
     /**
      * Matches string against regexp.
+     *
      * @param regexPattern
      *        regex to match string with. May be null.
      * @param str

--- a/sevntu-checks/src/main/java/com/github/sevntu/checkstyle/checks/coding/NoNullForCollectionReturnCheck.java
+++ b/sevntu-checks/src/main/java/com/github/sevntu/checkstyle/checks/coding/NoNullForCollectionReturnCheck.java
@@ -48,6 +48,7 @@ import com.puppycrawl.tools.checkstyle.api.TokenTypes;
  * PriorityBlockingQueue, PriorityQueue, RoleList, RoleUnresolvedList, Stack, SynchronousQueue,
  * TreeSet, Vector, Collection, List, Map, Set.
  * </p>
+ *
  * @author <a href="mailto:IliaDubinin91@gmail.com">Ilja Dubinin</a>
  * @since 1.9.0
  */
@@ -97,6 +98,7 @@ public class NoNullForCollectionReturnCheck extends AbstractCheck {
      * <p>
      * Setter for list of known collections.
      * </p>
+     *
      * @param collectionList
      *        - line contains all collection names.
      */
@@ -111,6 +113,7 @@ public class NoNullForCollectionReturnCheck extends AbstractCheck {
      * <p>
      * Setter for searching through body of the method.
      * </p>
+     *
      * @param searchThroughMethodBody
      *        - deep search value.
      */
@@ -172,6 +175,7 @@ public class NoNullForCollectionReturnCheck extends AbstractCheck {
      * <p>
      * Returns true, when method type is a collection or an array.
      * </p>
+     *
      * @param methodDef
      *        - DetailAST contains method definition node.
      * @return true, when method return collection.
@@ -187,6 +191,7 @@ public class NoNullForCollectionReturnCheck extends AbstractCheck {
      * <p>
      * Returns true when null literal has in return expression.
      * </p>
+     *
      * @param returnLit
      *        - DetailAST contains return literal
      * @return true when null literal has in return expression.
@@ -208,6 +213,7 @@ public class NoNullForCollectionReturnCheck extends AbstractCheck {
      * <p>
      * Returns true, when variable in return may be null.
      * </p>
+     *
      * @param returnLit
      *        - DetailAST contains LITERAL_RETURN
      * @return true, when variable may be null.
@@ -254,6 +260,7 @@ public class NoNullForCollectionReturnCheck extends AbstractCheck {
      * <p>
      * Return all the nested subblocks in block.
      * </p>
+     *
      * @param blockDef
      *        - node of the block.
      * @return all the nested subblocks in block.
@@ -289,6 +296,7 @@ public class NoNullForCollectionReturnCheck extends AbstractCheck {
      * <p>
      * Return true when variable is null into the variable definition.
      * </p>
+     *
      * @param subBlocks
      *        - list contains subblocks.
      * @param variableName
@@ -329,6 +337,7 @@ public class NoNullForCollectionReturnCheck extends AbstractCheck {
      * <p>
      * Returns all children of that have the specified type.
      * </p>
+     *
      * @param root
      *        - root token of a block
      * @param type
@@ -354,6 +363,7 @@ public class NoNullForCollectionReturnCheck extends AbstractCheck {
      * <p>
      * Return DetailAST that contained method definition.
      * </p>
+     *
      * @param returnLit
      *        - DetailAST contains LITERAL_RETURN.
      * @return DetailAST contains METHOD_DEF
@@ -370,6 +380,7 @@ public class NoNullForCollectionReturnCheck extends AbstractCheck {
      * <p>
      * Return body of the block.
      * </p>
+     *
      * @param blockDef
      *        - block definition node
      * @return body of the block.

--- a/sevntu-checks/src/main/java/com/github/sevntu/checkstyle/checks/coding/NumericLiteralNeedsUnderscoreCheck.java
+++ b/sevntu-checks/src/main/java/com/github/sevntu/checkstyle/checks/coding/NumericLiteralNeedsUnderscoreCheck.java
@@ -137,6 +137,7 @@ import com.puppycrawl.tools.checkstyle.api.TokenTypes;
  * int failingBinary = 0b00001111;
  * int passingBinary = 0b0000_1111;
  * </pre>
+ *
  * @author Cheng-Yu Pai
  * @since 1.18.0
  */
@@ -264,6 +265,7 @@ public class NumericLiteralNeedsUnderscoreCheck extends AbstractCheck {
     /**
      * Sets how many characters in a decimal literal there must be before it checks for an
      * underscore.
+     *
      * @param length
      *        minimum checking length of the literal
      */
@@ -274,6 +276,7 @@ public class NumericLiteralNeedsUnderscoreCheck extends AbstractCheck {
     /**
      * Sets how many characters there can be until there must be an underscore (for decimal
      * literals).
+     *
      * @param amount
      *        maximum number of characters between underscores
      */
@@ -284,6 +287,7 @@ public class NumericLiteralNeedsUnderscoreCheck extends AbstractCheck {
     /**
      * Sets how many characters in a hex literal there must be before it checks for an
      * underscore.
+     *
      * @param length
      *        minimum checking length of the literal
      */
@@ -294,6 +298,7 @@ public class NumericLiteralNeedsUnderscoreCheck extends AbstractCheck {
     /**
      * Sets how many characters there can be until there must be an underscore (for hex
      * literals).
+     *
      * @param amount
      *        maximum number of characters between underscores
      */
@@ -304,6 +309,7 @@ public class NumericLiteralNeedsUnderscoreCheck extends AbstractCheck {
     /**
      * Sets how many characters in a byte literal there must be before it checks for an
      * underscore.
+     *
      * @param length
      *        minimum checking length of the literal
      */
@@ -314,6 +320,7 @@ public class NumericLiteralNeedsUnderscoreCheck extends AbstractCheck {
     /**
      * Sets how many characters there can be until there must be an underscore (binary
      * literals).
+     *
      * @param amount
      *        maximum number of characters between underscores
      */
@@ -323,6 +330,7 @@ public class NumericLiteralNeedsUnderscoreCheck extends AbstractCheck {
 
     /**
      * Sets the regexp pattern for field names to ignore.
+     *
      * @param pattern
      *        the regexp pattern of fields to ignore
      */
@@ -359,6 +367,7 @@ public class NumericLiteralNeedsUnderscoreCheck extends AbstractCheck {
 
     /**
      * Checks if the provided token is a field.
+     *
      * @param ast
      *        the token to check
      * @return whether or not the token is a field
@@ -377,6 +386,7 @@ public class NumericLiteralNeedsUnderscoreCheck extends AbstractCheck {
 
     /**
      * Returns the provided field's name.
+     *
      * @param ast
      *        the field for which the function looks for a name
      * @return the field's name
@@ -395,6 +405,7 @@ public class NumericLiteralNeedsUnderscoreCheck extends AbstractCheck {
 
     /**
      * Returns true if the ast passes the check.
+     *
      * @param ast
      *        the numeric literal to check
      * @return if the numeric literal passes the check
@@ -425,6 +436,7 @@ public class NumericLiteralNeedsUnderscoreCheck extends AbstractCheck {
 
     /**
      * Parses the numeric literal to return the minimum checking length for the literal's type.
+     *
      * @param type
      *        the type of numerical literal
      * @return minimum length before checking
@@ -450,6 +462,7 @@ public class NumericLiteralNeedsUnderscoreCheck extends AbstractCheck {
     /**
      * Parses the numeric literal to return the maximum number of characters before there must
      * be an underscore for the literal's type.
+     *
      * @param type
      *        the type of numerical literal
      * @return maximum number of characters between underscores
@@ -482,6 +495,7 @@ public class NumericLiteralNeedsUnderscoreCheck extends AbstractCheck {
      * perfectly readable.
      * </p>
      * Additionally, Java will not compile underscores next to decimal points etc.
+     *
      * @param strippedLiteral
      *        numeric literal stripped of any prefixes and postfixes
      * @param type
@@ -520,6 +534,7 @@ public class NumericLiteralNeedsUnderscoreCheck extends AbstractCheck {
      * <p>
      * Binary literals are preceded by 0b. Example: 0b00001111
      * </p>
+     *
      * @param rawLiteral
      *        numeric literal
      * @return the type of literal (either decimal, hex, or binary)
@@ -547,6 +562,7 @@ public class NumericLiteralNeedsUnderscoreCheck extends AbstractCheck {
     /**
      * Returns whether or not the text passes the underscore requirement given the text and
      * minimum length.
+     *
      * @param numericSegment
      *        the numeric segment to check
      * @param minLength
@@ -581,6 +597,7 @@ public class NumericLiteralNeedsUnderscoreCheck extends AbstractCheck {
 
     /**
      * Removes 0x, 0b prefixes, and l, L, f, F, d, D postfixes from numeric literals.
+     *
      * @param rawLiteral
      *        the numeric literal that needs to be stripped of prefixes and postfixes
      * @param literalType
@@ -609,6 +626,7 @@ public class NumericLiteralNeedsUnderscoreCheck extends AbstractCheck {
 
     /**
      * Removes the prefixes 0x and 0b.
+     *
      * @param text
      *        the text to remove the prefixes
      * @return the text without the prefixes
@@ -620,6 +638,7 @@ public class NumericLiteralNeedsUnderscoreCheck extends AbstractCheck {
     /**
      * Removes the postfix from the text if it exists. Does not handle hex literals correctly,
      * for that use removePostfixHex.
+     *
      * @param text
      *        the text to remove the postfixes
      * @return the text without the postfixes
@@ -639,6 +658,7 @@ public class NumericLiteralNeedsUnderscoreCheck extends AbstractCheck {
     /**
      * Removes the postfix from the hex literal text if it exists. Does not handle other
      * literals correctly, for those use removeLetterPostfix.
+     *
      * @param text
      *        the text to remove the postfixes
      * @return the text without the postfixes

--- a/sevntu-checks/src/main/java/com/github/sevntu/checkstyle/checks/coding/OverridableMethodInConstructorCheck.java
+++ b/sevntu-checks/src/main/java/com/github/sevntu/checkstyle/checks/coding/OverridableMethodInConstructorCheck.java
@@ -473,6 +473,7 @@ public class OverridableMethodInConstructorCheck extends AbstractCheck {
     /**
      * Gets the method definition is related to the current METHOD_CALL
      * DetailAST node. If method definition doesn't find, will returned null.
+     *
      * @param methodCallAST
      *            A METHOD_CALL DetailAST node is currently being processed.
      * @return the METHOD_DEF DetailAST node is pointing to the method
@@ -580,6 +581,7 @@ public class OverridableMethodInConstructorCheck extends AbstractCheck {
 
     /**
      * Return type of the variable, if it is declaration procedure.
+     *
      * @param methodCall The token to examine.
      * @return variables type name
      */
@@ -608,6 +610,7 @@ public class OverridableMethodInConstructorCheck extends AbstractCheck {
     /**
      * Return true when usedIbjectName contains current class name or base class
      * name.
+     *
      * @param objectTypeName The object type name to check against.
      * @param classDefNode The token to examine.
      * @return true if the type is the same as the current class.
@@ -636,6 +639,7 @@ public class OverridableMethodInConstructorCheck extends AbstractCheck {
     /**
      * Return true when the method called via keyword "this" (this.methodName
      * or ClassName.this.methodName)
+     *
      * @param firstPartOfTheMethodCall The first part of the method call.
      * @param classDefNode The token to examine.
      * @return If the method is called via keyword "this".
@@ -651,6 +655,7 @@ public class OverridableMethodInConstructorCheck extends AbstractCheck {
     /**
      * Gets the count of parameters for current method definition or
      * method call.
+     *
      * @param methodDefOrCallAST METHOD_DEF or METHOD_CALL
      *     DetailAST node
      * @return the count of parameters for current method.
@@ -918,6 +923,7 @@ public class OverridableMethodInConstructorCheck extends AbstractCheck {
 
         /**
          * Creates an instance of OverridableMetCall and initializes fields.
+         *
          * @param methodCallAST
          *            DetailAST node related to the method call that leads
          *            to call of the overridable method.

--- a/sevntu-checks/src/main/java/com/github/sevntu/checkstyle/checks/coding/RedundantReturnCheck.java
+++ b/sevntu-checks/src/main/java/com/github/sevntu/checkstyle/checks/coding/RedundantReturnCheck.java
@@ -73,6 +73,7 @@ import com.puppycrawl.tools.checkstyle.api.TokenTypes;
  *    public void testMethod1(){
  *        return;
  *    }</pre>
+ *
  * @author <a href="mailto:fishh1991@gmail.com">Troshin Sergey</a>
  * @author <a href="mailto:maxvetrenko2241@gmail.com">Max Vetrenko</a>
  * @author <a href="mailto:nesterenko-aleksey@list.ru">Alexey Nesterenko</a>
@@ -93,6 +94,7 @@ public class RedundantReturnCheck extends AbstractCheck {
 
     /**
      * Setter for allowReturnInEmptyMethodsAndConstructors.
+     *
      * @param allowEmptyBlocks allow 'return' in empty constructors and methods that return void.
      */
     public void setAllowReturnInEmptyMethodsAndConstructors(boolean allowEmptyBlocks) {
@@ -145,6 +147,7 @@ public class RedundantReturnCheck extends AbstractCheck {
     /**
      * Ignores method or constructor if it contains <b>only</b> return statement
      * in its body.
+     *
      * @param objectBlockAst The token to examine.
      * @return true if the block can be ignored.
      */
@@ -157,6 +160,7 @@ public class RedundantReturnCheck extends AbstractCheck {
 
     /**
      * Checks if method's or ctor's body is not empty.
+     *
      * @param defAst The token to examine.
      * @return true if body is not empty.
      */
@@ -166,6 +170,7 @@ public class RedundantReturnCheck extends AbstractCheck {
 
     /**
      * Checks if method is void and has a body.
+     *
      * @param methodDefAst The token to examine.
      * @return true if void method has non-empty body.
      */
@@ -179,6 +184,7 @@ public class RedundantReturnCheck extends AbstractCheck {
     /**
      * Puts violation on each redundant return met in object block of
      * method or ctor.
+     *
      * @param redundantReturnsAst The token to examine.
      */
     private void log(List<DetailAST> redundantReturnsAst) {
@@ -190,6 +196,7 @@ public class RedundantReturnCheck extends AbstractCheck {
     /**
      * Returns the list of redundant returns found in method's or ctor's
      * object block.
+     *
      * @param objectBlockAst
      *            - a method or constructor object block
      * @return list of redundant returns or empty list if none were found
@@ -221,6 +228,7 @@ public class RedundantReturnCheck extends AbstractCheck {
 
     /**
      * Returns the list of redundant returns found in try, catch, finally object blocks.
+     *
      * @param tryAst
      *            - Ast that contain a try node.
      * @return list of redundant returns or empty list if none were found
@@ -281,6 +289,7 @@ public class RedundantReturnCheck extends AbstractCheck {
 
     /**
      * Gets next catch block in try block if exists.
+     *
      * @param blockAst The token to examine.
      * @return next found catchBlockAst, if no catch was found - returns null
      */
@@ -295,6 +304,7 @@ public class RedundantReturnCheck extends AbstractCheck {
 
     /**
      * Returns redundant return from try-catch-finally block.
+     *
      * @param statementAst
      *            - a place where the redundantReturn is expected.
      * @return redundant literal return if found, else null.
@@ -322,6 +332,7 @@ public class RedundantReturnCheck extends AbstractCheck {
 
     /**
      * Looks for literal return in the last statement of a catch block.
+     *
      * @param lastStatementInCatchBlockAst The token to examine.
      * @return redundant literal return, if there's no one - returns null
      */
@@ -363,6 +374,7 @@ public class RedundantReturnCheck extends AbstractCheck {
 
     /**
      * Checks if the {@code ast} is the final return statement.
+     *
      * @param ast the AST to examine.
      * @return {@code true} if the {@code ast} is the final return statement.
      */

--- a/sevntu-checks/src/main/java/com/github/sevntu/checkstyle/checks/coding/RequireFailForTryCatchInJunitCheck.java
+++ b/sevntu-checks/src/main/java/com/github/sevntu/checkstyle/checks/coding/RequireFailForTryCatchInJunitCheck.java
@@ -67,6 +67,7 @@ import com.puppycrawl.tools.checkstyle.utils.AnnotationUtil;
  *     }
  *   }
  * </pre>
+ *
  * @author Richard Veach
  * @since 1.25.0
  */
@@ -172,6 +173,7 @@ public class RequireFailForTryCatchInJunitCheck extends AbstractCheck {
 
     /**
      * Examines the try block for violations.
+     *
      * @param ast The try block to examine.
      */
     private void examineTry(DetailAST ast) {
@@ -192,6 +194,7 @@ public class RequireFailForTryCatchInJunitCheck extends AbstractCheck {
 
     /**
      * Checks if the given method is a test method, defined by the junit annotation Test.
+     *
      * @param method the method AST to examine.
      * @return {@code true} if the method is a test method.
      */
@@ -208,6 +211,7 @@ public class RequireFailForTryCatchInJunitCheck extends AbstractCheck {
 
     /**
      * Checks if the expression is an junit fail assertion.
+     *
      * @param expression The expression to examine.
      * @return {@code true} if the expression is a valid junit fail assertion.
      */
@@ -236,6 +240,7 @@ public class RequireFailForTryCatchInJunitCheck extends AbstractCheck {
     /**
      * Retrieves the method definition AST parent from the specified node, as long as it doesn't
      * contain a lambda.
+     *
      * @param node The node to examine.
      * @return The parent method definition.
      */

--- a/sevntu-checks/src/main/java/com/github/sevntu/checkstyle/checks/coding/ReturnCountExtendedCheck.java
+++ b/sevntu-checks/src/main/java/com/github/sevntu/checkstyle/checks/coding/ReturnCountExtendedCheck.java
@@ -171,6 +171,7 @@ public class ReturnCountExtendedCheck extends AbstractCheck {
 
     /**
      * Sets maximum allowed "return" literals count per method/ctor/lambda.
+     *
      * @param maxReturnCount - the new "maxReturnCount" property value.
      * @see ReturnCountExtendedCheck#maxReturnCount
      */
@@ -181,6 +182,7 @@ public class ReturnCountExtendedCheck extends AbstractCheck {
     /**
      * Sets the maximum number of lines of which method/ctor/lambda body may consist to
      * be skipped by check.
+     *
      * @param ignoreMethodLinesCount
      *        - the new value of "ignoreMethodLinesCount" property.
      * @see ReturnCountExtendedCheck#ignoreMethodLinesCount
@@ -192,6 +194,7 @@ public class ReturnCountExtendedCheck extends AbstractCheck {
     /**
      * Sets the minimum "return" statement depth with that will be skipped by
      * check.
+     *
      * @param minIgnoreReturnDepth
      *        - the new "minIgnoreReturnDepth" property value.
      */
@@ -202,6 +205,7 @@ public class ReturnCountExtendedCheck extends AbstractCheck {
     /**
      * Sets the "ignoring empty return statements in void methods and ctors and lambdas"
      * option state.
+     *
      * @param ignoreEmptyReturns
      *        the new "allowEmptyReturns" property value.
      * @see ReturnCountExtendedCheck#ignoreEmptyReturns
@@ -213,6 +217,7 @@ public class ReturnCountExtendedCheck extends AbstractCheck {
     /**
      * Sets the count of code lines on the top of each
      * processed method/ctor that will be ignored by check.
+     *
      * @param topLinesToIgnoreCount
      *        the new "rowsToIgnoreCount" property value.
      * @see ReturnCountExtendedCheck#topLinesToIgnoreCount
@@ -269,6 +274,7 @@ public class ReturnCountExtendedCheck extends AbstractCheck {
 
     /**
      * Reports violation to user based on the parameters given.
+     *
      * @param node The node that the violation is on.
      * @param nodeName The name given to the node.
      * @param mCurReturnCount The return count violation amount.
@@ -300,6 +306,7 @@ public class ReturnCountExtendedCheck extends AbstractCheck {
      * Gets the "return" statements count for given method/ctor/lambda and saves the
      * last "return" statement DetailAST node for given method/ctor/lambda body. Uses
      * an iterative algorithm.
+     *
      * @param methodOpeningBrace
      *        a DetailAST node that points to the current method`s opening
      *        brace.
@@ -353,6 +360,7 @@ public class ReturnCountExtendedCheck extends AbstractCheck {
     /**
      * Checks that the current processed "return" statement is "empty" and
      * should to be counted.
+     *
      * @param returnNode
      *        the DetailAST node is pointing to the current "return" statement.
      *        is being processed.
@@ -369,6 +377,7 @@ public class ReturnCountExtendedCheck extends AbstractCheck {
      * Gets the depth level of given "return" statement. There are few supported
      * coding blocks when depth counting: "if-else", "for", "while"/"do-while"
      * and "switch".
+     *
      * @param methodDefNode
      *        a DetailAST node that points to the current method`s definition.
      * @param returnStmtNode
@@ -399,6 +408,7 @@ public class ReturnCountExtendedCheck extends AbstractCheck {
     /**
      * Gets the name of given method by DetailAST node is pointing to desired
      * method definition.
+     *
      * @param methodDefNode
      *        a DetailAST node that points to the current method`s definition.
      * @return the method name.
@@ -418,6 +428,7 @@ public class ReturnCountExtendedCheck extends AbstractCheck {
     /**
      * Gets the line count between the two DetailASTs which are related to the
      * given "begin" and "end" tokens.
+     *
      * @param beginAst
      *        the "begin" token AST node.
      * @param endAST

--- a/sevntu-checks/src/main/java/com/github/sevntu/checkstyle/checks/coding/SimpleAccessorNameNotationCheck.java
+++ b/sevntu-checks/src/main/java/com/github/sevntu/checkstyle/checks/coding/SimpleAccessorNameNotationCheck.java
@@ -86,6 +86,7 @@ public class SimpleAccessorNameNotationCheck extends AbstractCheck {
 
     /**
      * Setter for prefix.
+     *
      * @param prefix
      *        - prefix of field's name
      */
@@ -137,6 +138,7 @@ public class SimpleAccessorNameNotationCheck extends AbstractCheck {
      * <p>
      * Returns true when setter is correct.
      * </p>
+     *
      * @param methodDef
      *        - DetailAST contains method definition.
      * @param methodName
@@ -176,6 +178,7 @@ public class SimpleAccessorNameNotationCheck extends AbstractCheck {
      * Returns true when getter is correct.
      * </p>
      * .
+     *
      * @param methodDef
      *        - DetailAST contains method definition.
      * @param methodName
@@ -211,6 +214,7 @@ public class SimpleAccessorNameNotationCheck extends AbstractCheck {
      * Returns true, when object block contains only three child: EXPR, SEMI and
      * RCURLY.
      * </p>
+     *
      * @param objectBlock
      *        - is a link to checked block
      * @return true if object block is correct
@@ -225,6 +229,7 @@ public class SimpleAccessorNameNotationCheck extends AbstractCheck {
      * <p>
      * Return name of the field, that use in the setter.
      * </p>
+     *
      * @param assign
      *        - DetailAST contains ASSIGN from EXPR of the setter.
      * @param parameters
@@ -261,6 +266,7 @@ public class SimpleAccessorNameNotationCheck extends AbstractCheck {
      * Compare name of the field and part of name of the method. Return true
      * when they are different.
      * </p>
+     *
      * @param fieldName
      *        - name of the field.
      * @param methodName
@@ -277,6 +283,7 @@ public class SimpleAccessorNameNotationCheck extends AbstractCheck {
      * <p>
      * Returns true, when object block contains only one child: LITERAL_RETURN.
      * </p>
+     *
      * @param methodBody
      *        - DetailAST contains object block of the getter.
      * @return true when object block correct.
@@ -289,6 +296,7 @@ public class SimpleAccessorNameNotationCheck extends AbstractCheck {
      * <p>
      * Return true when getter has correct arguments of return.
      * </p>
+     *
      * @param literalReturn
      *        - DetailAST contains LITERAL_RETURN
      * @return - true when getter has correct return.
@@ -303,6 +311,7 @@ public class SimpleAccessorNameNotationCheck extends AbstractCheck {
      * <p>
      * Return name of the field, that use in the getter.
      * </p>
+     *
      * @param expr
      *        - DetailAST contains expression from getter.
      * @return name of the field, that use in getter.
@@ -333,6 +342,7 @@ public class SimpleAccessorNameNotationCheck extends AbstractCheck {
      * Return true when name of the field is not contained in parameters of the
      * setter method.
      * </p>
+     *
      * @param parameters
      *        - DetailAST contains parameters of the setter.
      * @param fieldName
@@ -359,6 +369,7 @@ public class SimpleAccessorNameNotationCheck extends AbstractCheck {
      * <p>
      * Returns true when method has contained into an anonymous class.
      * </p>
+     *
      * @param methodDef the METHOD_DEF token.
      * @return true when method has contained into an anonymous class.
      */
@@ -371,6 +382,7 @@ public class SimpleAccessorNameNotationCheck extends AbstractCheck {
      * <p>
      * Returns true when method or other block has a body.
      * </p>
+     *
      * @param methodDef
      *        - method definition node
      * @return true when method or other block has a body.
@@ -382,6 +394,7 @@ public class SimpleAccessorNameNotationCheck extends AbstractCheck {
 
     /**
      * Returns true when method has an override annotation.
+     *
      * @param methodDef method definition node
      * @return true when method has an override annotation.
      */

--- a/sevntu-checks/src/main/java/com/github/sevntu/checkstyle/checks/coding/TernaryPerExpressionCountCheck.java
+++ b/sevntu-checks/src/main/java/com/github/sevntu/checkstyle/checks/coding/TernaryPerExpressionCountCheck.java
@@ -180,6 +180,7 @@ public class TernaryPerExpressionCountCheck extends AbstractCheck {
 
     /**
      * Puts question nodes from current expression node into the list.
+     *
      * @param expressionNode
      *          Globally considering expression node
      * @return
@@ -206,6 +207,7 @@ public class TernaryPerExpressionCountCheck extends AbstractCheck {
      * Checks if options <b>ignoreTernaryInBraces</b> or
      * <b>ignoreOneTernaryPerLine</b> were set, hence, count ternary
      * operators in current expression or not.
+     *
      * @param questionAST The token to examine.
      * @return true if can skip ternary operator.
      */
@@ -217,6 +219,7 @@ public class TernaryPerExpressionCountCheck extends AbstractCheck {
     /**
      * Checks ternary operator if it is in braces, which are explicitly setting
      * the priority level.
+     *
      * @param questionAST The token to examine.
      * @return true if ternary operator is in braces.
      */
@@ -227,6 +230,7 @@ public class TernaryPerExpressionCountCheck extends AbstractCheck {
 
     /**
      * Checks if there's one ternary operator per line.
+     *
      * @param questionAST The token to examine.
      * @return true if ternary is isolated on line.
      */
@@ -239,6 +243,7 @@ public class TernaryPerExpressionCountCheck extends AbstractCheck {
 
     /**
      * Checks line parameter on containing more than 1 ternary operator.
+     *
      * @param line The line to examine.
      * @param lineNo The line number of the line.
      * @return true if line is single ternary.

--- a/sevntu-checks/src/main/java/com/github/sevntu/checkstyle/checks/coding/UnnecessaryParenthesesExtendedCheck.java
+++ b/sevntu-checks/src/main/java/com/github/sevntu/checkstyle/checks/coding/UnnecessaryParenthesesExtendedCheck.java
@@ -239,6 +239,7 @@ public class UnnecessaryParenthesesExtendedCheck extends AbstractCheck {
 
     /**
      * Examines the expression AST for violations.
+     *
      * @param ast The AST to examine.
      */
     private void leaveTokenExpression(DetailAST ast) {
@@ -281,6 +282,7 @@ public class UnnecessaryParenthesesExtendedCheck extends AbstractCheck {
      * In short, does <code>aAST</code> have a previous sibling whose type is
      * <code>TokenTypes.LPAREN</code> and a next sibling whose type is <code>
      * TokenTypes.RPAREN</code>.
+     *
      * @param ast the <code>DetailAST</code> to check if it is surrounded by
      *        parentheses.
      * @return <code>true</code> if <code>aAST</code> is surrounded by
@@ -296,6 +298,7 @@ public class UnnecessaryParenthesesExtendedCheck extends AbstractCheck {
 
     /**
      * Tests if the given expression node is surrounded by parentheses.
+     *
      * @param ast a <code>DetailAST</code> whose type is
      *        <code>TokenTypes.EXPR</code>.
      * @return <code>true</code> if the expression is surrounded by
@@ -309,6 +312,7 @@ public class UnnecessaryParenthesesExtendedCheck extends AbstractCheck {
 
     /**
      * Check if the given token type can be found in an array of token types.
+     *
      * @param type the token type.
      * @param tokens an array of token types to search.
      * @return <code>true</code> if <code>aType</code> was found in <code>
@@ -330,6 +334,7 @@ public class UnnecessaryParenthesesExtendedCheck extends AbstractCheck {
      * Returns the specified string chopped to <code>MAX_QUOTED_LENGTH</code>
      * plus an ellipsis (...) if the length of the string exceeds <code>
      * MAX_QUOTED_LENGTH</code>.
+     *
      * @param string the string to potentially chop.
      * @return the chopped string if <code>aString</code> is longer than
      *         <code>MAX_QUOTED_LENGTH</code>; otherwise <code>aString</code>.
@@ -348,6 +353,7 @@ public class UnnecessaryParenthesesExtendedCheck extends AbstractCheck {
     /**
      * Returns the type of the subtree, witch need to detect equals
      * in boolean calculation.
+     *
      * @param ast the <code>DetailAST</code>
      * @return integer value of subtree
      */

--- a/sevntu-checks/src/main/java/com/github/sevntu/checkstyle/checks/coding/UselessSingleCatchCheck.java
+++ b/sevntu-checks/src/main/java/com/github/sevntu/checkstyle/checks/coding/UselessSingleCatchCheck.java
@@ -91,6 +91,7 @@ public class UselessSingleCatchCheck extends AbstractCheck {
     /**
      * Determines whether throw node is of form
      * <code>throw exceptionObject;</code>.
+     *
      * @param throwNode
      *        node of type TokenTypes.LITERAL_THROW
      * @return whether this throw node is of specified form
@@ -104,6 +105,7 @@ public class UselessSingleCatchCheck extends AbstractCheck {
 
     /**
      * Gets catch parameter name.
+     *
      * @param catchNode
      *        node of type TokenTypes.LITERAL_CATCH
      * @return catch parameter name
@@ -117,6 +119,7 @@ public class UselessSingleCatchCheck extends AbstractCheck {
     /**
      * Gets throw parameter name. throw node must be of the form
      * <code>throw exceptionObject;</code>
+     *
      * @param throwNode
      *        node of type TokenTypes.LITERAL_THROW
      * @return throw parameter name

--- a/sevntu-checks/src/main/java/com/github/sevntu/checkstyle/checks/coding/UselessSuperCtorCallCheck.java
+++ b/sevntu-checks/src/main/java/com/github/sevntu/checkstyle/checks/coding/UselessSuperCtorCallCheck.java
@@ -171,6 +171,7 @@ public class UselessSuperCtorCallCheck extends AbstractCheck {
 
     /**
      * Sets flag to allowCallToNoArgsSuperCtor.
+     *
      * @param aAllowCallToNoArgsSuperCtor
      *        if true, check will allow super() calls without arguments
      */
@@ -180,6 +181,7 @@ public class UselessSuperCtorCallCheck extends AbstractCheck {
 
     /**
      * Sets flag to allowCallToNoArgsSuperCtorIfMultiplePublicCtor.
+     *
      * @param aAllowCall
      *        if true, check will allow super() calls without arguments if class
      *        has multiple public constructors
@@ -225,6 +227,7 @@ public class UselessSuperCtorCallCheck extends AbstractCheck {
 
     /**
      * Returns class name for given class definition node.
+     *
      * @param aClassDefNode
      *          a class definition node(TokenTypes.CLASS_DEF)
      * @return class name for given class definition
@@ -235,6 +238,7 @@ public class UselessSuperCtorCallCheck extends AbstractCheck {
 
     /**
      * Returns arguments count for super ctor call.
+     *
      * @param aMethodCallNode
      *        a super ctor call node(TokenTypes.SUPER_CTOR_CALL)
      * @return arguments count for super ctor call
@@ -247,6 +251,7 @@ public class UselessSuperCtorCallCheck extends AbstractCheck {
 
     /**
      * Returns class definition node for class, which contains given AST node.
+     *
      * @param aNode
      *        AST node inside class
      * @return class definition node
@@ -263,6 +268,7 @@ public class UselessSuperCtorCallCheck extends AbstractCheck {
 
     /**
      * Calculates public constructor count for given class.
+     *
      * @param aClassDefNode
      *          a class definition node(TokenTypes.CLASS_DEF)
      * @return public constructor count for given class
@@ -285,6 +291,7 @@ public class UselessSuperCtorCallCheck extends AbstractCheck {
 
     /**
      * Checks whether given ctor is public.
+     *
      * @param aCtorDefNode
      *          a ctor definition node(TokenTypes.CTOR_DEF)
      * @return true, if given ctor is public
@@ -297,6 +304,7 @@ public class UselessSuperCtorCallCheck extends AbstractCheck {
 
     /**
      * Checks whether this class is derived from other class.
+     *
      * @param aClassDefNode
      *        class definition node
      * @return true, if this class extends anything

--- a/sevntu-checks/src/main/java/com/github/sevntu/checkstyle/checks/coding/WhitespaceBeforeArrayInitializerCheck.java
+++ b/sevntu-checks/src/main/java/com/github/sevntu/checkstyle/checks/coding/WhitespaceBeforeArrayInitializerCheck.java
@@ -89,6 +89,7 @@ public class WhitespaceBeforeArrayInitializerCheck extends AbstractCheck {
 
     /**
      * Checks if firstAst and secondAst are separated by whitespace.
+     *
      * @param firstAST DetailAST
      * @param secondAST DetailAST
      * @return true if firstAST and secondAST are separated by whitespace,false otherwise
@@ -107,6 +108,7 @@ public class WhitespaceBeforeArrayInitializerCheck extends AbstractCheck {
 
     /**
      * Checks whether inspected array initializer is nested in other array initializer.
+     *
      * @param ast {@link TokenTypes#ARRAY_INIT} token to inspect
      * @return true when this array initializer is nested in other initializer; false otherwise
      */
@@ -116,6 +118,7 @@ public class WhitespaceBeforeArrayInitializerCheck extends AbstractCheck {
 
     /**
      * Calculate previous ast from given.
+     *
      * @param ast given ast
      * @return previous ast
      */

--- a/sevntu-checks/src/main/java/com/github/sevntu/checkstyle/checks/design/AvoidConditionInversionCheck.java
+++ b/sevntu-checks/src/main/java/com/github/sevntu/checkstyle/checks/design/AvoidConditionInversionCheck.java
@@ -125,6 +125,7 @@ public class AvoidConditionInversionCheck extends AbstractCheck {
 
     /**
      * Setter for applyOnlyToRelationalOperands.
+     *
      * @param applyOnlyToRelationalOperands The new value for the field.
      */
     public void setApplyOnlyToRelationalOperands(boolean applyOnlyToRelationalOperands) {
@@ -194,6 +195,7 @@ public class AvoidConditionInversionCheck extends AbstractCheck {
 
     /**
      * Checks if return statement is not empty.
+     *
      * @param returnAst
      *             Node of type
      *             {@link com.puppycrawl.tools.checkstyle.api.TokenTypes#LITERAL_RETURN}
@@ -205,6 +207,7 @@ public class AvoidConditionInversionCheck extends AbstractCheck {
 
     /**
      * Checks if condition in for-loop is not empty.
+     *
      * @param forConditionAst
      *             Node of type {@link com.puppycrawl.tools.checkstyle.api.TokenTypes#FOR_CONDITION}
      * @return true if the for condition is empty.
@@ -215,6 +218,7 @@ public class AvoidConditionInversionCheck extends AbstractCheck {
 
     /**
      * Gets inversion node of condition if one exists.
+     *
      * @param expressionAst
      *             Node of type {@link com.puppycrawl.tools.checkstyle.api.TokenTypes#EXPR}
      * @return Node of type {@link com.puppycrawl.tools.checkstyle.api.TokenTypes#LNOT}
@@ -226,6 +230,7 @@ public class AvoidConditionInversionCheck extends AbstractCheck {
 
     /**
      * Checks if current inversion is avoidable according to Check's properties.
+     *
      * @param inversionAst
      *             Node of type {@link com.puppycrawl.tools.checkstyle.api.TokenTypes#LNOT}
      * @return true if the inversion is avoidable.
@@ -239,6 +244,7 @@ public class AvoidConditionInversionCheck extends AbstractCheck {
      * it depends from user-defined property <b>"applyOnlyToRelationalOperands"</b>.
      * if it's <b>true</b> - Check will ignore inverted conditions with
      * non-relational operands
+     *
      * @param inversionConditionAst
      *             Node of type {@link com.puppycrawl.tools.checkstyle.api.TokenTypes#LNOT}
      * @return true if token can be skipped.
@@ -253,6 +259,7 @@ public class AvoidConditionInversionCheck extends AbstractCheck {
      * Checks if current inverted condition contains only
      * <a href="https://docs.oracle.com/javase/tutorial/java/nutsandbolts/opsummary.html">
      * relational</a> operands.
+     *
      * @param inversionConditionAst
      *             Node of type {@link com.puppycrawl.tools.checkstyle.api.TokenTypes#LNOT}
      * @return true if the node contains only relation operands.
@@ -284,6 +291,7 @@ public class AvoidConditionInversionCheck extends AbstractCheck {
      * Checks if current operand is
      * <a href="https://docs.oracle.com/javase/tutorial/java/nutsandbolts/opsummary.html">
      * relational</a> operand.
+     *
      * @param operandAst
      *             Child node of {@link com.puppycrawl.tools.checkstyle.api.TokenTypes#LNOT} node
      * @return true if the operand is relational.
@@ -297,6 +305,7 @@ public class AvoidConditionInversionCheck extends AbstractCheck {
      * Checks if current condition contains
      * <a href="https://docs.oracle.com/javase/tutorial/java/nutsandbolts/opsummary.html">
      * conditional</a> operators.
+     *
      * @param inversionAst
      *             Node of type {@link com.puppycrawl.tools.checkstyle.api.TokenTypes#LNOT}
      * @return true if the node contains conditional or relational operands.
@@ -319,6 +328,7 @@ public class AvoidConditionInversionCheck extends AbstractCheck {
 
     /**
      * Logs message on line where inverted condition is used.
+     *
      * @param inversionAst
      *             Node of type {@link com.puppycrawl.tools.checkstyle.api.TokenTypes#LNOT}
      */

--- a/sevntu-checks/src/main/java/com/github/sevntu/checkstyle/checks/design/CauseParameterInExceptionCheck.java
+++ b/sevntu-checks/src/main/java/com/github/sevntu/checkstyle/checks/design/CauseParameterInExceptionCheck.java
@@ -44,6 +44,7 @@ import com.puppycrawl.tools.checkstyle.api.TokenTypes;
  * <li>regexp to ignore classes by names ("ignoredClassNamesRegexp" option).
  * </li><li>The names of classes which would be considered as Exception cause
  * ("allowedCauseTypes" option).</li></ol><br>
+ *
  * @author <a href="mailto:Daniil.Yaroslavtsev@gmail.com"> Daniil
  *         Yaroslavtsev</a>
  * @since 1.8.0
@@ -91,6 +92,7 @@ public class CauseParameterInExceptionCheck extends AbstractCheck {
 
     /**
      * Sets the regexp for the names of classes, that should be checked.
+     *
      * @param classNamesRegexp
      *        String contains the regex to set for the names of classes, that
      *        should be checked.
@@ -109,6 +111,7 @@ public class CauseParameterInExceptionCheck extends AbstractCheck {
     /**
      * Sets the regexp for the names of classes, that should be ignored by
      * check.
+     *
      * @param ignoredClassNamesRegexp
      *        String contains the regex to set for the names of classes, that
      *        should be ignored by check.
@@ -126,6 +129,7 @@ public class CauseParameterInExceptionCheck extends AbstractCheck {
 
     /**
      * Sets the names of classes which would be considered as Exception cause.
+     *
      * @param allowedCauseTypes
      *        - the list of classNames separated by a comma. ClassName should be
      *        short, such as "NullpointerException", do not use full name -
@@ -195,6 +199,7 @@ public class CauseParameterInExceptionCheck extends AbstractCheck {
     /**
      * Checks that the given constructor contains exception cause as a
      * parameter.
+     *
      * @param ctorDefNode
      *        The CTOR_DEF DetailAST node is related to the constructor
      *        definition.
@@ -216,6 +221,7 @@ public class CauseParameterInExceptionCheck extends AbstractCheck {
 
     /**
      * Gets the list of classNames for given constructor parameters types.
+     *
      * @param parametersAST - A PARAMETERS DetailAST.
      * @return the list of classNames for given constructor parameters types.
      */
@@ -235,6 +241,7 @@ public class CauseParameterInExceptionCheck extends AbstractCheck {
 
     /**
      * Gets the name of given class or constructor.
+     *
      * @param classOrCtorDefNode
      *        the a CLASS_DEF or CTOR_DEF node
      * @return the name of class or constructor is related to CLASS_DEF or
@@ -248,6 +255,7 @@ public class CauseParameterInExceptionCheck extends AbstractCheck {
 
     /**
      * Gets the parent CLASS_DEF DetailAST node for given DetailAST node.
+     *
      * @param node
      *        The DetailAST node.
      * @return The parent CLASS_DEF node for the class that owns a token is
@@ -265,6 +273,7 @@ public class CauseParameterInExceptionCheck extends AbstractCheck {
     /**
      * Gets all the children which are one level below on the current DetailAST
      * parent node.
+     *
      * @param node
      *        Current parent node.
      * @return The list of children one level below on the current parent node.

--- a/sevntu-checks/src/main/java/com/github/sevntu/checkstyle/checks/design/CheckstyleTestMakeupCheck.java
+++ b/sevntu-checks/src/main/java/com/github/sevntu/checkstyle/checks/design/CheckstyleTestMakeupCheck.java
@@ -110,6 +110,7 @@ public class CheckstyleTestMakeupCheck extends AbstractCheck {
 
     /**
      * Setter for {@link #createMethodRegexp}.
+     *
      * @param createMethodRegexp The value to set.
      */
     public void setCreateMethodRegexp(Pattern createMethodRegexp) {
@@ -118,6 +119,7 @@ public class CheckstyleTestMakeupCheck extends AbstractCheck {
 
     /**
      * Setter for {@link #verifyMethodRegexp}.
+     *
      * @param verifyMethodRegexp The value to set.
      */
     public void setVerifyMethodRegexp(Pattern verifyMethodRegexp) {
@@ -168,6 +170,7 @@ public class CheckstyleTestMakeupCheck extends AbstractCheck {
 
     /**
      * Examines the method to see if it is part of a Test.
+     *
      * @param ast The method to examine.
      */
     private void checkMethod(DetailAST ast) {
@@ -183,6 +186,7 @@ public class CheckstyleTestMakeupCheck extends AbstractCheck {
      * a {@code null}, createModuleConfig, or createRootConfig and is tracked for future purposes.
      * Variables of type {@link File} with the modifier {@code final} are tracked for future
      * purposes.
+     *
      * @param ast The variable to examine.
      */
     private void checkVariable(DetailAST ast) {
@@ -208,6 +212,7 @@ public class CheckstyleTestMakeupCheck extends AbstractCheck {
     /**
      * Examines the configuration variable to see if it is defined as described in
      * {@link #checkVariable(DetailAST)}.
+     *
      * @param ast The variable to examine.
      */
     private void checkConfigurationVariable(DetailAST ast) {
@@ -236,6 +241,7 @@ public class CheckstyleTestMakeupCheck extends AbstractCheck {
      * addAttribute method which is called by one of the configurations found earlier, must have
      * all its parameters be acceptable to {@link #isValidMethodCallExpression(DetailAST)}.
      * Any method that matches {@link #verifyMethodRegexp} are tracked for future purposes.
+     *
      * @param ast The method call to examine.
      */
     private void checkMethodCall(DetailAST ast) {
@@ -266,6 +272,7 @@ public class CheckstyleTestMakeupCheck extends AbstractCheck {
 
     /**
      * Retrieves the name of the method being called.
+     *
      * @param ast The method call token to examine.
      * @return The name of the method.
      */
@@ -282,6 +289,7 @@ public class CheckstyleTestMakeupCheck extends AbstractCheck {
 
     /**
      * Retrieves the name of the variable calling the method.
+     *
      * @param ast The method call token to examine.
      * @return The name of who is calling the method.
      */
@@ -303,6 +311,7 @@ public class CheckstyleTestMakeupCheck extends AbstractCheck {
      * Plain {@code null} is allowed due to backward compatibility.
      * Method calls are allowed only if they are any form of getPath, converting an enum to a
      * string, or retrieving the path of a final {@link File} variable.
+     *
      * @param expression The expression to examine.
      * @return {@code true} if the method call is defined correctly.
      */
@@ -334,6 +343,7 @@ public class CheckstyleTestMakeupCheck extends AbstractCheck {
     /**
      * Identifies if the inner method call of a method call is valid as defined in
      * {@link #isValidMethodCallExpression(DetailAST)}.
+     *
      * @param firstChild The first child of the method call.
      * @return {@code true} if the method call is defined correctly.
      */
@@ -361,6 +371,7 @@ public class CheckstyleTestMakeupCheck extends AbstractCheck {
 
     /**
      * Checks if the method call is calling toString, getName, or name on an enumeration.
+     *
      * @param ast The AST to examine.
      * @return {@code true} if the method call is on a enumeration.
      */
@@ -383,6 +394,7 @@ public class CheckstyleTestMakeupCheck extends AbstractCheck {
 
     /**
      * Checks if the method call is 'getPath' on a {@link File} variable.
+     *
      * @param firstChild The AST to examine.
      * @return {@code true} if the method call is on a file variable.
      */
@@ -393,6 +405,7 @@ public class CheckstyleTestMakeupCheck extends AbstractCheck {
 
     /**
      * Checks if the method name is a form of 'getPath'.
+     *
      * @param methodName The name to examine.
      * @return {@code true} if the method is of the form.
      */

--- a/sevntu-checks/src/main/java/com/github/sevntu/checkstyle/checks/design/ChildBlockLengthCheck.java
+++ b/sevntu-checks/src/main/java/com/github/sevntu/checkstyle/checks/design/ChildBlockLengthCheck.java
@@ -44,6 +44,7 @@ import com.puppycrawl.tools.checkstyle.utils.TokenUtil;
  * to read in case child block is long(few display screens). Such child blocks
  * should be refactored or moved to separate method.
  * </p>
+ *
  * @author <a href="mailto:Daniil.Yaroslavtsev@gmail.com"> Daniil
  *         Yaroslavtsev</a>
  * @since 1.8.0
@@ -96,6 +97,7 @@ public class ChildBlockLengthCheck extends AbstractCheck {
      * Sets allowed types of blocks to be checked. Supported block types:
      * LITERAL_IF, LITERAL_SWITCH, LITERAL_FOR, LITERAL_DO, LITERAL_WHILE,
      * LITERAL_TRY, LITERAL_ELSE, LITERAL_CATCH.
+     *
      * @param blockTypes
      *        - DetailAST tokenTypes that are related to the types which are
      *        allowed by user in check preferences.
@@ -110,6 +112,7 @@ public class ChildBlockLengthCheck extends AbstractCheck {
     /**
      * Sets the maximum percentage ratio between child and parent block. (sets
      * "maxChildBlockPercentage" option value)
+     *
      * @param maxChildBlockPercentage
      *        the new "maxChildBlockPercentage" option value.
      */
@@ -119,6 +122,7 @@ public class ChildBlockLengthCheck extends AbstractCheck {
 
     /**
      * Sets the maximum linelength of blocks that will be ignored by check.
+     *
      * @param ignoreBlockLinesCount
      *        the maximum linelength of the block to be ignored.
      */
@@ -189,6 +193,7 @@ public class ChildBlockLengthCheck extends AbstractCheck {
     /**
      * Gets all the child blocks for given parent block. Uses an iterative
      * algorithm.
+     *
      * @param blockOpeningBrace
      *        a DetailAST node that points to the current method`s opening
      *        brace.
@@ -230,6 +235,7 @@ public class ChildBlockLengthCheck extends AbstractCheck {
 
     /**
      * Checks that given child block type is allowed.
+     *
      * @param blockType
      *        the token type ID for the given block.
      * @return true, if the given child block type is allowed.
@@ -248,6 +254,7 @@ public class ChildBlockLengthCheck extends AbstractCheck {
     /**
      * Gets the child blocks which occupies too much size (in percentage) of
      * given parent block size.
+     *
      * @param blocksList
      *        the blocks
      * @param parentBlockSize
@@ -268,6 +275,7 @@ public class ChildBlockLengthCheck extends AbstractCheck {
     /**
      * Checks if the child block size percentage from parent block is greater
      * than.
+     *
      * @param childBlock
      *        the a child block node
      * @param parentBlockSize
@@ -289,6 +297,7 @@ public class ChildBlockLengthCheck extends AbstractCheck {
     /**
      * Gets the percentage which the child block occupies inside the parent
      * block.
+     *
      * @param parentBlockSize
      *        the parent block size in lines
      * @param childBlockSize
@@ -304,6 +313,7 @@ public class ChildBlockLengthCheck extends AbstractCheck {
 
     /**
      * Gets the opening brace for the given block.
+     *
      * @param parentBlock
      *        the DetailAST node is related to the given parent block.
      * @return the DetailAST node is related to the given block opening brace
@@ -321,6 +331,7 @@ public class ChildBlockLengthCheck extends AbstractCheck {
 
     /**
      * Gets the closing brace for the given block.
+     *
      * @param parentBlockNode
      *        the DetailAST node is related to the given parent block.
      * @return the DetailAST node is related to the given block closing brace
@@ -339,6 +350,7 @@ public class ChildBlockLengthCheck extends AbstractCheck {
 
     /**
      * Gets the lines count between braces of the given block.
+     *
      * @param blockAst
      *        - the DetailAST node is related to the given block (the block
      *        should have braces!).
@@ -350,6 +362,7 @@ public class ChildBlockLengthCheck extends AbstractCheck {
 
     /**
      * Gets the lines count between the given block opening and closing braces.
+     *
      * @param openingBrace
      *        the block opening brace DetailAST (LCURLY or SLIST type)
      * @param closingBrace

--- a/sevntu-checks/src/main/java/com/github/sevntu/checkstyle/checks/design/ForbidWildcardAsReturnTypeCheck.java
+++ b/sevntu-checks/src/main/java/com/github/sevntu/checkstyle/checks/design/ForbidWildcardAsReturnTypeCheck.java
@@ -63,6 +63,7 @@ import com.puppycrawl.tools.checkstyle.utils.AnnotationUtil;
  * <p>If suppressions become too wide spread and annoying it might be reasonable to update Check
  * with option to ignore wildcard if used with another type (not alone).
  * </p>
+ *
  * @author <a href='mailto:barataliba@gmail.com'>Baratali Izmailov</a>
  * @since 1.9.0
  */
@@ -139,6 +140,7 @@ public class ForbidWildcardAsReturnTypeCheck extends AbstractCheck {
 
     /**
      * Setter for checkPublicMethods.
+     *
      * @param checkPublicMethods New value for the field.
      */
     public void setCheckPublicMethods(boolean checkPublicMethods) {
@@ -147,6 +149,7 @@ public class ForbidWildcardAsReturnTypeCheck extends AbstractCheck {
 
     /**
      * Setter for checkProtectedMethods.
+     *
      * @param checkProtectedMethods New value for the field.
      */
     public void setCheckProtectedMethods(boolean checkProtectedMethods) {
@@ -155,6 +158,7 @@ public class ForbidWildcardAsReturnTypeCheck extends AbstractCheck {
 
     /**
      * Setter for checkPackageMethods.
+     *
      * @param checkPackageMethods New value for the field.
      */
     public void setCheckPackageMethods(boolean checkPackageMethods) {
@@ -163,6 +167,7 @@ public class ForbidWildcardAsReturnTypeCheck extends AbstractCheck {
 
     /**
      * Setter for checkPrivateMethods.
+     *
      * @param checkPrivateMethods New value for the field.
      */
     public void setCheckPrivateMethods(boolean checkPrivateMethods) {
@@ -171,6 +176,7 @@ public class ForbidWildcardAsReturnTypeCheck extends AbstractCheck {
 
     /**
      * Setter for checkOverrideMethods.
+     *
      * @param checkOverrideMethods New value for the field.
      */
     public void setCheckOverrideMethods(boolean checkOverrideMethods) {
@@ -179,6 +185,7 @@ public class ForbidWildcardAsReturnTypeCheck extends AbstractCheck {
 
     /**
      * Setter for checkDeprecatedMethods.
+     *
      * @param checkDeprecatedMethods New value for the field.
      */
     public void setCheckDeprecatedMethods(boolean checkDeprecatedMethods) {
@@ -187,6 +194,7 @@ public class ForbidWildcardAsReturnTypeCheck extends AbstractCheck {
 
     /**
      * Setter for allowReturnWildcardWithSuper.
+     *
      * @param allowReturnWildcardWithSuper New value for the field.
      */
     public void setAllowReturnWildcardWithSuper(boolean allowReturnWildcardWithSuper) {
@@ -195,6 +203,7 @@ public class ForbidWildcardAsReturnTypeCheck extends AbstractCheck {
 
     /**
      * Setter for allowReturnWildcardWithExtends.
+     *
      * @param allowReturnWildcardWithExtends New value for the field.
      */
     public void setAllowReturnWildcardWithExtends(boolean allowReturnWildcardWithExtends) {
@@ -203,6 +212,7 @@ public class ForbidWildcardAsReturnTypeCheck extends AbstractCheck {
 
     /**
      * Setter for returnTypeClassNamesIgnoreRegex.
+     *
      * @param returnTypeClassNamesIgnoreRegex New value for the field.
      */
     public void setReturnTypeClassNamesIgnoreRegex(String returnTypeClassNamesIgnoreRegex) {
@@ -249,6 +259,7 @@ public class ForbidWildcardAsReturnTypeCheck extends AbstractCheck {
 
     /**
      * Checks if the method scope is defined as one of the types to check.
+     *
      * @param methodScope The string version of the scope.
      * @return {@code true} if the method should be checked.
      */
@@ -261,6 +272,7 @@ public class ForbidWildcardAsReturnTypeCheck extends AbstractCheck {
 
     /**
      * Returns the visibility scope of method.
+     *
      * @param methodDefAst DetailAST of method definition.
      * @return one of "public", "private", "protected", "package"
      */
@@ -285,6 +297,7 @@ public class ForbidWildcardAsReturnTypeCheck extends AbstractCheck {
 
     /**
      * Verify that method definition is inside interface definition.
+     *
      * @param methodDefAst DetailAST of method definition.
      * @return true if method definition is inside interface definition.
      */
@@ -300,6 +313,7 @@ public class ForbidWildcardAsReturnTypeCheck extends AbstractCheck {
 
     /**
      * Returns the set of modifier Strings for a METHOD_DEF AST.
+     *
      * @param methodDefAst AST for a method definition
      * @return the set of modifier Strings for aMethodDefAST
      */
@@ -316,6 +330,7 @@ public class ForbidWildcardAsReturnTypeCheck extends AbstractCheck {
 
     /**
      * Get identifier of aAST.
+     *
      * @param ast
      *        DetailAST instance
      * @return identifier of aAST, null if AST does not have identifier.
@@ -327,6 +342,7 @@ public class ForbidWildcardAsReturnTypeCheck extends AbstractCheck {
 
     /**
      * Receive list of arguments(AST nodes) which have wildcard.
+     *
      * @param methodDefAst
      *        DetailAST of method definition.
      * @return list of arguments which have wildcard.
@@ -347,6 +363,7 @@ public class ForbidWildcardAsReturnTypeCheck extends AbstractCheck {
 
     /**
      * Get all type arguments of TypeAST.
+     *
      * @param typeAst
      *        DetailAST of type definition.
      * @return array of type arguments.
@@ -375,6 +392,7 @@ public class ForbidWildcardAsReturnTypeCheck extends AbstractCheck {
 
     /**
      * Verify that aAST has token of aTokenType type.
+     *
      * @param ast
      *        DetailAST instance.
      * @param tokenType
@@ -388,6 +406,7 @@ public class ForbidWildcardAsReturnTypeCheck extends AbstractCheck {
     /**
      * Verify that method with wildcards as return type is allowed by current
      * check configuration.
+     *
      * @param methodDefAst DetailAST of method definition.
      * @param wildcardTypeArguments list of wildcard type arguments.
      * @return true if method is allowed by current check configuration.
@@ -429,6 +448,7 @@ public class ForbidWildcardAsReturnTypeCheck extends AbstractCheck {
 
     /**
      * Verify that method's return type name matches ignore regexp.
+     *
      * @param methodDefAst DetailAST of method.
      * @return true if aMethodDefAST's name matches ignore regexp.
      *      false otherwise.
@@ -443,6 +463,7 @@ public class ForbidWildcardAsReturnTypeCheck extends AbstractCheck {
 
     /**
      * Verify that method has bounded wildcard in type arguments list.
+     *
      * @param typeArgumentsList list of type arguments.
      * @param boundedWildcardType type of bounded wildcard.
      * @return true if aTypeArgumentsList contains bounded wildcard.

--- a/sevntu-checks/src/main/java/com/github/sevntu/checkstyle/checks/design/HideUtilityClassConstructorCheck.java
+++ b/sevntu-checks/src/main/java/com/github/sevntu/checkstyle/checks/design/HideUtilityClassConstructorCheck.java
@@ -127,6 +127,7 @@ public class HideUtilityClassConstructorCheck extends AbstractCheck {
 
     /**
      * Test is AST object has abstract modifier.
+     *
      * @param ast class definition for check.
      * @return true if a given class declared as abstract.
      */
@@ -139,6 +140,7 @@ public class HideUtilityClassConstructorCheck extends AbstractCheck {
 
     /**
      * Test is AST object has static modifier.
+     *
      * @param ast class definition for check.
      * @return true if a given class declared as static.
      */

--- a/sevntu-checks/src/main/java/com/github/sevntu/checkstyle/checks/design/NestedSwitchCheck.java
+++ b/sevntu-checks/src/main/java/com/github/sevntu/checkstyle/checks/design/NestedSwitchCheck.java
@@ -49,6 +49,7 @@ import com.puppycrawl.tools.checkstyle.api.TokenTypes;
  * <pre>
  * &lt;module name=&quot;NestedSwitchCheck&quot;/&gt;
  * </pre>
+ *
  * @author Damian Szczepanik (damianszczepanik@github)
  * @since 1.13.0
  */
@@ -67,6 +68,7 @@ public class NestedSwitchCheck extends AbstractCheck {
 
     /**
      * Setter for maximum allowed nesting depth.
+     *
      * @param max maximum allowed nesting depth.
      */
     public final void setMax(int max) {

--- a/sevntu-checks/src/main/java/com/github/sevntu/checkstyle/checks/design/NoMainMethodInAbstractClassCheck.java
+++ b/sevntu-checks/src/main/java/com/github/sevntu/checkstyle/checks/design/NoMainMethodInAbstractClassCheck.java
@@ -29,6 +29,7 @@ import com.puppycrawl.tools.checkstyle.api.TokenTypes;
 /**
  * Forbids main methods in abstract classes. Existence of 'main' method can
  * mislead a developer to consider this class as a ready-to-use implementation.
+ *
  * @author Baratali Izmailov <a href="mailto:barataliba@gmail.com">email</a>
  * @since 1.9.0
  */
@@ -88,6 +89,7 @@ public class NoMainMethodInAbstractClassCheck extends AbstractCheck {
 
     /**
      * Verify that class is not inner.
+     *
      * @param classDefAST
      *        DetailAST of class definition.
      * @return true if class is not inner, false otherwise.
@@ -106,6 +108,7 @@ public class NoMainMethodInAbstractClassCheck extends AbstractCheck {
 
     /**
      * Verify that aMethodDefAST is child token of considered objblock.
+     *
      * @param methodDefAST DetailAST of method definition.
      * @return true if aMethodDefAST is child of of considered objblock.
      */
@@ -117,6 +120,7 @@ public class NoMainMethodInAbstractClassCheck extends AbstractCheck {
 
     /**
      * Return true if AST has abstract modifier.
+     *
      * @param classDefAST
      *        AST which has modifier
      * @return true if AST has abstract modifier, false otherwise.
@@ -129,6 +133,7 @@ public class NoMainMethodInAbstractClassCheck extends AbstractCheck {
 
     /**
      * Verifies that the given DetailAST is a main method.
+     *
      * @param methodAST
      *        DetailAST instance.
      * @return true if aMethodAST is a main method, false otherwise.
@@ -150,6 +155,7 @@ public class NoMainMethodInAbstractClassCheck extends AbstractCheck {
     /**
      * Get identifier of AST. These can be names of types, subpackages,
      * fields, methods, parameters, and local variables.
+     *
      * @param ast
      *        DetailAST instance
      * @return identifier of AST, null if AST does not have name.
@@ -161,6 +167,7 @@ public class NoMainMethodInAbstractClassCheck extends AbstractCheck {
 
     /**
      * Verifies that given AST has appropriate modifiers for main method.
+     *
      * @param methodAST
      *        DetailAST instance.
      * @return true if aMethodAST has (public & static & !abstract) modifiers,
@@ -175,6 +182,7 @@ public class NoMainMethodInAbstractClassCheck extends AbstractCheck {
 
     /**
      * Verifies that given AST has type and this type is void.
+     *
      * @param methodAST
      *        DetailAST instance.
      * @return true if AST's type void, false otherwise.
@@ -186,6 +194,7 @@ public class NoMainMethodInAbstractClassCheck extends AbstractCheck {
 
     /**
      * Verifies that given AST has appropriate for main method parameters.
+     *
      * @param methodAST
      *        instance of a method
      * @return true if parameters of aMethodAST are appropriate for main method,
@@ -201,6 +210,7 @@ public class NoMainMethodInAbstractClassCheck extends AbstractCheck {
     /**
      * Return true if AST of method parameters has String[] parameter child
      * token.
+     *
      * @param parametersAST
      *        DetailAST of method parameters.
      * @return true if AST has String[] parameter child token, false otherwise.
@@ -233,6 +243,7 @@ public class NoMainMethodInAbstractClassCheck extends AbstractCheck {
     /**
      * Return true if AST of method parameters has String... parameter child
      * token.
+     *
      * @param parametersAST
      *        DetailAST of method parameters.
      * @return true if aParametersAST has String... parameter child token, false
@@ -263,6 +274,7 @@ public class NoMainMethodInAbstractClassCheck extends AbstractCheck {
 
     /**
      * Return true if aAST has token of aTokenType type.
+     *
      * @param ast
      *        DetailAST instance.
      * @param tokenType

--- a/sevntu-checks/src/main/java/com/github/sevntu/checkstyle/checks/design/PublicReferenceToPrivateTypeCheck.java
+++ b/sevntu-checks/src/main/java/com/github/sevntu/checkstyle/checks/design/PublicReferenceToPrivateTypeCheck.java
@@ -69,6 +69,7 @@ import com.puppycrawl.tools.checkstyle.api.TokenTypes;
  * Such situation usually happens after bulk refactoring and usually means
  * dead/useless code<br>
  * <br>
+ *
  * @author <a href="mailto:nesterenko-aleksey@list.ru">Aleksey Nesterenko</a>
  * @since 1.12.0
  */
@@ -161,6 +162,7 @@ public class PublicReferenceToPrivateTypeCheck extends AbstractCheck {
 
     /**
      * Adds type to the list of private types.
+     *
      * @param classOrInterfaceOrEnumDefAst
      *        AST subtree that represent inner private type definition.
      */
@@ -173,6 +175,7 @@ public class PublicReferenceToPrivateTypeCheck extends AbstractCheck {
     /**
      * Appends non-private, defined in top-level class method's returned or
      * parameter type, or field's type to general list of out referenced types.
+     *
      * @param methodDefAst
      *        AST subtree that represent method definition.
      */
@@ -188,6 +191,7 @@ public class PublicReferenceToPrivateTypeCheck extends AbstractCheck {
     /**
      * Appends non-private, defined in top-level class field's type to general
      * list of out referenced types.
+     *
      * @param fieldDefAst
      *        AST subtree that represent field definition.
      */
@@ -198,6 +202,7 @@ public class PublicReferenceToPrivateTypeCheck extends AbstractCheck {
 
     /**
      * Gets the return type of method or field type.
+     *
      * @param typeAst
      *        AST subtree to process.
      * @return the return types of the token.
@@ -219,6 +224,7 @@ public class PublicReferenceToPrivateTypeCheck extends AbstractCheck {
 
     /**
      * Gets method's parameters types.
+     *
      * @param parametersDefAst The token to examine.
      * @return The parameter types of the method.
      */
@@ -253,6 +259,7 @@ public class PublicReferenceToPrivateTypeCheck extends AbstractCheck {
     /**
      * Checks if defined type or interface extends or implements any
      * <u>non-private type</u>.
+     *
      * @param classOrInterfaceDefAst The token to examine.
      * @return Method returns true if class extends or implements something.
      */
@@ -267,6 +274,7 @@ public class PublicReferenceToPrivateTypeCheck extends AbstractCheck {
     /**
      * Checks if inner class or interface extends or implements <u>inner private
      * type</u>.
+     *
      * @param classOrInterfaceDefAst The token to examine.
      * @return true if extending or implementing type is in collection of inner
      *         private types
@@ -310,6 +318,7 @@ public class PublicReferenceToPrivateTypeCheck extends AbstractCheck {
     /**
      * Checks if class, interface, enumeration, method or field definition has an
      * access modifier of specified type.
+     *
      * @param modifierType modifier type
      * @param defAst definition ast (METHOD_DEF, FIELD_DEF, etc.)
      * @return true if class, interface, enumeration, method or field definition has an
@@ -323,6 +332,7 @@ public class PublicReferenceToPrivateTypeCheck extends AbstractCheck {
 
     /**
      * Checks if method or field is defined in top-level class.
+     *
      * @param methodOrFieldDefAst The token to examine.
      * @return true if method is defined in top-level class
      */

--- a/sevntu-checks/src/main/java/com/github/sevntu/checkstyle/checks/design/StaticMethodCandidateCheck.java
+++ b/sevntu-checks/src/main/java/com/github/sevntu/checkstyle/checks/design/StaticMethodCandidateCheck.java
@@ -61,6 +61,7 @@ import com.puppycrawl.tools.checkstyle.utils.ScopeUtil;
  * Private methods called by reflection are not supported and have to be suppressed.
  * </li>
  * </ul>
+ *
  * @author Vladislav Lisetskiy
  * @since 1.17.0
  */
@@ -107,6 +108,7 @@ public class StaticMethodCandidateCheck extends AbstractCheck {
 
     /**
      * Sets custom skipped methods.
+     *
      * @param skippedMethods user's skipped methods.
      */
     public void setSkippedMethods(String skippedMethods) {
@@ -240,6 +242,7 @@ public class StaticMethodCandidateCheck extends AbstractCheck {
 
     /**
      * Create a new Frame from METHOD_DEF ast.
+     *
      * @param ast METHOD_DEF ast.
      * @param parentFrame the parent frame for a new frame.
      * @return a new frame with the set fields.
@@ -265,6 +268,7 @@ public class StaticMethodCandidateCheck extends AbstractCheck {
 
     /**
      * Check whether the ast is an anonymous class.
+     *
      * @param ast the ast to check.
      * @return if the checked ast is an anonymous class.
      */
@@ -277,6 +281,7 @@ public class StaticMethodCandidateCheck extends AbstractCheck {
     /**
      * Create a new Frame from CLASS_DEF, LITERAL_IF, LITERAL_FOR, LITERAL_WHILE, LITERAL_DO,
      * LITERAL_CATCH, LITERAL_TRY, CTOR_DEF, ENUM_DEF.
+     *
      * @param ast the processed ast.
      * @param parentFrame the parent frame for a new frame.
      * @return a new frame with the set fields.
@@ -306,6 +311,7 @@ public class StaticMethodCandidateCheck extends AbstractCheck {
 
     /**
      * Check whether the ast is a Frame.
+     *
      * @param ast the ast to check.
      * @return true if the checked ast is a Frame.
      */
@@ -317,6 +323,7 @@ public class StaticMethodCandidateCheck extends AbstractCheck {
     /**
      * Check whether the frame or its parent, which is a private method,
      * is a static method candidate.
+     *
      * @param parentFrame the frame to check.
      * @return true if the frame or its parent, which is a private method,
      *     is a static method candidate.
@@ -347,6 +354,7 @@ public class StaticMethodCandidateCheck extends AbstractCheck {
 
     /**
      * Get the name of the field.
+     *
      * @param field to get the name from.
      * @return name of the field.
      */
@@ -356,6 +364,7 @@ public class StaticMethodCandidateCheck extends AbstractCheck {
 
     /**
      * Whether the ast has static modifier.
+     *
      * @param ast the ast to check.
      * @return true if the ast has static modifier.
      */
@@ -366,6 +375,7 @@ public class StaticMethodCandidateCheck extends AbstractCheck {
 
     /**
      * Check expressions in the given frame for being acceptable is static methods.
+     *
      * @param frame the frame to check.
      * @return true if the currently checked method
      *     is still a static method candidate.
@@ -383,6 +393,7 @@ public class StaticMethodCandidateCheck extends AbstractCheck {
 
     /**
      * Check types in the given frame for being acceptable in static methods.
+     *
      * @param frame the frame to check.
      * @return true if the currently checked method
      *     is still a static method candidate.
@@ -403,6 +414,7 @@ public class StaticMethodCandidateCheck extends AbstractCheck {
     /**
      * Check whether the expression only contains fields and method calls accepted
      * in static methods (which can be checked).
+     *
      * @param frame the frame where the expression is located.
      * @param expr the expression to check.
      * @return true if the currently checked method
@@ -439,6 +451,7 @@ public class StaticMethodCandidateCheck extends AbstractCheck {
 
     /**
      * Find a frame with the specified name among the current frame and its parents.
+     *
      * @param frame the frame to start searching from.
      * @param frameName the specified name.
      * @return search result.
@@ -461,6 +474,7 @@ public class StaticMethodCandidateCheck extends AbstractCheck {
 
     /**
      * Find a type variable with the specified name.
+     *
      * @param frame the frame to start searching from.
      * @param type the name of the type variable to find.
      * @return true if a type variable with the specified name is found.
@@ -477,6 +491,7 @@ public class StaticMethodCandidateCheck extends AbstractCheck {
 
     /**
      * Check whether a {@code static} method is called.
+     *
      * @param frame the frame where the method call is located.
      * @param methodCallAst METHOD_CALL ast.
      * @return true if a {@code static} method is called.
@@ -507,6 +522,7 @@ public class StaticMethodCandidateCheck extends AbstractCheck {
 
     /**
      * Determine whether the method call should be checked.
+     *
      * @param parentAst parent ast of the ident.
      * @return true, if LITERAL_THIS is used or the usage is too complex to check.
      */
@@ -519,6 +535,7 @@ public class StaticMethodCandidateCheck extends AbstractCheck {
 
     /**
      * Check whether a {@code static} field or a local variable is used.
+     *
      * @param frame the frame where the field is located.
      * @param identAst the identifier ast of the checked field.
      * @return true if the field is {@code static} or local.
@@ -552,6 +569,7 @@ public class StaticMethodCandidateCheck extends AbstractCheck {
 
     /**
      * Whether the type frame should be checked.
+     *
      * @param typeFrame the frame of the type to check.
      * @return true if the type frame should be checked.
      */
@@ -562,6 +580,7 @@ public class StaticMethodCandidateCheck extends AbstractCheck {
 
     /**
      * Get the leftmost ident of the method call.
+     *
      * @param mCall METHOD_CALL to get ident from.
      * @return the leftmost's ident DetailAST.
      */
@@ -576,6 +595,7 @@ public class StaticMethodCandidateCheck extends AbstractCheck {
 
     /**
      * Find a static field definition or local variable.
+     *
      * @param startFrame the frame to start searching from.
      * @param identAst the IDENT ast to check.
      * @return search result.
@@ -602,6 +622,7 @@ public class StaticMethodCandidateCheck extends AbstractCheck {
 
     /**
      * Check whether the field is acceptable is a {@code static} method.
+     *
      * @param field the checked field.
      * @return true if the checked field is acceptable is a {@code static} method.
      */
@@ -619,6 +640,7 @@ public class StaticMethodCandidateCheck extends AbstractCheck {
      * Find a {@code static} method definition of the specified method call
      * and ensure that there are no non-{@code static} methods with the same name and
      * number of parameters in the current frame or its parents.
+     *
      * @param startFrame the frame to start searching from.
      * @param methodCall METHOD_CALL ast.
      * @param checkedMethodName the name of the called method.
@@ -667,6 +689,7 @@ public class StaticMethodCandidateCheck extends AbstractCheck {
 
     /**
      * Check whether the field is a local variable.
+     *
      * @param ast VARIABLE_DEF ast.
      * @return true if the field is a local variable.
      */
@@ -678,6 +701,7 @@ public class StaticMethodCandidateCheck extends AbstractCheck {
 
     /**
      * Check whether the field is declared before its usage in case of methods.
+     *
      * @param field field to check.
      * @param objCalledOn object equals method called on.
      * @return true if the field is declared before the method call.
@@ -746,6 +770,7 @@ public class StaticMethodCandidateCheck extends AbstractCheck {
 
         /**
          * Creates new frame.
+         *
          * @param parent parent frame.
          */
         /* package */ Frame(Frame parent) {
@@ -754,6 +779,7 @@ public class StaticMethodCandidateCheck extends AbstractCheck {
 
         /**
          * Add method call to this Frame.
+         *
          * @param exprAst EXPR ast.
          */
         public void addExpr(DetailAST exprAst) {
@@ -762,6 +788,7 @@ public class StaticMethodCandidateCheck extends AbstractCheck {
 
         /**
          * Add child frame to this frame.
+         *
          * @param child frame to add.
          */
         public void addChild(Frame child) {
@@ -770,6 +797,7 @@ public class StaticMethodCandidateCheck extends AbstractCheck {
 
         /**
          * Add field to this Frame.
+         *
          * @param field the ast of the field.
          */
         public void addField(DetailAST field) {
@@ -778,6 +806,7 @@ public class StaticMethodCandidateCheck extends AbstractCheck {
 
         /**
          * Add method definition to this frame.
+         *
          * @param method METHOD_DEF ast.
          */
         public void addMethod(DetailAST method) {
@@ -786,6 +815,7 @@ public class StaticMethodCandidateCheck extends AbstractCheck {
 
         /**
          * Add method call to this frame.
+         *
          * @param enumConst ENUM_CONST_DEF ast.
          */
         public void addEnumConst(DetailAST enumConst) {
@@ -794,6 +824,7 @@ public class StaticMethodCandidateCheck extends AbstractCheck {
 
         /**
          * Add type variable name to this frame.
+         *
          * @param typeVariable the type variable name.
          */
         public void addTypeVariable(String typeVariable) {
@@ -802,6 +833,7 @@ public class StaticMethodCandidateCheck extends AbstractCheck {
 
         /**
          * Add type to this frame.
+         *
          * @param type the type name.
          */
         public void addType(String type) {
@@ -810,6 +842,7 @@ public class StaticMethodCandidateCheck extends AbstractCheck {
 
         /**
          * Determine whether this Frame contains the field.
+         *
          * @param name the name of the field to check.
          * @return search result.
          */
@@ -825,6 +858,7 @@ public class StaticMethodCandidateCheck extends AbstractCheck {
 
         /**
          * Determine whether this Frame contains the enum constant.
+         *
          * @param name the name of the enum constant to check.
          * @return search result.
          */

--- a/sevntu-checks/src/main/java/com/github/sevntu/checkstyle/checks/naming/UniformEnumConstantNameCheck.java
+++ b/sevntu-checks/src/main/java/com/github/sevntu/checkstyle/checks/naming/UniformEnumConstantNameCheck.java
@@ -123,6 +123,7 @@ public class UniformEnumConstantNameCheck extends AbstractCheck {
 
     /**
      * Method sets format to match Class Enumeration names.
+     *
      * @param regexps format to check against
      */
     public final void setFormats(String... regexps) {

--- a/sevntu-checks/src/main/java/com/github/sevntu/checkstyle/checks/sizes/LineLengthExtendedCheck.java
+++ b/sevntu-checks/src/main/java/com/github/sevntu/checkstyle/checks/sizes/LineLengthExtendedCheck.java
@@ -249,6 +249,7 @@ public class LineLengthExtendedCheck extends AbstractCheck {
 
     /**
      * Setter for the field max.
+     *
      * @param length
      *            the maximum length of a line
      */


### PR DESCRIPTION
According to https://checkstyle.sourceforge.io/config_javadoc.html#JavadocParagraph
> There is one blank line between each of two paragraphs and one blank line before the at-clauses block if it is present.

Unfortunately, this check is not working yet in checkstyle, so many of these violations sneaked into the repository.

In https://github.com/checkstyle/checkstyle/pull/8084 @pbludov recommend that I apply the fixes suggested by using this PR: https://github.com/checkstyle/checkstyle/pull/7932. Also the regression tests of https://github.com/checkstyle/checkstyle/pull/7932 discovered these same checkstyle violations in this repository.

I wrote a script to apply the missing newline violations from mvn verify. It is available here: https://github.com/josephmate/FixAtClauseError