### PR TITLE
minor: make id value selectable

### DIFF
--- a/sevntu-checks/suppressions.xml
+++ b/sevntu-checks/suppressions.xml
@@ -24,7 +24,7 @@
     <suppress checks="Translation" files=".*"/>
     
     <!-- this is allowed and legacy use case -->
-    <suppress id="noUsageOfGetFileContents()Method" files="TernaryPerExpressionCountCheck.java"/>
+    <suppress id="noUsageOfGetFileContentsMethod" files="TernaryPerExpressionCountCheck.java"/>
 
     <!-- until https://github.com/sevntu-checkstyle/sevntu.checkstyle/issues/669 -->
     <suppress id="MatchXPathBranchContains" files="[\\/]LogicConditionNeedOptimizationCheck.java"/>


### PR DESCRIPTION
As discussed from https://github.com/checkstyle/checkstyle/pull/9909#discussion_r628893136

The id value "noUsageOfGetFileContents()Method" should get rid of () to be selectable by double click.