### PR TITLE
config: update maven-javadoc-plugin for sonar plugin to 3.4.1

### DIFF
--- a/sevntu-checkstyle-sonar-plugin/pom.xml
+++ b/sevntu-checkstyle-sonar-plugin/pom.xml
@@ -91,7 +91,12 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.10.4</version>
+        <version>3.4.1</version>
+        <configuration>
+          <!-- To allow build with latest JDK the source version must be explicitly set
+            See https://bugs.openjdk.java.net/browse/JDK-8212233 for details -->
+          <source>${java.version}</source>
+        </configuration>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -99,8 +104,8 @@
             <goals>
               <goal>jar</goal>
             </goals>
-          </execution>
-        </executions>
+         </execution>
+       </executions>
       </plugin>
 
       <plugin>


### PR DESCRIPTION
Same update as before.

I am not sure how I missed this before or how it passed on my local before when I was going through this.

I did another scan and did not find any other POMs with the old version.