### PR TITLE
minor: fix violations from RequireEmptyLineBeforeAtClauseBlock

### DIFF
--- a/sevntu-checks/src/test/java/com/github/sevntu/checkstyle/checks/coding/AvoidModifiersForTypesCheckTest.java
+++ b/sevntu-checks/src/test/java/com/github/sevntu/checkstyle/checks/coding/AvoidModifiersForTypesCheckTest.java
@@ -32,6 +32,7 @@ import com.puppycrawl.tools.checkstyle.api.TokenTypes;
 
 /**
  * <p>
+ *
  * @author <a href="mailto:Daniil.Yaroslavtsev@gmail.com"> Daniil Yaroslavtsev</a>
  * @author <a href="mailto:yasser.aziza@gmail.com">Yasser Aziza</a>
  * </p>

--- a/sevntu-checks/src/test/java/com/github/sevntu/checkstyle/checks/coding/EitherLogOrThrowCheckTest.java
+++ b/sevntu-checks/src/test/java/com/github/sevntu/checkstyle/checks/coding/EitherLogOrThrowCheckTest.java
@@ -28,6 +28,7 @@ import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
 
 /**
  * Test for EitherLogOrThrowCheck.
+ *
  * @author <a href="mailto:barataliba@gmail.com">Baratali Izmailov</a>
  */
 public class EitherLogOrThrowCheckTest extends AbstractModuleTestSupport {

--- a/sevntu-checks/src/test/java/com/github/sevntu/checkstyle/checks/design/ForbidWildcardAsReturnTypeCheckTest.java
+++ b/sevntu-checks/src/test/java/com/github/sevntu/checkstyle/checks/design/ForbidWildcardAsReturnTypeCheckTest.java
@@ -33,6 +33,7 @@ import com.puppycrawl.tools.checkstyle.utils.CommonUtil;
 
 /**
  * Test class for ForbidWildcardInReturnTypeCheck.
+ *
  * @author <a href='mailto:barataliba@gmail.com'>Baratali Izmailov</a>
  */
 public class ForbidWildcardAsReturnTypeCheckTest extends AbstractModuleTestSupport {
@@ -117,6 +118,7 @@ public class ForbidWildcardAsReturnTypeCheckTest extends AbstractModuleTestSuppo
 
     /**
      * Main test.
+     *
      * @throws Exception
      *         exceptions while verify()
      */
@@ -143,6 +145,7 @@ public class ForbidWildcardAsReturnTypeCheckTest extends AbstractModuleTestSuppo
 
     /**
      * Test only public methods.
+     *
      * @throws Exception
      *         exceptions while verify()
      */
@@ -170,6 +173,7 @@ public class ForbidWildcardAsReturnTypeCheckTest extends AbstractModuleTestSuppo
 
     /**
      * Test only private methods.
+     *
      * @throws Exception
      *         exceptions while verify()
      */
@@ -197,6 +201,7 @@ public class ForbidWildcardAsReturnTypeCheckTest extends AbstractModuleTestSuppo
 
     /**
      * Test only protected methods.
+     *
      * @throws Exception
      *         exceptions while verify()
      */
@@ -224,6 +229,7 @@ public class ForbidWildcardAsReturnTypeCheckTest extends AbstractModuleTestSuppo
 
     /**
      * Test only package methods.
+     *
      * @throws Exception
      *         exceptions while verify()
      */
@@ -251,6 +257,7 @@ public class ForbidWildcardAsReturnTypeCheckTest extends AbstractModuleTestSuppo
 
     /**
      * Allow wildcard with super.
+     *
      * @throws Exception
      *         exceptions while verify()
      */
@@ -280,6 +287,7 @@ public class ForbidWildcardAsReturnTypeCheckTest extends AbstractModuleTestSuppo
 
     /**
      * Allow wildcard with extends.
+     *
      * @throws Exception
      *         exceptions while verify()
      */
@@ -309,6 +317,7 @@ public class ForbidWildcardAsReturnTypeCheckTest extends AbstractModuleTestSuppo
 
     /**
      * Allow wildcard with extends and super.
+     *
      * @throws Exception
      *         exceptions while verify()
      */
@@ -339,6 +348,7 @@ public class ForbidWildcardAsReturnTypeCheckTest extends AbstractModuleTestSuppo
 
     /**
      * Allow certain types in ignoreListForClassNames.
+     *
      * @throws Exception
      *         exceptions while verify()
      */
@@ -369,6 +379,7 @@ public class ForbidWildcardAsReturnTypeCheckTest extends AbstractModuleTestSuppo
 
     /**
      * Don't check override methods.
+     *
      * @throws Exception
      *         exceptions while verify()
      */
@@ -398,6 +409,7 @@ public class ForbidWildcardAsReturnTypeCheckTest extends AbstractModuleTestSuppo
 
     /**
      * Don't check deprecated methods.
+     *
      * @throws Exception
      *         exceptions while verify()
      */
@@ -438,6 +450,7 @@ public class ForbidWildcardAsReturnTypeCheckTest extends AbstractModuleTestSuppo
 
     /**
      * Create new set of line numbers.
+     *
      * @param aLines
      *        arrays of line numbers
      * @return sorted set of line numbers.
@@ -448,6 +461,7 @@ public class ForbidWildcardAsReturnTypeCheckTest extends AbstractModuleTestSuppo
 
     /**
      * Create array of expected messages.
+     *
      * @param aLines sorted set of line numbers.
      * @return array of messages.
      */

--- a/sevntu-checks/src/test/java/com/github/sevntu/checkstyle/checks/design/NoMainMethodInAbstractClassCheckTest.java
+++ b/sevntu-checks/src/test/java/com/github/sevntu/checkstyle/checks/design/NoMainMethodInAbstractClassCheckTest.java
@@ -28,6 +28,7 @@ import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
 
 /**
  * Test class for NoMainMethodInAbstractClass check.
+ *
  * @author Baratali Izmailov
  */
 public class NoMainMethodInAbstractClassCheckTest extends AbstractModuleTestSupport {
@@ -48,6 +49,7 @@ public class NoMainMethodInAbstractClassCheckTest extends AbstractModuleTestSupp
 
     /**
      * Main test.
+     *
      * @throws Exception
      *         exceptions while verify()
      */

--- a/sevntu-checks/src/test/java/com/github/sevntu/checkstyle/checks/design/PublicReferenceToPrivateTypeCheckTest.java
+++ b/sevntu-checks/src/test/java/com/github/sevntu/checkstyle/checks/design/PublicReferenceToPrivateTypeCheckTest.java
@@ -42,6 +42,7 @@ public class PublicReferenceToPrivateTypeCheckTest extends AbstractModuleTestSup
 
     /**
      * Test file without method return instance of private class.
+     *
      * @throws Exception
      *         exceptions while verify()
      */
@@ -58,6 +59,7 @@ public class PublicReferenceToPrivateTypeCheckTest extends AbstractModuleTestSup
 
     /**
      * Test file with method return instance of private class.
+     *
      * @throws Exception
      *         exceptions while verify()
      */
@@ -76,6 +78,7 @@ public class PublicReferenceToPrivateTypeCheckTest extends AbstractModuleTestSup
     /**
      * Test file with method return instance of private class private class
      * implements interface.
+     *
      * @throws Exception
      *         exceptions while verify()
      */
@@ -93,6 +96,7 @@ public class PublicReferenceToPrivateTypeCheckTest extends AbstractModuleTestSup
     /**
      * Test file with method return instance of private class private class
      * extends another class.
+     *
      * @throws Exception
      *         exceptions while verify()
      */
@@ -109,6 +113,7 @@ public class PublicReferenceToPrivateTypeCheckTest extends AbstractModuleTestSup
 
     /**
      * Test file with method return array of instances of private class.
+     *
      * @throws Exception
      *         exceptions while verify()
      */
@@ -126,6 +131,7 @@ public class PublicReferenceToPrivateTypeCheckTest extends AbstractModuleTestSup
 
     /**
      * Test file with method return collection of instances of private class.
+     *
      * @throws Exception
      *         exceptions while verify()
      */
@@ -144,6 +150,7 @@ public class PublicReferenceToPrivateTypeCheckTest extends AbstractModuleTestSup
     /**
      * Test file with method return collection of collections instances of
      * private class.
+     *
      * @throws Exception
      *         exceptions while verify()
      */
@@ -162,6 +169,7 @@ public class PublicReferenceToPrivateTypeCheckTest extends AbstractModuleTestSup
     /**
      * Test file with method return several times included in collection
      * instances of private class.
+     *
      * @throws Exception
      *         exceptions while verify()
      */
@@ -180,6 +188,7 @@ public class PublicReferenceToPrivateTypeCheckTest extends AbstractModuleTestSup
     /**
      * Test file with different inner classes(default, public, private,
      * protected).
+     *
      * @throws Exception
      *         exceptions while verify()
      */
@@ -202,6 +211,7 @@ public class PublicReferenceToPrivateTypeCheckTest extends AbstractModuleTestSup
     /**
      * Test file with different methods modifiers((default, public, private,
      * protected).
+     *
      * @throws Exception
      *         exceptions while verify()
      */
@@ -223,6 +233,7 @@ public class PublicReferenceToPrivateTypeCheckTest extends AbstractModuleTestSup
 
     /**
      * Test file with wildcards.
+     *
      * @throws Exception
      *         exceptions while verify()
      */

--- a/sevntu-checks/src/test/java/com/github/sevntu/checkstyle/internal/AllChecksTest.java
+++ b/sevntu-checks/src/test/java/com/github/sevntu/checkstyle/internal/AllChecksTest.java
@@ -297,6 +297,7 @@ public class AllChecksTest {
 
     /**
      * Removes 'Check' suffix from each class name in the set.
+     *
      * @param checks class instances.
      * @return a set of simple names.
      */
@@ -310,6 +311,7 @@ public class AllChecksTest {
 
     /**
      * Checks that an array is a subset of other array.
+     *
      * @param array to check whether it is a subset.
      * @param arrayToCheckIn array to check in.
      */

--- a/sevntu-checks/src/test/java/com/github/sevntu/checkstyle/internal/CheckUtil.java
+++ b/sevntu-checks/src/test/java/com/github/sevntu/checkstyle/internal/CheckUtil.java
@@ -100,6 +100,7 @@ public final class CheckUtil {
 
     /**
      * Gets the checkstyle's non abstract checks.
+     *
      * @return the set of checkstyle's non abstract check classes.
      * @throws Exception if the attempt to read class path resources failed.
      */
@@ -159,6 +160,7 @@ public final class CheckUtil {
 
     /**
      * Get's the check's messages.
+     *
      * @param module class to examine.
      * @return a set of checkstyle's module message fields.
      * @throws ClassNotFoundException if the attempt to read a protected class fails.


### PR DESCRIPTION
According to https://checkstyle.sourceforge.io/config_javadoc.html#JavadocParagraph
> There is one blank line between each of two paragraphs and one blank line before the at-clauses block if it is present.

Unfortunately, this check is not working yet in checkstyle, so many of these violations sneaked into the repository, but it's coming in https://github.com/checkstyle/checkstyle/pull/7932 .

I wrote a script to apply the missing newline violations from mvn verify. It is available here: https://github.com/josephmate/FixAtClauseError