### PR TITLE
config: bump sonar runtime to jdk11 as it demands now as minimal version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -74,7 +74,7 @@ matrix:
         - CMD="./.ci/travis.sh pr-description"
 
     # https://sonarcloud.io (openjdk8)
-    - jdk: openjdk8
+    - jdk: openjdk11
       env:
         - DESC="sonarcloud.io"
         - USE_MAVEN_REPO="true"


### PR DESCRIPTION
https://travis-ci.org/github/sevntu-checkstyle/sevntu.checkstyle/jobs/759133754#L877