### PR TITLE
minor: make private class final with default constructor

### DIFF
--- a/sevntu-checks/src/main/java/com/github/sevntu/checkstyle/checks/coding/CustomDeclarationOrderCheck.java
+++ b/sevntu-checks/src/main/java/com/github/sevntu/checkstyle/checks/coding/CustomDeclarationOrderCheck.java
@@ -1326,7 +1326,7 @@ public class CustomDeclarationOrderCheck extends AbstractCheck {
     /**
      * Class to keep current position and collect getters, setters.
      */
-    private static class ClassDetail {
+    private static final class ClassDetail {
 
         /**
          * Current position in custom order declaration.


### PR DESCRIPTION
minor: make private class final with default constructor

This is part of https://github.com/checkstyle/checkstyle/pull/12737

According to the https://docs.oracle.com/javase/specs/jls/se17/html/jls-8.html#jls-8.8.9 The default constructor has the same access modifier as the class.
and according to the check https://checkstyle.org/config_design.html#FinalClass a class that has only private constructors and has no descendant classes is declared as final.