### PR TITLE
Issue #915: correct handling of checkstyle.ant.skip

### DIFF
--- a/sevntu-checks/ant-phase-verify-sevntu.xml
+++ b/sevntu-checks/ant-phase-verify-sevntu.xml
@@ -1,12 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <project name="phase-package" default="execute">
-
-  <condition property="checkstyle.ant.skip">
-    <isset property="checkstyle.ant.skip" />
+  <condition property="run">
+    <or>
+        <not>
+            <isset property="checkstyle.ant.skip"/>
+        </not>
+        <isfalse value="${checkstyle.ant.skip}"/>
+     </or>
   </condition>
 
-  <target name="execute" unless="checkstyle.ant.skip">
+  <target name="execute" if="run">
     <taskdef resource="com/puppycrawl/tools/checkstyle/ant/checkstyle-ant-task.properties"/>
 
     <property name="check.config" location="sevntu-checks.xml"/>

--- a/sevntu-checks/ant-phase-verify.xml
+++ b/sevntu-checks/ant-phase-verify.xml
@@ -1,12 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <project name="phase-package" default="execute">
-
-  <condition property="checkstyle.ant.skip">
-    <isset property="checkstyle.ant.skip" />
+  <condition property="run">
+    <or>
+        <not>
+            <isset property="checkstyle.ant.skip"/>
+        </not>
+        <isfalse value="${checkstyle.ant.skip}"/>
+     </or>
   </condition>
 
-  <target name="execute" unless="checkstyle.ant.skip">
+  <target name="execute" if="run">
     <taskdef resource="com/puppycrawl/tools/checkstyle/ant/checkstyle-ant-task.properties"/>
 
     <tstamp>


### PR DESCRIPTION
The [Ant manual Property Task](http://ant.apache.org/manual/Tasks/property.html) states:

>    Properties are immutable: whoever sets a property first freezes it for the rest of the build; they are most definitely not variables.

I created a intermediator variable to handle to make the conditions easier and make handling same as original.