### PR TITLE
infra: fix bump_license_year.yml not adding year to commit message

### DIFF
--- a/.github/workflows/bump_license_year.yml
+++ b/.github/workflows/bump_license_year.yml
@@ -7,7 +7,8 @@
 name: "Bump license year"
 on:
   schedule:
-    - cron: '0 20 1 1 *'
+    - cron: "0 0 1 1 *"
+  workflow_dispatch:
 permissions:
   contents: write
   pull-requests: write
@@ -17,21 +18,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout the latest code
-        uses: actions/checkout@v2
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+        uses: actions/checkout@v3
       - name: Set Current Year
-        id: CURRENT_YEAR
         run: |
-          echo "::set-output name=year::$(date +'%Y')"
+          echo "YEAR=$(date +'%Y')" >> "$GITHUB_ENV"
       - name: Modify Files
         run: |
-          ./.ci/bump-license-year.sh $(expr ${{ env.YEAR }} - 1) ${{ env.YEAR }} .
-        env:
-          YEAR: ${{ steps.CURRENT_YEAR.outputs.year }}
+          ./.ci/bump-license-year.sh $(("${{ env.YEAR }}" - 1)) ${{ env.YEAR }} .
       - name: Push commit
         run: |
-          git config --global user.name 'github-actions[bot]'
-          git config --global user.email 'github-actions[bot]@users.noreply.github.com'
+          git config user.name 'github-actions[bot]'
+          git config user.email 'github-actions[bot]@users.noreply.github.com'
           git commit -am "minor: Bump year to ${{ env.YEAR }}"
           git push


### PR DESCRIPTION
Source: https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-environment-variable

Proof of working: https://github.com/Vyom-Yadav/actions-test/commit/8ae3f4490e16f3bbba5f252f96b03e15198e8122