### PR TITLE
Issue #817: Support static wildcard import of junit's fail method in RequireFailForTryCatchInJUnitCheck

### DIFF
--- a/sevntu-checks/src/main/java/com/github/sevntu/checkstyle/checks/coding/RequireFailForTryCatchInJunitCheck.java
+++ b/sevntu-checks/src/main/java/com/github/sevntu/checkstyle/checks/coding/RequireFailForTryCatchInJunitCheck.java
@@ -85,15 +85,17 @@ public class RequireFailForTryCatchInJunitCheck extends AbstractCheck {
             "org.junit.Test",
             "org.junit.jupiter.api.Test");
     /**
-     * Fully qualified junit `fail` methods.
-     */
-    private static final List<String> FQ_JUNIT_FAIL_METHODS = Arrays.asList(
-            "org.junit.Assert.fail",
-            "org.junit.jupiter.api.Assertions.fail");
-    /**
      * JUnit's fail assertion method name.
      */
     private static final String FAIL = "fail";
+    /**
+     * Import statements that import junit's static `fail` method.
+     */
+    private static final List<String> JUNIT_FAIL_STATIC_IMPORTS = Arrays.asList(
+            "org.junit.Assert.*",
+            "org.junit.Assert." + FAIL,
+            "org.junit.jupiter.api.Assertions.*",
+            "org.junit.jupiter.api.Assertions." + FAIL);
 
     /**
      * {@code true} if the junit test is imported.
@@ -158,7 +160,7 @@ public class RequireFailForTryCatchInJunitCheck extends AbstractCheck {
             case TokenTypes.STATIC_IMPORT:
                 final String staticImprt = getImportText(ast);
 
-                if (FQ_JUNIT_FAIL_METHODS.contains(staticImprt)) {
+                if (JUNIT_FAIL_STATIC_IMPORTS.contains(staticImprt)) {
                     importStaticFail = true;
                 }
                 break;

--- a/sevntu-checks/src/test/java/com/github/sevntu/checkstyle/checks/coding/RequireFailForTryCatchInJunitCheckTest.java
+++ b/sevntu-checks/src/test/java/com/github/sevntu/checkstyle/checks/coding/RequireFailForTryCatchInJunitCheckTest.java
@@ -117,6 +117,24 @@ public class RequireFailForTryCatchInJunitCheckTest extends AbstractModuleTestSu
     }
 
     @Test
+    public void testStaticWildCardImport() throws Exception {
+        final DefaultConfiguration checkConfig =
+                createModuleConfig(RequireFailForTryCatchInJunitCheck.class);
+        final String[] expected = CommonUtil.EMPTY_STRING_ARRAY;
+        verify(checkConfig, getPath("InputRequireFailForTryCatchInJunitCheck8.java"), expected);
+    }
+
+    @Test
+    public void testStaticWildCardImportFailMissing() throws Exception {
+        final DefaultConfiguration checkConfig =
+                createModuleConfig(RequireFailForTryCatchInJunitCheck.class);
+        final String[] expected = {
+            "9:9: " + getCheckMessage(MSG_KEY),
+        };
+        verify(checkConfig, getPath("InputRequireFailForTryCatchInJunitCheck9.java"), expected);
+    }
+
+    @Test
     public void testUnsupportedNode() {
         final DetailAstImpl sync = new DetailAstImpl();
         sync.setType(TokenTypes.LITERAL_SYNCHRONIZED);
@@ -132,5 +150,4 @@ public class RequireFailForTryCatchInJunitCheckTest extends AbstractModuleTestSu
             Assert.assertEquals("Found unsupported token: LITERAL_SYNCHRONIZED", ex.getMessage());
         }
     }
-
 }

--- a/sevntu-checks/src/test/resources/com/github/sevntu/checkstyle/checks/coding/InputRequireFailForTryCatchInJunitCheck8.java
+++ b/sevntu-checks/src/test/resources/com/github/sevntu/checkstyle/checks/coding/InputRequireFailForTryCatchInJunitCheck8.java
@@ -1,0 +1,15 @@
+package com.github.sevntu.checkstyle.checks.coding;
+
+import static org.junit.Assert.*;
+import org.junit.Test;
+
+public class InputRequireFailForTryCatchInJunitCheck8 {
+    @Test
+    public void junit4Test() {
+        try {
+            fail();
+        }
+        catch (Exception expected) {
+        }
+    }
+}

--- a/sevntu-checks/src/test/resources/com/github/sevntu/checkstyle/checks/coding/InputRequireFailForTryCatchInJunitCheck9.java
+++ b/sevntu-checks/src/test/resources/com/github/sevntu/checkstyle/checks/coding/InputRequireFailForTryCatchInJunitCheck9.java
@@ -1,0 +1,15 @@
+package com.github.sevntu.checkstyle.checks.coding;
+
+import static org.junit.Assert.*;
+import org.junit.Test;
+
+public class InputRequireFailForTryCatchInJunitCheck9 {
+    @Test
+    public void junit4Test() {
+        try {
+            // fail();
+        }
+        catch (Exception expected) {
+        }
+    }
+}


### PR DESCRIPTION
#817