### PR TITLE
minor: fix violation for MissingLeadingAsterisk

### DIFF
--- a/sevntu-checks/src/main/java/com/github/sevntu/checkstyle/checks/annotation/RequiredParameterForAnnotationCheck.java
+++ b/sevntu-checks/src/main/java/com/github/sevntu/checkstyle/checks/annotation/RequiredParameterForAnnotationCheck.java
@@ -67,7 +67,7 @@ import com.puppycrawl.tools.checkstyle.api.TokenTypes;
  * class SomeClass {}
  * </code>
  * </pre>
- <p>
+ * <p>
  * <b>Example 2.</b><br>
  * Configuration:
  * </p>


### PR DESCRIPTION
Fixed a violation caused in `RequiredParameterForAnnotationCheck` caused by the new check MissingLeadingAsteriskCheck
As discussed in the comments of [checkstyle/checkstyle#8085](https://github.com/checkstyle/checkstyle/pull/8085).