### PR TITLE
infra: use free arch in Travis to avoid usage of credits

### DIFF
--- a/.ci/travis.sh
+++ b/.ci/travis.sh
@@ -56,9 +56,10 @@ sevntu-checks)
   mvn -e -Pcoverall install
   mvn -e verify -Pno-validations,selftesting
   mvn -e javadoc:javadoc
-  if [[ $TRAVIS == 'true' ]]; then
-    mvn -e -Pcoverall jacoco:report coveralls:report
-  fi
+  # until problem coverall back to online
+  #if [[ $TRAVIS == 'true' ]]; then
+  #  mvn -e -Pcoverall jacoco:report coveralls:report
+  #fi
   ;;
 
 all-sevntu-checks-contribution)

--- a/.travis.yml
+++ b/.travis.yml
@@ -102,7 +102,7 @@ script:
       if [[ $USE_MAVEN_REPO == 'true' && ! -d "~/.m2" ]]; then
        echo "Maven local repo cache is not found, initializing it ..."
        cd sevntu-checks
-       mvn -B install -Pno-validations
+       mvn  -e --no-transfer-progress install -Pno-validations
        cd ../
       fi
       echo "eval of CMD is starting";

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,6 +28,7 @@ matrix:
   include:
     # eclipse-cs
     - jdk: openjdk8
+      arch: s390x
       env:
         - DESC="eclipse-cs"
         - USE_MAVEN_REPO="true"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,8 @@
+version: ~> 1.0
+dist: focal
+# this arch is required as is for Partner Queue Solution - DO NOT MODIFY
+arch: ppc64le
+
 language: java
 sudo: false
 
@@ -9,6 +14,7 @@ addons:
   apt:
     packages:
       - xmlstarlet
+      - maven
 
 branches:
   only:


### PR DESCRIPTION
Travis allow unlimited execution only on special arch
https://blog.travis-ci.com/2019-11-12-multi-cpu-architecture-ibm-power-ibm-z

s390x: no jdk11 support, only jre (problmes with jacoco, javadoc), jdk8 support is problematic.
Question to support: https://travis-ci.community/t/arch-s390x-has-jre-but-most-builds-of-java-needs-jdk/12143/2