### PR TITLE
minor: adds sevntu compatibility matrix

### DIFF
--- a/README.textile
+++ b/README.textile
@@ -16,6 +16,26 @@ Additional(non-standard) checks for Checkstyle that are compiled as:
 - extension to "Checkstyle Eclipse plugin":http://eclipse-cs.sourceforge.net/ how to use: install from EclipseCS "update site":
 !https://cloud.githubusercontent.com/assets/812984/2935361/20e479c8-d805-11e3-9391-f41cc4aa979c.png!
 
+h3. Compatibility Matrix
+
+| Sevntu Plugin | Checkstyle | Jdk |
+| 1.43.0        | 10.4       | 11  |
+| 1.42.0        | 10.0       | 11  |
+| 1.41.0        | 9.1        | 8   |
+| 1.40.0        | 8.40       | 8   |
+| 1.39.0        | 8.29       | 8   |
+| 1.38.0        | 8.29       | 8   |
+| 1.37.1        | 8.29       | 8   |
+| 1.37.0        | 8.26       | 8   |
+| 1.36.0        | 8.26       | 8   |
+| 1.35.0        | 8.18       | 8   |
+| 1.34.1        | 8.18       | 8   |
+| 1.34.0        | 8.18       | 8   |
+| 1.33.0        | 8.18       | 8   |
+| 1.32.0        | 8.12       | 8   |
+| 1.31.0        | 8.11       | 8   |
+| 1.30.0        | 8.10       | 8   |
+
 h3. Related Projects
 
 "Checkstyle":http://checkstyle.sourceforge.net/, "EclipseCS":http://eclipse-cs.sourceforge.net/, "Checkstyle IDEA":https://github.com/jshiell/checkstyle-idea, "Checkstyle Beans to NetBeans":http://plugins.netbeans.org/plugin/3413/checkstyle-beans, "Checkstyle Addons":http://checkstyle-addons.thomasjensen.com/, "Maven Checkstyle Plugin":http://maven.apache.org/plugins/maven-checkstyle-plugin/, "Gradle Checkstyle Plugin":https://docs.gradle.org/current/userguide/checkstyle_plugin.html, "Sonar Checkstyle Plugin":http://redirect.sonarsource.com/plugins/checkstyle.html


### PR DESCRIPTION
I only wrote as far back as 1.30.0 but I can do all the way back.

Generated via:
````
@echo off

call :CheckSevntu 1.10.0
call :CheckSevntu 1.11.0
call :CheckSevntu 1.12.0
call :CheckSevntu 1.13.0
call :CheckSevntu 1.13.1
call :CheckSevntu 1.13.2
call :CheckSevntu 1.13.3
call :CheckSevntu 1.13.4
call :CheckSevntu 1.13.5
call :CheckSevntu 1.13.6
call :CheckSevntu 1.14.0
call :CheckSevntu 1.15.0
call :CheckSevntu 1.16.0
call :CheckSevntu 1.16.1
call :CheckSevntu 1.17.0
call :CheckSevntu 1.17.1
call :CheckSevntu 1.18.0
call :CheckSevntu 1.19.0
call :CheckSevntu 1.19.1
call :CheckSevntu 1.19.2
call :CheckSevntu 1.20.0
call :CheckSevntu 1.21.0
call :CheckSevntu 1.21.1
call :CheckSevntu 1.22.0
call :CheckSevntu 1.23.0
call :CheckSevntu 1.23.1
call :CheckSevntu 1.24.0
call :CheckSevntu 1.24.1
call :CheckSevntu 1.24.2
call :CheckSevntu 1.25.0
call :CheckSevntu 1.26.0
call :CheckSevntu 1.27.0
call :CheckSevntu 1.28.0
call :CheckSevntu 1.29.0
call :CheckSevntu 1.30.0
call :CheckSevntu 1.31.0
call :CheckSevntu 1.32.0
call :CheckSevntu 1.33.0
call :CheckSevntu 1.34.0
call :CheckSevntu 1.34.1
call :CheckSevntu 1.35.0
call :CheckSevntu 1.36.0
call :CheckSevntu 1.37.0
call :CheckSevntu 1.37.1
call :CheckSevntu 1.38.0
call :CheckSevntu 1.39.0
call :CheckSevntu 1.40.0
call :CheckSevntu 1.41.0
call :CheckSevntu 1.42.0
call :CheckSevntu 1.43.0

EXIT /B %ERRORLEVEL%

:CheckSevntu


echo Checking %~1

cd sevntu

git checkout %~1

cd sevntu-checks

echo cs eclipsecs expression
call mvn -e --no-transfer-progress -q -DforceStdout help:evaluate -D""expression=checkstyle.eclipse-cs.version""
echo.

