### PR TITLE
Replace usage of CheckUtil#createFullType with FullIdent#createFullIdent

### DIFF
--- a/sevntu-checks/src/main/java/com/github/sevntu/checkstyle/checks/coding/AvoidNotShortCircuitOperatorsForBooleanCheck.java
+++ b/sevntu-checks/src/main/java/com/github/sevntu/checkstyle/checks/coding/AvoidNotShortCircuitOperatorsForBooleanCheck.java
@@ -27,7 +27,6 @@ import com.puppycrawl.tools.checkstyle.api.AbstractCheck;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
 import com.puppycrawl.tools.checkstyle.api.FullIdent;
 import com.puppycrawl.tools.checkstyle.api.TokenTypes;
-import com.puppycrawl.tools.checkstyle.utils.CheckUtil;
 
 /**
  * This check limits using of not short-circuit operators
@@ -143,7 +142,7 @@ public class AvoidNotShortCircuitOperatorsForBooleanCheck extends AbstractCheck 
      */
     private static boolean isBooleanType(final DetailAST node) {
         final FullIdent methodOrVariableType =
-                CheckUtil.createFullType(node.findFirstToken(TokenTypes.TYPE));
+                FullIdent.createFullIdent(node.findFirstToken(TokenTypes.TYPE).getFirstChild());
         return BOOLEAN_TYPE_PATTERN
                 .matcher(methodOrVariableType.getText())
                 .find();

--- a/sevntu-checks/src/main/java/com/github/sevntu/checkstyle/checks/coding/IllegalCatchExtendedCheck.java
+++ b/sevntu-checks/src/main/java/com/github/sevntu/checkstyle/checks/coding/IllegalCatchExtendedCheck.java
@@ -27,7 +27,6 @@ import com.puppycrawl.tools.checkstyle.api.AbstractCheck;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
 import com.puppycrawl.tools.checkstyle.api.FullIdent;
 import com.puppycrawl.tools.checkstyle.api.TokenTypes;
-import com.puppycrawl.tools.checkstyle.utils.CheckUtil;
 
 /**
  * Catching java.lang.Exception, java.lang.Error or java.lang.RuntimeException
@@ -142,7 +141,7 @@ public final class IllegalCatchExtendedCheck extends AbstractCheck {
              || allowRethrow && secondLvlChild.getType() == TokenTypes.LITERAL_NEW);
 
         final DetailAST excType = paramDef.findFirstToken(TokenTypes.TYPE);
-        final FullIdent ident = CheckUtil.createFullType(excType);
+        final FullIdent ident = FullIdent.createFullIdent(excType.getFirstChild());
 
         if (!noWarning && isIllegalClassName(ident.getText())) {
             log(detailAST, MSG_KEY, ident.getText());


### PR DESCRIPTION
Related to changes at https://github.com/checkstyle/checkstyle/pull/10839/commits/7462b00c2f0d470be6d3d8825f83c717cc5696aa, and noticed in check regression testing for https://github.com/checkstyle/checkstyle/pull/10979, we need to replace usages of `CheckUtil#createFullType` with `FullIdent#createFullIdent` now that `CheckUtil#createFullType` has been removed.

It breaking compatibility with main library.
New versions of sevntu can not work with checkstyle versions below 9.2 due to https://github.com/checkstyle/checkstyle/issues/10144