### PR TITLE
minor: update checks (related to checkstyle #3145)

### DIFF
--- a/sevntu-checks/src/main/java/com/github/sevntu/checkstyle/checks/coding/AvoidNotShortCircuitOperatorsForBooleanCheck.java
+++ b/sevntu-checks/src/main/java/com/github/sevntu/checkstyle/checks/coding/AvoidNotShortCircuitOperatorsForBooleanCheck.java
@@ -21,9 +21,11 @@ package com.github.sevntu.checkstyle.checks.coding;
 
 import java.util.LinkedList;
 import java.util.List;
+import java.util.regex.Pattern;
 
 import com.puppycrawl.tools.checkstyle.api.AbstractCheck;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
+import com.puppycrawl.tools.checkstyle.api.FullIdent;
 import com.puppycrawl.tools.checkstyle.api.TokenTypes;
 import com.puppycrawl.tools.checkstyle.utils.CheckUtil;
 
@@ -80,9 +82,9 @@ public class AvoidNotShortCircuitOperatorsForBooleanCheck extends AbstractCheck 
     public static final String MSG_KEY = "avoid.not.short.circuit.operators.for.boolean";
 
     /**
-     * A "boolean" String.
-     * */
-    private static final String BOOLEAN = "boolean";
+     * Pattern to match boolean types, including array types.
+     */
+    private static final Pattern BOOLEAN_TYPE_PATTERN = Pattern.compile("^boolean(\\[[^]]*])*");
 
     /**
      * A list contains all names of operands, which are used in the current
@@ -140,8 +142,11 @@ public class AvoidNotShortCircuitOperatorsForBooleanCheck extends AbstractCheck 
      * @return "true" if current method or variable has a Boolean type.
      */
     private static boolean isBooleanType(final DetailAST node) {
-        return BOOLEAN.equals(CheckUtil.createFullType(
-                node.findFirstToken(TokenTypes.TYPE)).getText());
+        final FullIdent methodOrVariableType =
+                CheckUtil.createFullType(node.findFirstToken(TokenTypes.TYPE));
+        return BOOLEAN_TYPE_PATTERN
+                .matcher(methodOrVariableType.getText())
+                .find();
     }
 
     /**

--- a/sevntu-checks/src/main/java/com/github/sevntu/checkstyle/checks/coding/NoNullForCollectionReturnCheck.java
+++ b/sevntu-checks/src/main/java/com/github/sevntu/checkstyle/checks/coding/NoNullForCollectionReturnCheck.java
@@ -181,10 +181,11 @@ public class NoNullForCollectionReturnCheck extends AbstractCheck {
      * @return true, when method return collection.
      */
     private boolean isReturnCollection(DetailAST methodDef) {
-        DetailAST methodType = methodDef.findFirstToken(TokenTypes.TYPE);
-        methodType = methodType.getFirstChild();
-        return methodType.getType() == TokenTypes.ARRAY_DECLARATOR
-                || collectionList.contains(methodType.getText());
+        final DetailAST methodType = methodDef.findFirstToken(TokenTypes.TYPE);
+        final boolean isArrayType =
+                methodType.findFirstToken(TokenTypes.ARRAY_DECLARATOR) != null;
+        return isArrayType
+                || collectionList.contains(methodType.getFirstChild().getText());
     }
 
     /**

--- a/sevntu-checks/src/test/java/com/github/sevntu/checkstyle/checks/coding/AvoidNotShortCircuitOperatorsForBooleanCheckTest.java
+++ b/sevntu-checks/src/test/java/com/github/sevntu/checkstyle/checks/coding/AvoidNotShortCircuitOperatorsForBooleanCheckTest.java
@@ -78,4 +78,16 @@ public class AvoidNotShortCircuitOperatorsForBooleanCheckTest extends AbstractMo
             CommonUtil.EMPTY_STRING_ARRAY);
     }
 
+    @Test
+    public final void testBitwiseOrAfterArrayIndex() throws Exception {
+        final DefaultConfiguration checkConfig =
+                createModuleConfig(AvoidNotShortCircuitOperatorsForBooleanCheck.class);
+        final String[] expected = {
+            "6:19: " + getCheckMessage(MSG_KEY, "|="),
+            "8:20: " + getCheckMessage(MSG_KEY, "|="),
+        };
+        verify(checkConfig,
+                getPath("InputAvoidNotShortCircuitOperatorsForBooleanCheckBitwiseAfterArray.java"),
+                expected);
+    }
 }

--- a/sevntu-checks/src/test/resources/com/github/sevntu/checkstyle/checks/coding/InputAvoidNotShortCircuitOperatorsForBooleanCheckBitwiseAfterArray.java
+++ b/sevntu-checks/src/test/resources/com/github/sevntu/checkstyle/checks/coding/InputAvoidNotShortCircuitOperatorsForBooleanCheckBitwiseAfterArray.java
@@ -1,0 +1,10 @@
+package com.github.sevntu.checkstyle.checks.coding;
+
+public class InputAvoidNotShortCircuitOperatorsForBooleanCheckBitwiseAfterArray {
+    void boolFalse(String[] args) {
+        final boolean[] values = {false};
+        values[0] |= (args.length > 0);
+        final boolean[][] val2 = {{false}, {false}};
+        val2[0][0] |= (args.length > 0);
+    }
+}


### PR DESCRIPTION
Related to https://github.com/checkstyle/checkstyle/pull/9922,  before we update sevntu check's `checkstyle.eclipse-cs.version` to 8.43, we will need to merge this PR to avoid regression in `AvoidNotShortCircuitOperatorsForBooleanCheck` and `NoNullForCollectionReturnCheck`.

Diff report from checkstyle#9922: https://checkstyle-diff-reports.s3.us-east-2.amazonaws.com/24f673f_2021192452/reports/diff/index.html (regression)

Diff report after this PR: https://nmancus1.github.io/sevntu-diff-3145-b/index.html (no regression)