### PR TITLE
minor: fix broken URLs

### DIFF
--- a/eclipsecs-sevntu-plugin-feature/feature.xml
+++ b/eclipsecs-sevntu-plugin-feature/feature.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <feature id="com.github.sevntu.checkstyle.checks.feature" label="Extension for eclipse-cs plugin with additional Checks" version="1.40.0">
 
-   <description url="http://sevntu-checkstyle.github.com/sevntu.checkstyle/">
+   <description url="http://sevntu-checkstyle.github.io/sevntu.checkstyle/">
       http://sevntu-checkstyle.github.io/sevntu.checkstyle/
    </description>
 
-   <copyright url="http://sevntu-checkstyle.github.com/sevntu.checkstyle/">
+   <copyright url="http://sevntu-checkstyle.github.io/sevntu.checkstyle/">
       Please visit site to view developer list - https://github.com/sevntu-checkstyle/sevntu.checkstyle#contributors
    </copyright>
 
@@ -16,8 +16,8 @@ Eclipse Public License - Version 1.0
 
    <url>
       <discovery label="Sources on GitHub" url="https://github.com/sevntu-checkstyle/sevntu.checkstyle"/>
-      <discovery label="SevNTU checks site" url="http://sevntu-checkstyle.github.com/sevntu.checkstyle/"/>
-      <discovery label="Eclipse Update site" url="http://sevntu-checkstyle.github.com/sevntu.checkstyle/update-site/"/>
+      <discovery label="SevNTU checks site" url="http://sevntu-checkstyle.github.io/sevntu.checkstyle/"/>
+      <discovery label="Eclipse Update site" url="http://sevntu-checkstyle.github.io/sevntu.checkstyle/update-site/"/>
    </url>
 
    <plugin id="eclipsecs-sevntu-plugin" download-size="0" install-size="0" version="1.40.0" unpack="false"/>


### PR DESCRIPTION
Fix the URLs that should have used `.io` instead of `.com`.

https://github.com/sevntu-checkstyle/sevntu.checkstyle/issues/857#issuecomment-903161782