echo checkstyle dependency
call mvn -e --no-transfer-progress dependency:tree | findstr checkstyle:jar
echo.

cd ..
cd ..

EXIT /B 0
````

Output:
````
Checking 1.10.0
cs eclipsecs expression
null object or invalid expression
checkstyle dependency
[INFO] +- com.puppycrawl.tools:checkstyle:jar:5.6:compile

Checking 1.11.0
cs eclipsecs expression
null object or invalid expression
checkstyle dependency
[INFO] +- com.puppycrawl.tools:checkstyle:jar:5.7:compile

Checking 1.12.0
cs eclipsecs expression
null object or invalid expression
checkstyle dependency
[INFO] +- com.puppycrawl.tools:checkstyle:jar:5.7:compile

Checking 1.13.0
cs eclipsecs expression
null object or invalid expression
checkstyle dependency
[INFO] +- com.puppycrawl.tools:checkstyle:jar:6.5:compile

Checking 1.13.1
cs eclipsecs expression
null object or invalid expression
checkstyle dependency
[INFO] +- com.puppycrawl.tools:checkstyle:jar:6.5:compile

Checking 1.13.2
cs eclipsecs expression
null object or invalid expression
checkstyle dependency
[INFO] +- com.puppycrawl.tools:checkstyle:jar:6.5:compile

Checking 1.13.3
cs eclipsecs expression
null object or invalid expression
checkstyle dependency
[INFO] +- com.puppycrawl.tools:checkstyle:jar:6.5:compile

Checking 1.13.4
cs eclipsecs expression
null object or invalid expression
checkstyle dependency
[INFO] +- com.puppycrawl.tools:checkstyle:jar:6.5:compile

Checking 1.13.5
cs eclipsecs expression
null object or invalid expression
checkstyle dependency
[INFO] +- com.puppycrawl.tools:checkstyle:jar:6.5:compile

Checking 1.13.6
cs eclipsecs expression
null object or invalid expression
checkstyle dependency
[INFO] +- com.puppycrawl.tools:checkstyle:jar:6.7:compile

Checking 1.14.0
cs eclipsecs expression
null object or invalid expression
checkstyle dependency
[INFO] +- com.puppycrawl.tools:checkstyle:jar:6.7:compile

Checking 1.15.0
cs eclipsecs expression
null object or invalid expression
checkstyle dependency
[INFO] +- com.puppycrawl.tools:checkstyle:jar:6.11.2:compile

Checking 1.16.0
cs eclipsecs expression
null object or invalid expression
checkstyle dependency
[INFO] +- com.puppycrawl.tools:checkstyle:jar:6.11.2:compile

Checking 1.16.1
cs eclipsecs expression
null object or invalid expression
checkstyle dependency
[INFO] +- com.puppycrawl.tools:checkstyle:jar:6.11.2:compile

Checking 1.17.0
cs eclipsecs expression
null object or invalid expression
checkstyle dependency
[INFO] +- com.puppycrawl.tools:checkstyle:jar:6.11.2:compile

Checking 1.17.1
cs eclipsecs expression
null object or invalid expression
checkstyle dependency
[INFO] +- com.puppycrawl.tools:checkstyle:jar:6.11.2:compile

Checking 1.18.0
cs eclipsecs expression
null object or invalid expression
checkstyle dependency
[INFO] +- com.puppycrawl.tools:checkstyle:jar:6.11.2:compile

Checking 1.19.0
cs eclipsecs expression
6.16.1
checkstyle dependency
[INFO] +- com.puppycrawl.tools:checkstyle:jar:6.16.1:compile

Checking 1.19.1
cs eclipsecs expression
6.16.1
checkstyle dependency
[INFO] +- com.puppycrawl.tools:checkstyle:jar:6.16.1:compile

Checking 1.19.2
cs eclipsecs expression
6.16.1
checkstyle dependency
[INFO] +- com.puppycrawl.tools:checkstyle:jar:6.16.1:compile

Checking 1.20.0
cs eclipsecs expression
6.16.1
checkstyle dependency
[INFO] +- com.puppycrawl.tools:checkstyle:jar:6.16.1:compile

Checking 1.21.0
cs eclipsecs expression
6.16.1
checkstyle dependency
[INFO] +- com.puppycrawl.tools:checkstyle:jar:6.16.1:compile

Checking 1.21.1
cs eclipsecs expression
6.16.1
checkstyle dependency
[INFO] +- com.puppycrawl.tools:checkstyle:jar:6.16.1:compile

