### PR TITLE
config: adds dependabot for sevntu idea and sevntu sonar

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,3 +8,19 @@ updates:
   open-pull-requests-limit: 2
   commit-message:
     prefix: dependency
+- package-ecosystem: maven
+  directory: "/sevntu-checkstyle-idea-extension"
+  schedule:
+    interval: weekly
+    day: "friday"
+  open-pull-requests-limit: 2
+  commit-message:
+    prefix: dependency
+- package-ecosystem: maven
+  directory: "/sevntu-checkstyle-sonar-plugin"
+  schedule:
+    interval: weekly
+    day: "friday"
+  open-pull-requests-limit: 2
+  commit-message:
+    prefix: dependency


### PR DESCRIPTION
Added to more sevntu projects. I assume eclipsecs is not possible since it is not in maven.