### PR TITLE
doc: fix typo in hyperlink

### DIFF
--- a/update-site/index.html
+++ b/update-site/index.html
@@ -76,7 +76,7 @@ a:hover {
     <h1><a href="https://github.com/sevntu-checkstyle/sevntu.checkstyle">Sevntu-Checkstyle</a></h1>
       <p><span class="small">By students from around the world.
       <br/>
-	Licence is <a href="https://www.gnu.org/licenses/lgpl-2.1.en.html">GNU LESSER GENERAL PUBLIC LICENSE Version 2.1.</a>
+	Licence is <a href="https://www.gnu.org/licenses/lgpl-2.1.en.html">GNU LESSER GENERAL PUBLIC LICENSE Version 2.1</a>.
       </span></p>
 
     <h2>Update Site</h2>


### PR DESCRIPTION
Sentence finish should not be part of hyperlink.