### PR TITLE
config: adds dependabot for sevntu checks

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+- package-ecosystem: maven
+  directory: "/sevntu-checks"
+  schedule:
+    interval: weekly
+    day: "friday"
+  open-pull-requests-limit: 2
+  commit-message:
+    prefix: dependency


### PR DESCRIPTION
Only adding 1 folder for now. Set for weekly, max 2 PRs.

After the first set of PRs, we can probably switch it to monthly with a bit higher PR count.