### PR TITLE
infra: use latest ecj compiler in ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -62,7 +62,7 @@ matrix:
         - CMD="./.ci/travis.sh checkstyle-regression"
 
     # eclipse static analysis
-    - jdk: openjdk8
+    - jdk: openjdk11
       env:
         - DESC="eclipse-analysis"
         - USE_MAVEN_REPO="true"

--- a/sevntu-checks/.ci/eclipse-compiler-javac.sh
+++ b/sevntu-checks/.ci/eclipse-compiler-javac.sh
@@ -12,15 +12,14 @@ if [ -z "$2" ]; then
     exit 1
 fi
 
-# Eclipse releases every 13 weeks: https://wiki.eclipse.org/SimRel/Simultaneous_Release_Cycle_FAQ
-# After that these variables should be updated.
-ECJ_MAVEN_VERSION="R-4.20-202106111600"
-ECJ_JAR="ecj-4.20.jar"
+ECLIPSE_URL="http://ftp-stud.fht-esslingen.de/pub/Mirrors/eclipse/eclipse/downloads/drops4"
+ECJ_MAVEN_VERSION=$(wget --quiet -O- "$ECLIPSE_URL/?C=M;O=D" | grep -o "R-[^/]*" | head -n1)
+echo "Latest eclipse release is $ECJ_MAVEN_VERSION"
+ECJ_JAR=$(wget --quiet -O- "$ECLIPSE_URL/$ECJ_MAVEN_VERSION/" | grep -o "ecj-[^\"]*" | head -n1)
 ECJ_PATH=~/.m2/repository/$ECJ_MAVEN_VERSION/$ECJ_JAR
 
 if [ ! -f $ECJ_PATH ]; then
     echo "$ECJ_PATH is not found, downloading ..."
-    ECLIPSE_URL="http://ftp-stud.fht-esslingen.de/pub/Mirrors/eclipse/eclipse/downloads/drops4"
     cd target
     wget $ECLIPSE_URL/$ECJ_MAVEN_VERSION/$ECJ_JAR
     echo "test jar after download:"
@@ -30,7 +29,10 @@ if [ ! -f $ECJ_PATH ]; then
     cd ..
 fi
 
-wget https://github.com/checkstyle/checkstyle/blob/checkstyle-$2/config/org.eclipse.jdt.core.prefs
+wget https://raw.githubusercontent.com/checkstyle/checkstyle/checkstyle-$2/config/org.eclipse.jdt.core.prefs
+
+# Suppress Eclipse compiler false violation. See https://bugs.eclipse.org/bugs/show_bug.cgi?id=353394
+sed -i -e "s/reportMethodCanBeStatic=error/reportMethodCanBeStatic=warning/g" org.eclipse.jdt.core.prefs
 
 mkdir -p target/classes target/test-classes target/eclipse
 

--- a/sevntu-checks/src/main/java/com/github/sevntu/checkstyle/checks/design/StaticMethodCandidateCheck.java
+++ b/sevntu-checks/src/main/java/com/github/sevntu/checkstyle/checks/design/StaticMethodCandidateCheck.java
@@ -678,13 +678,12 @@ public class StaticMethodCandidateCheck extends AbstractCheck {
                         hasNonStaticMethod = true;
                         break;
                     }
-                    else {
-                        // if a static method is found, we keep searching for a similar
-                        // non-static one to the end of the frame and if a non-static
-                        // method is not found, then the checked method is still
-                        // a static method candidate
-                        hasStaticMethod = true;
-                    }
+
+                    // if a static method is found, we keep searching for a similar
+                    // non-static one to the end of the frame and if a non-static
+                    // method is not found, then the checked method is still
+                    // a static method candidate
+                    hasStaticMethod = true;
                 }
             }
             frame = Optional.fromNullable(frame.get().parent);


### PR DESCRIPTION
Same changes as for the upstream. With a couple of additions.