### PR TITLE
config: bump checkstyle to 9.2 version

### DIFF
--- a/sevntu-checks/pom.xml
+++ b/sevntu-checks/pom.xml
@@ -16,7 +16,7 @@
   <properties>
     <project.build.sourceEncoding>iso-8859-1</project.build.sourceEncoding>
     <!-- It is compile dependency to checkstyle, this version has to be the same as eclipse-cs depends on -->
-    <checkstyle.eclipse-cs.version>9.1</checkstyle.eclipse-cs.version>
+    <checkstyle.eclipse-cs.version>9.2</checkstyle.eclipse-cs.version>
     <!-- verify time version -->
     <checkstyle.version>9.2.1</checkstyle.version>
     <checkstyle.configLocation>https://raw.githubusercontent.com/checkstyle/checkstyle/checkstyle-${checkstyle.version}/config/checkstyle_checks.xml</checkstyle.configLocation>

--- a/sevntu-checks/src/test/java/com/github/sevntu/checkstyle/checks/coding/Jsr305AnnotationsCheckTest.java
+++ b/sevntu-checks/src/test/java/com/github/sevntu/checkstyle/checks/coding/Jsr305AnnotationsCheckTest.java
@@ -383,7 +383,8 @@ public class Jsr305AnnotationsCheckTest extends AbstractModuleTestSupport {
         ast.setType(TokenTypes.WILDCARD_TYPE);
 
         final Method handleDefinition =
-                TestUtil.getClassDeclaredMethod(Jsr305AnnotationsCheck.class, "handleDefinition");
+                TestUtil.getClassDeclaredMethod(Jsr305AnnotationsCheck.class,
+                        "handleDefinition", 1);
 
         try {
             handleDefinition.invoke(new Jsr305AnnotationsCheck(), ast);


### PR DESCRIPTION
Changes to TestUtil.getClassDeclaredMethod in https://github.com/checkstyle/checkstyle/issues/7368 requires update of unit test

Blocked by https://github.com/checkstyle/eclipse-cs/issues/329