### PR TITLE
minor: fix broken URLs

### DIFF
--- a/gsoc-2013-ideas.html
+++ b/gsoc-2013-ideas.html
@@ -56,7 +56,7 @@
   <h3><a href="https://github.com/sevntu-checkstyle/sevntu.checkstyle">sevntu.checkstyle</a></h3>
 
     <b>Brief explanation:</b><br/>
-      Our project is extension to <a href="http://eclipse-cs.sourceforge.net/">EclipseCS plugin</a>. You can install our project from Eclipse update site of  EclipseCS plugin in "Uncategorized" group. List of our already implemented Checks is <a href="http://sevntu-checkstyle.github.com/sevntu.checkstyle/">here</a>.
+      Our project is extension to <a href="http://eclipse-cs.sourceforge.net/">EclipseCS plugin</a>. You can install our project from Eclipse update site of  EclipseCS plugin in "Uncategorized" group. List of our already implemented Checks is <a href="http://sevntu-checkstyle.github.io/sevntu.checkstyle/">here</a>.
       <br/>
       <br/>
       Our project is a sort of a test area for many of non-standard Checkstyle Checks; some of them are presented in main stream of Checkstyle project and some have not yet shown up in there. Unfortunately, generating an idea of a new code-rule is not a trivial task. An idea has to be proven and tested throughly on a wide range of projects in open-source community, before it can finally get into the main project and become of use for most of the developers.

--- a/index.html
+++ b/index.html
@@ -228,7 +228,7 @@ We do deployment to Maven central -
 <span id="checkstyle-maven">- extension to <a href="https://maven.apache.org/plugins/maven-checkstyle-plugin/">maven-checkstyle-plugin</a> (how to use: <a href="https://maven.apache.org/plugins/maven-checkstyle-plugin/examples/custom-developed-checkstyle.html">in general</a>, <a href="https://github.com/sevntu-checkstyle/checkstyle-samples/tree/master/maven-project">maven example</a>, <a href="https://github.com/sevntu-checkstyle/checkstyle-samples/tree/master/ant-project">ant example</a>).</span><br>
 <span id="checkstyle-sonar">- extension to <a href="https://docs.codehaus.org/display/SONAR/Checkstyle+Plugin">Sonar Checkstyle Plugin</a> (how to use: <a href="https://github.com/sevntu-checkstyle/sevntu.checkstyle/wiki/How-to-integrate-sevntu-checks-into-SonarQubeTM-%28user%27s-guide%29">in general</a>).</span><br>
 <span id="checkstyle-idea">- extension to <a href="https://plugins.jetbrains.com/plugin/1065">CheckStyle-IDEA</a> (how to use: <a href="https://github.com/sevntu-checkstyle/sevntu.checkstyle/wiki/How-to-use-SevNTU-Checkstyle-in-Intellij-IDEA">in general</a>).</span><br>
-<span id="eclipsecs-update-site">- extension to <a href="https://eclipse-cs.sourceforge.net/">Checkstyle Eclipse plugin</a> how to use: install from EclipseCS “update site” or use our update site https://sevntu-checkstyle.github.com/sevntu.checkstyle/update-site/ (do not use this link in Browser, it will return 404 code, it is expected, but it will work well through Eclipse menu "Help"->"Install New Software ...") </span>
+<span id="eclipsecs-update-site">- extension to <a href="https://marketplace.eclipse.org/content/checkstyle-plug">Checkstyle Eclipse plugin</a> (how to use: install from EclipseCS “update site” or use our update site https://sevntu-checkstyle.github.io/sevntu.checkstyle/update-site/ (do not use this link in Browser, it will return 404 code, it is expected, but it will work well through Eclipse menu "Help"->"Install New Software ...")</span>
 </p>
 
 <h2 id="ExamplesOfUsage">Examples of usage</h2>
@@ -1664,7 +1664,7 @@ LineLengthExtendedCheck - extension of standard check with a lot of ignore optio
 
 	<h2>Examples and ideas</h2>
 	Examples of how to use SevNTU-Checkstyle with Maven, Ant or Gradle you can find at <a href="https://github.com/sevntu-checkstyle/checkstyle-samples">checkstyle-samples</a> repo.
-    <p><a href="https://sevntu-checkstyle.github.com/sevntu.checkstyle/gsoc-2013-ideas.html">GSOC 2013 ideas</a>
+    <p><a href="https://sevntu-checkstyle.github.io/sevntu.checkstyle/gsoc-2013-ideas.html">GSOC 2013 ideas</a>
 
     <h2>Download</h2>
     <p>


### PR DESCRIPTION
Fix the URLs that should have used `.io` instead of `.com`.

https://github.com/sevntu-checkstyle/sevntu.checkstyle/issues/857#issuecomment-903161782