### PR TITLE
infra: add 'mvn clean verify' to CI

### DIFF
--- a/wercker.yml
+++ b/wercker.yml
@@ -55,6 +55,18 @@ build:
         fi
 
   - script:
+      name: sevntu-checks 'mvn clean verify'
+      code: |
+        if [[ $SKIP_CI == 'false' ]]; then
+          cd sevntu-checks
+          echo "Command: mvn clean verify"
+          mvn clean verify
+          cd ..
+        else
+          echo "build is skipped ..."
+        fi
+
+  - script:
       name: NoExceptiontest - Apache Struts
       code: |
         if [[ $SKIP_CI == 'false' ]]; then


### PR DESCRIPTION
Noticed at https://github.com/sevntu-checkstyle/sevntu.checkstyle/pull/851, we have no `mvn clean verify` in sevntu's CI.