### PR TITLE
dependency: upgrades maven-javadoc-plugin to 3.4.1

### DIFF
--- a/sevntu-checks/pom.xml
+++ b/sevntu-checks/pom.xml
@@ -186,7 +186,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-javadoc-plugin</artifactId>
-          <version>2.10.4</version>
+          <version>3.4.1</version>
           <configuration>
             <!-- To allow build with latest JDK the source version must be explicitly set
               See https://bugs.openjdk.java.net/browse/JDK-8212233 for details -->


### PR DESCRIPTION
This resolves a spam of warnings when running the suite and my be related to the java 11 upgrade:
````
[WARNING] javadoc: warning - The code being documented uses modules but the packages defined in http://docs.oracle.com/javase/8/docs/api/ are in the unnamed module.
````