### PR TITLE
config: removal of s390x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,6 @@ jobs:
   include:
     # eclipse-cs
     - jdk: openjdk11
-      arch: s390x
       env:
         - DESC="eclipse-cs"
         - USE_MAVEN_REPO="true"

--- a/eclipse-pom.xml
+++ b/eclipse-pom.xml
@@ -22,14 +22,14 @@
   </modules>
 
   <properties>
-    <tycho-version>1.3.0</tycho-version>
+    <tycho-version>1.6.0</tycho-version>
   </properties>
 
   <repositories>
     <repository>
-      <id>indigo</id>
+      <id>2019-06</id>
       <layout>p2</layout>
-      <url>http://download.eclipse.org/releases/juno</url>
+      <url>https://download.eclipse.org/releases/2019-06</url>
     </repository>
   </repositories>
 


### PR DESCRIPTION
This removed s390x because travis is having issues running it and also synchronizes configuration with what is found in eclipse-cs.

Comparison at https://github.com/sevntu-checkstyle/sevntu.checkstyle/pull/928#issuecomment-1295942685