### PR TITLE
minor: restore features formatting and added remaining suppressions

### DIFF
--- a/eclipsecs-sevntu-plugin-feature/feature.xml
+++ b/eclipsecs-sevntu-plugin-feature/feature.xml
@@ -1,14 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<feature id="com.github.sevntu.checkstyle.checks.feature"
-   label="Extension for eclipse-cs plugin with additional Checks" version="1.44.0">
+<feature id="com.github.sevntu.checkstyle.checks.feature" label="Extension for eclipse-cs plugin with additional Checks" version="1.44.0">
 
    <description url="http://sevntu-checkstyle.github.io/sevntu.checkstyle/">
       http://sevntu-checkstyle.github.io/sevntu.checkstyle/
    </description>
 
    <copyright url="http://sevntu-checkstyle.github.io/sevntu.checkstyle/">
-      Please visit site to view developer list -
-      https://github.com/sevntu-checkstyle/sevntu.checkstyle#contributors
+      Please visit site to view developer list - https://github.com/sevntu-checkstyle/sevntu.checkstyle#contributors
    </copyright>
 
    <license url="http://www.eclipse.org/legal/epl-v10.html">
@@ -17,15 +15,11 @@ Eclipse Public License - Version 1.0
    </license>
 
    <url>
-      <discovery label="Sources on GitHub"
-         url="https://github.com/sevntu-checkstyle/sevntu.checkstyle"/>
-      <discovery label="SevNTU checks site"
-         url="http://sevntu-checkstyle.github.io/sevntu.checkstyle/"/>
-      <discovery label="Eclipse Update site"
-         url="http://sevntu-checkstyle.github.io/sevntu.checkstyle/update-site/"/>
+      <discovery label="Sources on GitHub" url="https://github.com/sevntu-checkstyle/sevntu.checkstyle"/>
+      <discovery label="SevNTU checks site" url="http://sevntu-checkstyle.github.io/sevntu.checkstyle/"/>
+      <discovery label="Eclipse Update site" url="http://sevntu-checkstyle.github.io/sevntu.checkstyle/update-site/"/>
    </url>
 
-   <plugin id="eclipsecs-sevntu-plugin" download-size="0" install-size="0" version="1.44.0"
-      unpack="false"/>
+   <plugin id="eclipsecs-sevntu-plugin" download-size="0" install-size="0" version="1.44.0" unpack="false"/>
 
 </feature>

--- a/sevntu-checks/config/checkstyle_non_main_files_suppressions.xml
+++ b/sevntu-checks/config/checkstyle_non_main_files_suppressions.xml
@@ -6,11 +6,21 @@
 
 <suppressions>
   <!-- START of legacy code, all violations will be resolved -->
-  <suppress id="lineLength" files=".*"/>
+  <suppress id="lineLength" files="checkstyle-metadata.xml"/>
+  <suppress id="lineLength" files="checkstyle-metadata.properties"/>
+  <suppress id="lineLength" files="CheckstyleFormatterForEclipse.xml"/>
+  <suppress id="lineLength" files="category.xml"/>
+  <suppress id="lineLength" files="sevntu-checks.xml"/>
+  <suppress id="lineLength" files="InputJsr305AnnotationsCheckWithConstructor.java"/>
+  <suppress id="lineLength" files="InputTernaryPerExpressionCountCheck.java"/>
+  <suppress id="lineLength" files="InputConstructorWithoutParamsCheck.java"/>
   <!-- END of legacy code -->
 
   <!-- till https://issues.apache.org/jira/browse/MRELEASE-1008 -->
   <suppress id="lineLength" files="pom.xml"/>
+
+  <!-- Eclipse maintains this file and will be modified on deployment -->
+  <suppress id="lineLength" files="eclipsecs-sevntu-plugin-feature[\\/]feature.xml"/>
 
   <!-- other images that do not support newer curl commands until
        https://github.com/checkstyle/checkstyle/issues/12451 -->


### PR DESCRIPTION
Issue identified during deployment test.

````
diff --git a/eclipsecs-sevntu-plugin-feature/feature.xml b/eclipsecs-sevntu-plugin-feature/feature.xml
index 82b90d8..e718a9f 100644
--- a/eclipsecs-sevntu-plugin-feature/feature.xml
+++ b/eclipsecs-sevntu-plugin-feature/feature.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<feature id="com.github.sevntu.checkstyle.checks.feature"
-   label="Extension for eclipse-cs plugin with additional Checks" version="1.44.0">
+<feature id="com.github.sevntu.checkstyle.checks.feature" label="Extension for eclipse-cs plugin with additional Checks" version="1.44.1">
 
    <description url="http://sevntu-checkstyle.github.io/sevntu.checkstyle/">
       http://sevntu-checkstyle.github.io/sevntu.checkstyle/
@@ -17,15 +16,11 @@
    </license>
 
    <url>
-      <discovery label="Sources on GitHub"
-         url="https://github.com/sevntu-checkstyle/sevntu.checkstyle"/>
-      <discovery label="SevNTU checks site"
-         url="http://sevntu-checkstyle.github.io/sevntu.checkstyle/"/>
-      <discovery label="Eclipse Update site"
-         url="http://sevntu-checkstyle.github.io/sevntu.checkstyle/update-site/"/>
+      <discovery label="Sources on GitHub" url="https://github.com/sevntu-checkstyle/sevntu.checkstyle"/>
+      <discovery label="SevNTU checks site" url="http://sevntu-checkstyle.github.io/sevntu.checkstyle/"/>
+      <discovery label="Eclipse Update site" url="http://sevntu-checkstyle.github.io/sevntu.checkstyle/update-site/"/>
    </url>
 
-   <plugin id="eclipsecs-sevntu-plugin" download-size="0" install-size="0" version="1.44.0"
-      unpack="false"/>
+   <plugin id="eclipsecs-sevntu-plugin" download-size="0" install-size="0" version="1.44.1" unpack="false"/>
 
 </feature>
````