Checking 1.22.0
cs eclipsecs expression
7.2
checkstyle dependency
[INFO] +- com.puppycrawl.tools:checkstyle:jar:7.2:compile

Checking 1.23.0
cs eclipsecs expression
7.2
checkstyle dependency
[INFO] +- com.puppycrawl.tools:checkstyle:jar:7.2:compile

Checking 1.23.1
cs eclipsecs expression
7.2
checkstyle dependency
[INFO] +- com.puppycrawl.tools:checkstyle:jar:7.2:compile

Checking 1.24.0
cs eclipsecs expression
7.2
checkstyle dependency
[INFO] +- com.puppycrawl.tools:checkstyle:jar:7.2:compile

Checking 1.24.1
cs eclipsecs expression
7.6
checkstyle dependency
[INFO] +- com.puppycrawl.tools:checkstyle:jar:7.6:compile

Checking 1.24.2
cs eclipsecs expression
7.6
checkstyle dependency
[INFO] +- com.puppycrawl.tools:checkstyle:jar:7.6:compile

Checking 1.25.0
cs eclipsecs expression
7.6
checkstyle dependency
[INFO] +- com.puppycrawl.tools:checkstyle:jar:7.6:compile

Checking 1.26.0
cs eclipsecs expression
8.5
checkstyle dependency
[INFO] +- com.puppycrawl.tools:checkstyle:jar:8.5:compile

Checking 1.27.0
cs eclipsecs expression
8.7
checkstyle dependency
[INFO] +- com.puppycrawl.tools:checkstyle:jar:8.7:compile

Checking 1.28.0
cs eclipsecs expression
8.8
checkstyle dependency
[INFO] +- com.puppycrawl.tools:checkstyle:jar:8.8:compile

Checking 1.29.0
cs eclipsecs expression
8.9
checkstyle dependency
[INFO] +- com.puppycrawl.tools:checkstyle:jar:8.9:compile

Checking 1.30.0
cs eclipsecs expression
8.10
checkstyle dependency
[INFO] +- com.puppycrawl.tools:checkstyle:jar:8.10:compile

Checking 1.31.0
cs eclipsecs expression
8.11
checkstyle dependency
[INFO] +- com.puppycrawl.tools:checkstyle:jar:8.11:compile

Checking 1.32.0
cs eclipsecs expression
8.12
checkstyle dependency
[INFO] +- com.puppycrawl.tools:checkstyle:jar:8.12:compile

Checking 1.33.0
cs eclipsecs expression
8.18
checkstyle dependency
[INFO] +- com.puppycrawl.tools:checkstyle:jar:8.18:compile

Checking 1.34.0
cs eclipsecs expression
8.18
checkstyle dependency
[INFO] +- com.puppycrawl.tools:checkstyle:jar:8.18:compile

Checking 1.34.1
cs eclipsecs expression
8.18
checkstyle dependency
[INFO] +- com.puppycrawl.tools:checkstyle:jar:8.18:compile

Checking 1.35.0
cs eclipsecs expression
8.18
checkstyle dependency
[INFO] +- com.puppycrawl.tools:checkstyle:jar:8.18:provided

Checking 1.36.0
cs eclipsecs expression
8.26
checkstyle dependency
[INFO] +- com.puppycrawl.tools:checkstyle:jar:8.26:provided

Checking 1.37.0
cs eclipsecs expression
8.26
checkstyle dependency
[INFO] +- com.puppycrawl.tools:checkstyle:jar:8.26:provided

Checking 1.37.1
cs eclipsecs expression
8.29
checkstyle dependency
[INFO] +- com.puppycrawl.tools:checkstyle:jar:8.29:provided

Checking 1.38.0
cs eclipsecs expression
8.29
checkstyle dependency
[INFO] +- com.puppycrawl.tools:checkstyle:jar:8.29:provided

Checking 1.39.0
cs eclipsecs expression
8.29
checkstyle dependency
[INFO] +- com.puppycrawl.tools:checkstyle:jar:8.29:provided

Checking 1.40.0
cs eclipsecs expression
8.40
checkstyle dependency
[INFO] +- com.puppycrawl.tools:checkstyle:jar:8.40:provided

Checking 1.41.0
cs eclipsecs expression
9.1
checkstyle dependency
[INFO] +- com.puppycrawl.tools:checkstyle:jar:9.1:provided

Checking 1.42.0
cs eclipsecs expression
10.0
checkstyle dependency
[INFO] +- com.puppycrawl.tools:checkstyle:jar:10.0:provided

Checking 1.43.0
cs eclipsecs expression
10.4
checkstyle dependency
[INFO] +- com.puppycrawl.tools:checkstyle:jar:10.4:provided
````