### PR TITLE
minor: simplify scripts and ensure we are able to rerun

### DIFF
--- a/.ci/checks-no-exception.sh
+++ b/.ci/checks-no-exception.sh
@@ -189,7 +189,7 @@ pmd-elasticsearch-lombok-ast)
                      --non-recursive org.codehaus.mojo:exec-maven-plugin:1.3.1:exec)
   echo CS_version: ${CS_POM_VERSION}
   echo SEVNTU_version: ${SEVNTU_POM_VERSION}
-  checkout_from "-b issue-529 https://github.com/nmancus1/contribution "
+  checkout_from "https://github.com/checkstyle/contribution.git"
   cd .ci-temp/contribution/checkstyle-tester
   sed -i.'' 's/^guava/#guava/' projects-to-test-on.properties
   sed -i.'' 's/#pmd/pmd/' projects-to-test-on.properties

--- a/.ci/checks-no-exception.sh
+++ b/.ci/checks-no-exception.sh
@@ -1,21 +1,7 @@
 #!/bin/bash
 set -e
 
-function checkout_from {
-  CLONE_URL=$1
-  PROJECT=$(echo "$CLONE_URL" | sed -nE 's/.*\/(.*).git/\1/p')
-  mkdir -p .ci-temp
-  cd .ci-temp
-  if [ -d "$PROJECT" ]; then
-    echo "Target project $PROJECT is already cloned, latest changes will be fetched"
-    cd $PROJECT
-    git fetch
-    cd ../
-  else
-    for i in 1 2 3 4 5; do git clone $CLONE_URL && break || sleep 15; done
-  fi
-  cd ../
-}
+source ./.ci/util.sh
 
 case $1 in
 

--- a/.ci/util.sh
+++ b/.ci/util.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+# This script contains common bash CI functions
+set -e
+
+function checkout_from {
+  CLONE_URL=$1
+  PROJECT=$(echo "$CLONE_URL" | sed -nE 's/.*\/(.*).git/\1/p')
+  mkdir -p .ci-temp
+  cd .ci-temp
+  if [ -d "$PROJECT" ]; then
+    echo "Target project $PROJECT is already cloned, latest changes will be fetched and reset"
+    cd "$PROJECT"
+    git fetch
+    git reset --hard HEAD
+    git clean -f -d
+    cd ../
+  else
+    for i in 1 2 3 4 5; do git clone "$CLONE_URL" && break || sleep 15; done
+  fi
+  cd ../
+}

--- a/.ci/validation.sh
+++ b/.ci/validation.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 set -e
 
+source ./.ci/util.sh
+
 case $1 in
 
 eclipse-cs)
@@ -15,10 +17,8 @@ eclipse-cs)
   cd sevntu-checks
   mvn -B -e clean install -Pno-validations
   cd ..
-  mkdir -p .ci-temp
-  cd .ci-temp
-  git clone https://github.com/checkstyle/eclipse-cs.git
-  cd eclipse-cs/
+  checkout_from "https://github.com/checkstyle/eclipse-cs.git"
+  cd .ci-temp/eclipse-cs/
   echo "Eclipse-cs tag: "$ECLIPSECS_TAG_NAME
   git checkout $ECLIPSECS_TAG_NAME
   mvn -B -e install
@@ -81,10 +81,7 @@ all-sevntu-checks-contribution)
   ;;
 
 checkstyle-regression)
-  mkdir -p .ci-temp
-  cd .ci-temp
-  git clone https://github.com/checkstyle/checkstyle
-  cd ../
+  checkout_from "https://github.com/checkstyle/checkstyle"
   # update checkstyle_sevntu_checks.xml file in checkstyle for new modules
   cd sevntu-checks
   SEVNTU_VERSION=$(mvn -e -q -Dexec.executable='echo' -Dexec.args='${project.version}' \


### PR DESCRIPTION
identified from https://github.com/sevntu-checkstyle/sevntu.checkstyle/blob/master/.ci/validation.sh#L20 when trying to run locally and running into issues,

````
sevntu.checkstyle/ $ ./.ci/validation.sh eclipse-cs

.....
fatal: destination path 'eclipse-cs' already exists and is not an empty directory.


sevntu.checkstyle/.ci-temp/eclipse-cs/ $ git status

HEAD detached at 10.0.0
Changes not staged for commit:
  (use "git add <file>..." to update what will be committed)
  (use "git checkout -- <file>..." to discard changes in working directory)

    modified:  docs/partials/releases/5.0.0final/release_notes.html
    modified:  docs/sitemap.xml

no changes added to commit (use "git add" and/or "git commit -a")
````