### PR TITLE
minor: removes outdated rule from pmd

### DIFF
--- a/sevntu-checks/pmd.xml
+++ b/sevntu-checks/pmd.xml
@@ -90,8 +90,6 @@
     <exclude name="CompareObjectsWithEquals"/>
     <!-- Too many false positives. -->
     <exclude name="DataflowAnomalyAnalysis"/>
-    <!-- This rule does not have any option, unreasonable to use. -->
-    <exclude name="MissingBreakInSwitch"/>
     <!-- We reuse Check instances between java files, we need to clear state of
          class in beginTree() methods. -->
     <exclude name="NullAssignment"/>


### PR DESCRIPTION
Resolves a spam of warnings from PMD:
````
[WARNING] Unable to exclude rules [MissingBreakInSwitch] from ruleset reference category/java/errorprone.xml; perhaps the rule name is misspelled or the rule doesn't exist anymore?
````