### PR TITLE
minor: fix handling of checkstyle checks for tests

### DIFF
--- a/sevntu-checks/src/test/java/com/github/sevntu/checkstyle/checks/coding/AvoidModifiersForTypesCheckTest.java
+++ b/sevntu-checks/src/test/java/com/github/sevntu/checkstyle/checks/coding/AvoidModifiersForTypesCheckTest.java
@@ -30,13 +30,6 @@ import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
 import com.puppycrawl.tools.checkstyle.DetailAstImpl;
 import com.puppycrawl.tools.checkstyle.api.TokenTypes;
 
-/**
- * <p>
- *
- * @author <a href="mailto:Daniil.Yaroslavtsev@gmail.com"> Daniil Yaroslavtsev</a>
- * @author <a href="mailto:yasser.aziza@gmail.com">Yasser Aziza</a>
- * </p>
- */
 public class AvoidModifiersForTypesCheckTest extends AbstractModuleTestSupport {
 
     @Override

--- a/sevntu-checks/src/test/java/com/github/sevntu/checkstyle/checks/coding/ConfusingConditionCheckTest.java
+++ b/sevntu-checks/src/test/java/com/github/sevntu/checkstyle/checks/coding/ConfusingConditionCheckTest.java
@@ -26,9 +26,6 @@ import org.junit.Test;
 import com.puppycrawl.tools.checkstyle.AbstractModuleTestSupport;
 import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
 
-/**
- * @author <a href="mailto:vadim.panasiuk@gmail.com">Vadim Panasiuk</a>
- */
 public class ConfusingConditionCheckTest extends AbstractModuleTestSupport {
 
     private final String warningMessage = getCheckMessage(MSG_KEY);

--- a/sevntu-checks/src/test/java/com/github/sevntu/checkstyle/checks/coding/ForbidCertainImportsCheckTest.java
+++ b/sevntu-checks/src/test/java/com/github/sevntu/checkstyle/checks/coding/ForbidCertainImportsCheckTest.java
@@ -30,10 +30,6 @@ import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
 import com.puppycrawl.tools.checkstyle.DetailAstImpl;
 import com.puppycrawl.tools.checkstyle.api.TokenTypes;
 
-/**
- * @author <a href="mailto:Daniil.Yaroslavtsev@gmail.com"> Daniil
- *         Yaroslavtsev</a>
- */
 public class ForbidCertainImportsCheckTest extends AbstractModuleTestSupport {
 
     @Override

--- a/sevntu-checks/src/test/java/com/github/sevntu/checkstyle/checks/coding/ForbidInstantiationCheckTest.java
+++ b/sevntu-checks/src/test/java/com/github/sevntu/checkstyle/checks/coding/ForbidInstantiationCheckTest.java
@@ -30,10 +30,6 @@ import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
 import com.puppycrawl.tools.checkstyle.DetailAstImpl;
 import com.puppycrawl.tools.checkstyle.api.TokenTypes;
 
-/**
- * @author <a href="mailto:Daniil.Yaroslavtsev@gmail.com"> Daniil
- *         Yaroslavtsev</a>
- */
 public class ForbidInstantiationCheckTest extends AbstractModuleTestSupport {
 
     @Override

--- a/sevntu-checks/src/test/java/com/github/sevntu/checkstyle/checks/coding/NameConventionForJunit4TestClassesCheckTest.java
+++ b/sevntu-checks/src/test/java/com/github/sevntu/checkstyle/checks/coding/NameConventionForJunit4TestClassesCheckTest.java
@@ -24,10 +24,6 @@ import org.junit.Test;
 import com.puppycrawl.tools.checkstyle.AbstractModuleTestSupport;
 import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
 
-/**
- * @author <a href="mailto:denant0vz@gmail.com">Denis Antonenkov</a>
- * @author <a href="mailto:zuy_alexey@mail.ru">Zuy Alexey</a>
- */
 public class NameConventionForJunit4TestClassesCheckTest extends AbstractModuleTestSupport {
 
     @Override

--- a/sevntu-checks/src/test/java/com/github/sevntu/checkstyle/checks/coding/SingleBreakOrContinueCheckTest.java
+++ b/sevntu-checks/src/test/java/com/github/sevntu/checkstyle/checks/coding/SingleBreakOrContinueCheckTest.java
@@ -26,9 +26,6 @@ import org.junit.Test;
 import com.puppycrawl.tools.checkstyle.AbstractModuleTestSupport;
 import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
 
-/**
- * @author <a href="mailto:yasser.aziza@gmail.com"> Yasser Aziza </a>
- */
 public class SingleBreakOrContinueCheckTest extends AbstractModuleTestSupport {
 
     /**

--- a/sevntu-checks/src/test/java/com/github/sevntu/checkstyle/checks/coding/TernaryPerExpressionCountCheckTest.java
+++ b/sevntu-checks/src/test/java/com/github/sevntu/checkstyle/checks/coding/TernaryPerExpressionCountCheckTest.java
@@ -28,9 +28,6 @@ import com.puppycrawl.tools.checkstyle.AbstractModuleTestSupport;
 import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
 import com.puppycrawl.tools.checkstyle.api.CheckstyleException;
 
-/**
- * @author <a href="mailto:nesterenko-aleksey@list.ru"> Aleksey Nesterenko</a>
- */
 public class TernaryPerExpressionCountCheckTest extends AbstractModuleTestSupport {
 
     @Override

--- a/sevntu-checks/src/test/java/com/github/sevntu/checkstyle/checks/design/AvoidConditionInversionCheckTest.java
+++ b/sevntu-checks/src/test/java/com/github/sevntu/checkstyle/checks/design/AvoidConditionInversionCheckTest.java
@@ -30,11 +30,6 @@ import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
 import com.puppycrawl.tools.checkstyle.DetailAstImpl;
 import com.puppycrawl.tools.checkstyle.api.TokenTypes;
 
-/**
- *
- * @author <a href="mailto:nesterenko-aleksey@list.ru">Aleksey Nesterenko</a>
- *
- */
 public class AvoidConditionInversionCheckTest extends AbstractModuleTestSupport {
 
     @Override

--- a/sevntu-checks/src/test/java/com/github/sevntu/checkstyle/checks/design/CauseParameterInExceptionCheckTest.java
+++ b/sevntu-checks/src/test/java/com/github/sevntu/checkstyle/checks/design/CauseParameterInExceptionCheckTest.java
@@ -30,10 +30,6 @@ import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
 import com.puppycrawl.tools.checkstyle.DetailAstImpl;
 import com.puppycrawl.tools.checkstyle.api.TokenTypes;
 
-/**
- * @author <a href="mailto:Daniil.Yaroslavtsev@gmail.com"> Daniil
- *         Yaroslavtsev</a>
- */
 public class CauseParameterInExceptionCheckTest extends AbstractModuleTestSupport {
 
     @Override

--- a/sevntu-checks/src/test/java/com/github/sevntu/checkstyle/checks/design/ChildBlockLengthCheckTest.java
+++ b/sevntu-checks/src/test/java/com/github/sevntu/checkstyle/checks/design/ChildBlockLengthCheckTest.java
@@ -26,10 +26,6 @@ import org.junit.Test;
 import com.puppycrawl.tools.checkstyle.AbstractModuleTestSupport;
 import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
 
-/**
- * @author <a href="mailto:Daniil.Yaroslavtsev@gmail.com"> Daniil
- *         Yaroslavtsev</a>
- */
 public class ChildBlockLengthCheckTest extends AbstractModuleTestSupport {
 
     @Override

--- a/sevntu-checks/src/test/java/com/github/sevntu/checkstyle/checks/design/HideUtilityClassConstructorCheckTest.java
+++ b/sevntu-checks/src/test/java/com/github/sevntu/checkstyle/checks/design/HideUtilityClassConstructorCheckTest.java
@@ -33,7 +33,7 @@ public class HideUtilityClassConstructorCheckTest extends AbstractModuleTestSupp
         return "com/github/sevntu/checkstyle/checks/design";
     }
 
-    /** Only static methods and no constructor - default ctor is visible */
+    /** Only static methods and no constructor - default ctor is visible. */
     @Test
     public void testUtilClass() throws Exception {
         final DefaultConfiguration checkConfig =
@@ -44,7 +44,7 @@ public class HideUtilityClassConstructorCheckTest extends AbstractModuleTestSupp
         verify(checkConfig, getPath("InputHideUtilityClassConstructorCheck.java"), expected);
     }
 
-    /** Non static methods - always OK */
+    /** Non static methods - always OK. */
     @Test
     public void testNonUtilClass() throws Exception {
         final DefaultConfiguration checkConfig =

--- a/sevntu-checks/src/test/java/com/github/sevntu/checkstyle/checks/design/NestedSwitchCheckTest.java
+++ b/sevntu-checks/src/test/java/com/github/sevntu/checkstyle/checks/design/NestedSwitchCheckTest.java
@@ -27,9 +27,6 @@ import com.puppycrawl.tools.checkstyle.AbstractModuleTestSupport;
 import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
 import com.puppycrawl.tools.checkstyle.utils.CommonUtil;
 
-/**
- * @author Damian Szczepanik (damianszczepanik@github)
- */
 public class NestedSwitchCheckTest extends AbstractModuleTestSupport {
 
     @Override

--- a/sevntu-checks/src/test/java/com/github/sevntu/checkstyle/checks/design/PublicReferenceToPrivateTypeCheckTest.java
+++ b/sevntu-checks/src/test/java/com/github/sevntu/checkstyle/checks/design/PublicReferenceToPrivateTypeCheckTest.java
@@ -30,9 +30,6 @@ import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
 import com.puppycrawl.tools.checkstyle.DetailAstImpl;
 import com.puppycrawl.tools.checkstyle.api.TokenTypes;
 
-/**
- * @author <a href="mailto:nesterenko-aleksey@list.ru">Aleksey Nesterenko</a>
- */
 public class PublicReferenceToPrivateTypeCheckTest extends AbstractModuleTestSupport {
 
     @Override

--- a/sevntu-checks/suppressions.xml
+++ b/sevntu-checks/suppressions.xml
@@ -14,10 +14,6 @@
     <!-- END of legacy code -->
 
     <!-- Tone down the checking for test code -->
-    <suppress checks="Javadoc|DesignForExtension" files=".*[\\/]src[\\/]test[\\/]"/>
-    <suppress checks="MagicNumber" files=".*[\\/]src[\\/]test[\\/]"/>
-    <suppress checks="AvoidStaticImport" files=".*[\\/]src[\\/]test[\\/]"/>
-    <suppress checks="WriteTag" files=".*[\\/]src[\\/]test[\\/]"/>
     <suppress checks="IllegalCatch" files="[\\/]internal[\\/]\w+Util\.java"/>
 
     <!-- we can not change name of pre-existing Check -->


### PR DESCRIPTION
Identified at https://github.com/checkstyle/checkstyle/pull/8177#issuecomment-782748438 ,

Suppressions were hiding too much in tests. They were removed and only javadoc issues were fixed.