### PR TITLE
infra: setup JAVA_HOME

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -96,6 +96,9 @@ script:
     set -e
     if [[ $RUN_JOB == 1 ]]; then
       MVN_SETTINGS=${TRAVIS_HOME}/.m2/settings.xml
+      export JAVA_HOME="/usr/lib/jvm/"$(ls /usr/lib/jvm/ | head -n 1)"/"
+      echo "JAVA_HOME="$JAVA_HOME
+      export PATH=$JAVA_HOME/bin:$PATH
       if [[ -f ${MVN_SETTINGS} ]]; then
         if [[ $TRAVIS_OS_NAME == 'osx' ]]; then
           sed -i'' -e "/<mirrors>/,/<\/mirrors>/ d" $MVN_SETTINGS


### PR DESCRIPTION
https://app.travis-ci.com/github/sevntu-checkstyle/sevntu.checkstyle/jobs/538683265#L809

```
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-javadoc-plugin:2.10.4:jar 
(attach-javadocs) on project sevntu-checks: MavenReportException: 
Error while generating Javadoc: Unable to find javadoc command: 
The environment variable JAVA_HOME is not correctly set. -> [Help 1]

org.apache.maven.lifecycle.LifecycleExecutionException: 
Failed to execute goal org.apache.maven.plugins:maven-javadoc-plugin:2.10.4:jar (attach-javadocs) 
on project sevntu-checks: MavenReportException: Error while generating Javadoc: 
Unable to find javadoc command: The environment variable JAVA_HOME is not correctly set.
```