### PR TITLE
minor: update checks(related to checkstyle issue#10100)

### DIFF
--- a/sevntu-checks/pom.xml
+++ b/sevntu-checks/pom.xml
@@ -16,7 +16,7 @@
   <properties>
     <project.build.sourceEncoding>iso-8859-1</project.build.sourceEncoding>
     <!-- It is compile dependency to checkstyle, this version has to be the same as eclipse-cs depends on -->
-    <checkstyle.eclipse-cs.version>8.43</checkstyle.eclipse-cs.version>
+    <checkstyle.eclipse-cs.version>8.44</checkstyle.eclipse-cs.version>
     <!-- verify time version -->
     <checkstyle.version>8.45.1</checkstyle.version>
     <checkstyle.configLocation>https://raw.githubusercontent.com/checkstyle/checkstyle/checkstyle-${checkstyle.version}/config/checkstyle_checks.xml</checkstyle.configLocation>

--- a/sevntu-checks/src/main/java/com/github/sevntu/checkstyle/checks/coding/CustomDeclarationOrderCheck.java
+++ b/sevntu-checks/src/main/java/com/github/sevntu/checkstyle/checks/coding/CustomDeclarationOrderCheck.java
@@ -1145,10 +1145,8 @@ public class CustomDeclarationOrderCheck extends AbstractCheck {
             final DetailAST parameterTypeAST = parameterDefinitionAST
                     .findFirstToken(TokenTypes.TYPE);
             if (hasChildToken(parameterTypeAST, TokenTypes.ARRAY_DECLARATOR)) {
-                final DetailAST arrayDeclaratorAST = parameterTypeAST
-                        .findFirstToken(TokenTypes.ARRAY_DECLARATOR);
                 final String parameterName =
-                        getIdentifier(arrayDeclaratorAST);
+                        parameterTypeAST.getFirstChild().getText();
                 result = "String".equals(parameterName);
             }
             else {

--- a/sevntu-checks/src/main/java/com/github/sevntu/checkstyle/checks/coding/Jsr305AnnotationsCheck.java
+++ b/sevntu-checks/src/main/java/com/github/sevntu/checkstyle/checks/coding/Jsr305AnnotationsCheck.java
@@ -31,6 +31,7 @@ import com.puppycrawl.tools.checkstyle.api.AbstractCheck;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
 import com.puppycrawl.tools.checkstyle.api.FullIdent;
 import com.puppycrawl.tools.checkstyle.api.TokenTypes;
+import com.puppycrawl.tools.checkstyle.utils.TokenUtil;
 
 /**
  * <p>
@@ -585,22 +586,17 @@ public class Jsr305AnnotationsCheck extends AbstractCheck {
     /**
      * Checks whether token is array or elipsis.
      *
-     * @param identToken
+     * @param typeToken
      *        the token
      * @return true if yes
      */
-    private static boolean isArrayOrElipsis(final DetailAST identToken) {
-        final DetailAST next = identToken.getNextSibling();
-        final boolean result;
-        switch (next.getType()) {
-            case TokenTypes.ARRAY_DECLARATOR:
-            case TokenTypes.ELLIPSIS:
-                result = true;
-                break;
-            default:
-                result = false;
-        }
-        return result;
+    private static boolean isArrayOrElipsis(final DetailAST typeToken) {
+        final DetailAST next = typeToken.getNextSibling();
+        final boolean isArrayDeclarator =
+                typeToken.findFirstToken(TokenTypes.ARRAY_DECLARATOR) != null;
+        final boolean hasArrayOrEllipses =
+                TokenUtil.isOfType(next, TokenTypes.ARRAY_DECLARATOR, TokenTypes.ELLIPSIS);
+        return hasArrayOrEllipses || isArrayDeclarator;
     }
 
     /**

--- a/sevntu-checks/src/main/java/com/github/sevntu/checkstyle/checks/coding/MultipleVariableDeclarationsExtendedCheck.java
+++ b/sevntu-checks/src/main/java/com/github/sevntu/checkstyle/checks/coding/MultipleVariableDeclarationsExtendedCheck.java
@@ -167,9 +167,7 @@ public class MultipleVariableDeclarationsExtendedCheck extends AbstractCheck {
         while (child != null) {
             final DetailAST newNode = getLastNode(child);
             if (newNode.getLineNo() > currentNode.getLineNo()
-                    || newNode.getLineNo()
-                        == currentNode.getLineNo() && newNode
-                            .getColumnNo() > currentNode.getColumnNo()) {
+                    && newNode.getColumnNo() > currentNode.getColumnNo()) {
                 currentNode = newNode;
             }
             child = child.getNextSibling();

--- a/sevntu-checks/src/main/java/com/github/sevntu/checkstyle/checks/coding/PreferMethodReferenceCheck.java
+++ b/sevntu-checks/src/main/java/com/github/sevntu/checkstyle/checks/coding/PreferMethodReferenceCheck.java
@@ -424,17 +424,22 @@ public class PreferMethodReferenceCheck extends AbstractCheck {
      *     {@code false} otherwise
      */
     private static boolean isArgUsedInArrayInit(DetailAST declarator, String name) {
-        final DetailAST nestedDecl = declarator.findFirstToken(TokenTypes.ARRAY_DECLARATOR);
-        final DetailAST expr = declarator.findFirstToken(TokenTypes.EXPR);
-        boolean result = false;
-        if (nestedDecl == null && expr != null) {
-            final DetailAST ident = expr.findFirstToken(TokenTypes.IDENT);
-            result = ident != null && name.equals(ident.getText());
+        boolean hasNoMultiDimensionalArrayWithExpressions = true;
+        DetailAST nextSibling = declarator.getNextSibling();
+        while (nextSibling != null) {
+            if (nextSibling.getType() == TokenTypes.ARRAY_DECLARATOR
+                    && nextSibling.getFirstChild().getType() == TokenTypes.EXPR) {
+                hasNoMultiDimensionalArrayWithExpressions = false;
+            }
+            nextSibling = nextSibling.getNextSibling();
         }
-        else if (nestedDecl != null && expr == null) {
-            result = isArgUsedInArrayInit(nestedDecl, name);
-        }
-        return result;
+
+        final boolean isFirstArrayDeclaratorInit =
+                declarator.getFirstChild().findFirstToken(TokenTypes.IDENT) != null
+                && name.equals(declarator.getFirstChild()
+                    .findFirstToken(TokenTypes.IDENT).getText());
+
+        return isFirstArrayDeclaratorInit && hasNoMultiDimensionalArrayWithExpressions;
     }
 
     /**

--- a/sevntu-checks/src/main/java/com/github/sevntu/checkstyle/checks/design/NoMainMethodInAbstractClassCheck.java
+++ b/sevntu-checks/src/main/java/com/github/sevntu/checkstyle/checks/design/NoMainMethodInAbstractClassCheck.java
@@ -223,10 +223,8 @@ public class NoMainMethodInAbstractClassCheck extends AbstractCheck {
             final DetailAST parameterTypeAST = parameterDefinitionAST
                     .findFirstToken(TokenTypes.TYPE);
             if (hasChildToken(parameterTypeAST, TokenTypes.ARRAY_DECLARATOR)) {
-                final DetailAST arrayDeclaratorAST = parameterTypeAST
-                        .findFirstToken(TokenTypes.ARRAY_DECLARATOR);
                 final String parameterName =
-                        getIdentifier(arrayDeclaratorAST);
+                        parameterTypeAST.getFirstChild().getText();
                 result = STRING_CLASS.equals(parameterName);
             }
             else {

--- a/sevntu-checks/src/test/java/com/github/sevntu/checkstyle/checks/coding/Jsr305AnnotationsCheckTest.java
+++ b/sevntu-checks/src/test/java/com/github/sevntu/checkstyle/checks/coding/Jsr305AnnotationsCheckTest.java
@@ -150,7 +150,7 @@ public class Jsr305AnnotationsCheckTest extends AbstractModuleTestSupport {
                     Jsr305AnnotationsCheck.MSG_PARAMETER_WITHOUT_NULLNESS_ANNOTATION, "e"),
             "76:43: " + getCheckMessage(
                     Jsr305AnnotationsCheck.MSG_PARAMETER_WITHOUT_NULLNESS_ANNOTATION, "e"),
-            "90:8: " + getCheckMessage(
+            "90:5: " + getCheckMessage(
                     Jsr305AnnotationsCheck.MSG_RETURN_WITHOUT_NULLNESS_ANNOTATION, "e"),
             "102:32: " + getCheckMessage(
                     Jsr305AnnotationsCheck.MSG_PARAMETER_WITHOUT_NULLNESS_ANNOTATION, "e"),

--- a/sevntu-checks/src/test/java/com/github/sevntu/checkstyle/checks/coding/NoNullForCollectionReturnCheckTest.java
+++ b/sevntu-checks/src/test/java/com/github/sevntu/checkstyle/checks/coding/NoNullForCollectionReturnCheckTest.java
@@ -182,4 +182,21 @@ public class NoNullForCollectionReturnCheckTest extends AbstractModuleTestSuppor
                 expected);
     }
 
+    @Test
+    public void testObjectArray()
+            throws Exception {
+        final DefaultConfiguration checkConfig =
+                createModuleConfig(NoNullForCollectionReturnCheck.class);
+
+        final String[] expected = {
+            "15:13: " + warningMessage,
+            "33:13: " + warningMessage,
+            "52:9: " + warningMessage,
+            "64:15: " + warningMessage,
+        };
+
+        verify(checkConfig, getPath("InputNoNullForCollectionReturnCheckObjectArray.java"),
+                expected);
+    }
+
 }

--- a/sevntu-checks/src/test/java/com/github/sevntu/checkstyle/checks/design/ForbidWildcardAsReturnTypeCheckTest.java
+++ b/sevntu-checks/src/test/java/com/github/sevntu/checkstyle/checks/design/ForbidWildcardAsReturnTypeCheckTest.java
@@ -448,6 +448,21 @@ public class ForbidWildcardAsReturnTypeCheckTest extends AbstractModuleTestSuppo
             CommonUtil.EMPTY_STRING_ARRAY);
     }
 
+    @Test
+    public final void testNewArrayStructure()
+            throws Exception {
+        final DefaultConfiguration checkConfig =
+                createModuleConfig(ForbidWildcardAsReturnTypeCheck.class);
+
+        final String[] expected = {
+            "4:5: " + getCheckMessage(MSG_KEY),
+        };
+
+        verify(checkConfig,
+            getPath("InputForbidWildcardAsReturnTypeCheckNewArrayStructure.java"),
+                expected);
+    }
+
     /**
      * Create new set of line numbers.
      *

--- a/sevntu-checks/src/test/resources/com/github/sevntu/checkstyle/checks/coding/InputNoNullForCollectionReturnCheckObjectArray.java
+++ b/sevntu-checks/src/test/resources/com/github/sevntu/checkstyle/checks/coding/InputNoNullForCollectionReturnCheckObjectArray.java
@@ -1,0 +1,67 @@
+package com.github.sevntu.checkstyle.checks.coding;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.jar.JarEntry;
+
+import org.assertj.core.internal.bytebuddy.implementation.bytecode.member.MethodInvocation;
+
+/* Config: default
+ *
+ */
+public class InputNoNullForCollectionReturnCheckObjectArray {
+    public static File[] getFiles1(int x) {
+        if (x == 9) {
+            return null; // violation
+        }
+        else {
+            return new File[9]; // ok
+        }
+    }
+
+    public static File[] getFiles2(int x) {
+        if (x == 9) {
+            return new File[5]; // ok
+        }
+        else {
+            return new File[9]; // ok
+        }
+    }
+
+    String[] getStrings1(int x) {
+        if (x == 9) {
+            return null; // violation
+        }
+        else {
+            return new String[9]; // ok
+        }
+    }
+
+    String[] getStrings2(int x) {
+        if (x == 9) {
+            return new String[5]; // ok
+        }
+        else {
+            return new String[9]; // ok
+        }
+    }
+
+    public java.security.cert.Certificate[] getCertificates()
+              throws IOException {
+        JarEntry e = getJarEntry();
+        return e != null ? e.getCertificates() : null; // violation
+    }
+
+    private static JarEntry getJarEntry() {
+        return null;
+    }
+
+    protected Object[] getMethodArguments(MethodInvocation invocation) {
+        if (invocation != null) {
+              return new MethodInvocation[2];
+        }
+        else {
+              return null;
+        }
+    }
+}

--- a/sevntu-checks/src/test/resources/com/github/sevntu/checkstyle/checks/design/InputForbidWildcardAsReturnTypeCheckNewArrayStructure.java
+++ b/sevntu-checks/src/test/resources/com/github/sevntu/checkstyle/checks/design/InputForbidWildcardAsReturnTypeCheckNewArrayStructure.java
@@ -1,0 +1,16 @@
+package com.github.sevntu.checkstyle.checks.design;
+
+public class InputForbidWildcardAsReturnTypeCheckNewArrayStructure {
+    protected Class<?>[] getAnnotatedClasses() {
+        return new Class<?>[]{
+                Parent.class,
+                Child.class
+        };
+    }
+
+    private class Parent {
+    }
+
+    private class Child {
+    }
+}


### PR DESCRIPTION
Related to https://github.com/checkstyle/checkstyle/pull/10104

### Original reports from Checkstyle PR showing regression:


https://nmancus1.github.io/issue-10100_check_diff_reports_2021_06_11/diff_sevntu-check-regression_part_1/index.html

`NoMainMethodInAbstractClassCheck`- new NPE
`ForbidWildcardAsReturnType` - lots of new legit violations, we were missing violations on methods like `public Class<?>[] getClasses() {}`
`InnerClass` - symmetrical column changes
`StaticMethodCandidate` - new violations, we were missing violations previously on methods with `String` return type


-----------------------

https://nmancus1.github.io/issue-10100_check_diff_reports_2021_06_11/diff_sevntu-check-regression_part_2/index.html

`MoveVariableInsideIf` - symmetrical column number changes
`SimpleAccessorNameNotation` - symmetrical column number changes
`CustomDeclarationOrder` - symmetrical column number changes

---------------------------

### New reports showing no regression:

https://nmancus1.github.io/issue-10100_check_diff_reports_2021_06_16/diff_sevntu-check-regression_part_1/index.html

Symmetric column changes and new legitimate violations
`NoMainMethodInAbstractClassCheck`- NPE is gone

-----------------------------

https://nmancus1.github.io/issue-10100_check_diff_reports_2021_06_16/diff_sevntu-check-regression_part_2/index.html

Symmetric column changes only

-----------------------------


All other changes were because of failing existing unit tests (found via `mvn clean verify`).

I will let the build fail to show that the changes in this PR are dependent on the changes at https://github.com/checkstyle/checkstyle/pull/10104, then I will change the Checkstyle repo to my PR to show that all pass.

Failed build (I had to add `mvn clean verify` to CI):

```
Results :

Failed tests: 
  NoMainMethodInAbstractClassCheckTest.testDefault:87->AbstractModuleTestSupport.verify:229->AbstractModuleTestSupport.verify:267->AbstractModuleTestSupport.verify:304 error message 0 expected:<...actClassCheck.java:1[00]:5: Main method insi...> but was:<...actClassCheck.java:1[16]:5: Main method insi...>
  ForbidWildcardAsReturnTypeCheckTest.testNewArrayStructure:461->AbstractModuleTestSupport.verify:229->AbstractModuleTestSupport.verify:267->AbstractModuleTestSupport.verify:304 error message 0 expected:<[/pipeline/source/sevntu-checks/src/test/resources/com/github/sevntu/checkstyle/checks/design/InputForbidWildcardAsReturnTypeCheckNewArrayStructure.java:4:5: Wildcard as return type should be avoided].> but was:<[Audit done].>
  PreferMethodReferenceCheckTest.testObjectCreation:146->AbstractModuleTestSupport.verify:229->AbstractModuleTestSupport.verify:267->AbstractModuleTestSupport.verify:304 error message 2 expected:<...ferenceCheck4.java:1[7]:39: Lambda can be r...> but was:<...ferenceCheck4.java:1[8]:39: Lambda can be r...>
  PreferMethodReferenceCheckTest.testStatementsListsWithExpressions:128->AbstractModuleTestSupport.verify:229->AbstractModuleTestSupport.verify:267->AbstractModuleTestSupport.verify:304 error message 11 expected:<...eferenceCheck3.java:[46]:40: Lambda can be r...> but was:<...eferenceCheck3.java:[50]:40: Lambda can be r...>
  Jsr305AnnotationsCheckTest.testArrays:161->AbstractModuleTestSupport.verify:229->AbstractModuleTestSupport.verify:267->AbstractModuleTestSupport.verify:304 error message 6 expected:<...kWithArrays.java:90:[5]: Return value must ...> but was:<...kWithArrays.java:90:[8]: Return value must ...>
  CustomDeclarationOrderCheckTest.mainMethod:189->AbstractModuleTestSupport.verify:229->AbstractModuleTestSupport.verify:267->AbstractModuleTestSupport.verify:304 error message 0 expected:<...d(private )' then 'M[ainM]ethod(.*)'.> but was:<...d(private )' then 'M[]ethod(.*)'.>

Tests run: 411, Failures: 6, Errors: 0, Skipped: 0

[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 32.994 s
[INFO] Finished at: 2021-06-16T11:42:15Z
[INFO] Final Memory: 56M/980M
[INFO] ---------------------------------------------------------------------

```
Full log at https://app.wercker.com/checkstyle/sevntu.checkstyle/runs/build/60c9e32c237ec900086455fa?step=60c9e3678ea84100087595c9

-------------

`mvn clean verify` is passing with Checkstyle version from  https://github.com/checkstyle/checkstyle/pull/10104