### PR TITLE
Pull #995: Point to files that were renamed to be kebab-case

### DIFF
--- a/eclipsecs-sevntu-plugin/pom.xml
+++ b/eclipsecs-sevntu-plugin/pom.xml
@@ -29,7 +29,7 @@
     <eclipsecs.version>10.4.0-SNAPSHOT</eclipsecs.version>
     <!-- verify time version -->
     <checkstyle.version>10.8.0</checkstyle.version>
-    <checkstyle.configLocation>https://raw.githubusercontent.com/checkstyle/checkstyle/checkstyle-${checkstyle.version}/config/checkstyle_checks.xml</checkstyle.configLocation>
+    <checkstyle.configLocation>https://raw.githubusercontent.com/checkstyle/checkstyle/checkstyle-${checkstyle.version}/config/checkstyle-checks.xml</checkstyle.configLocation>
     <checkstyle.header>https://raw.githubusercontent.com/checkstyle/checkstyle/master/config/java.header</checkstyle.header>
     <checkstyle.regexp.header>https://raw.githubusercontent.com/checkstyle/checkstyle/master/config/java-regexp.header</checkstyle.regexp.header>
     <antrun.plugin.version>3.1.0</antrun.plugin.version>

--- a/sevntu-checks/pom.xml
+++ b/sevntu-checks/pom.xml
@@ -19,9 +19,9 @@
     <checkstyle.eclipse-cs.version>10.4</checkstyle.eclipse-cs.version>
     <!-- verify time version -->
     <checkstyle.version>10.8.0</checkstyle.version>
-    <checkstyle.configLocation>https://raw.githubusercontent.com/checkstyle/checkstyle/checkstyle-${checkstyle.version}/config/checkstyle_checks.xml</checkstyle.configLocation>
-    <checkstyle.nonMain.configLocation>https://raw.githubusercontent.com/checkstyle/checkstyle/checkstyle-${checkstyle.version}/config/checkstyle_non_main_files_checks.xml</checkstyle.nonMain.configLocation>
-    <checkstyle.non-main-files-suppressions.file>config/checkstyle_non_main_files_suppressions.xml</checkstyle.non-main-files-suppressions.file>
+    <checkstyle.configLocation>https://raw.githubusercontent.com/checkstyle/checkstyle/checkstyle-${checkstyle.version}/config/checkstyle-checks.xml</checkstyle.configLocation>
+    <checkstyle.nonMain.configLocation>https://raw.githubusercontent.com/checkstyle/checkstyle/checkstyle-${checkstyle.version}/config/checkstyle-non-main-files-checks.xml</checkstyle.nonMain.configLocation>
+    <checkstyle.non-main-files-suppressions.file>config/checkstyle-non-main-files-suppressions.xml</checkstyle.non-main-files-suppressions.file>
     <checkstyle.header>https://raw.githubusercontent.com/checkstyle/checkstyle/master/config/java.header</checkstyle.header>
     <checkstyle.regexp.header>https://raw.githubusercontent.com/checkstyle/checkstyle/master/config/java-regexp.header</checkstyle.regexp.header>
     <antrun.plugin.version>3.1.0</antrun.plugin.version>

--- a/sevntu-checks/src/test/java/com/github/sevntu/checkstyle/internal/CheckUtil.java
+++ b/sevntu-checks/src/test/java/com/github/sevntu/checkstyle/internal/CheckUtil.java
@@ -48,11 +48,11 @@ public final class CheckUtil {
     }
 
     /**
-     * Gets a set of names of checkstyle's checks which are referenced in checkstyle_checks.xml.
+     * Gets a set of names of checkstyle's checks which are referenced in checkstyle-checks.xml.
      *
      * @param configFilePath
-     *            file path of checkstyle_checks.xml.
-     * @return names of checkstyle's checks which are referenced in checkstyle_checks.xml.
+     *            file path of checkstyle-checks.xml.
+     * @return names of checkstyle's checks which are referenced in checkstyle-checks.xml.
      */
     public static Set<String> getCheckStyleChecksReferencedInConfig(String configFilePath) {
         try {

--- a/sevntu-checks/src/test/java/com/github/sevntu/checkstyle/internal/CheckstyleRegressionTest.java
+++ b/sevntu-checks/src/test/java/com/github/sevntu/checkstyle/internal/CheckstyleRegressionTest.java
@@ -58,7 +58,7 @@ public class CheckstyleRegressionTest {
                 throw new IllegalStateException("Can't find project: " + project.getAbsolutePath());
             }
 
-            final File config = new File(project, "config/checkstyle_sevntu_checks.xml");
+            final File config = new File(project, "config/checkstyle-sevntu-checks.xml");
 
             if (!config.exists() || !config.isFile() || !config.canRead() || !config.canWrite()) {
                 throw new IllegalStateException("Can't read config: " + config.getAbsolutePath());
@@ -66,7 +66,7 @@ public class CheckstyleRegressionTest {
 
             System.out.println("Config Path: " + config.getCanonicalPath());
 
-            final File suppression = new File(project, "config/sevntu_suppressions.xml");
+            final File suppression = new File(project, "config/sevntu-suppressions.xml");
 
             if (!suppression.exists() || !suppression.isFile() || !suppression.canRead()
                     || !suppression.canWrite()) {

--- a/sevntu-checkstyle-sonar-plugin/pom.xml
+++ b/sevntu-checkstyle-sonar-plugin/pom.xml
@@ -180,7 +180,7 @@
               <goal>check</goal>
             </goals>
             <configuration>
-              <configLocation>https://raw.githubusercontent.com/checkstyle/checkstyle/checkstyle-${checkstyle.version}/config/checkstyle_checks.xml</configLocation>
+              <configLocation>https://raw.githubusercontent.com/checkstyle/checkstyle/checkstyle-${checkstyle.version}/config/checkstyle-checks.xml</configLocation>
               <failOnViolation>true</failOnViolation>
               <linkXRef>false</linkXRef>
               <propertiesLocation>checkstyle.properties</propertiesLocation>


### PR DESCRIPTION
Addresses https://github.com/sevntu-checkstyle/sevntu.checkstyle/pull/990#issuecomment-1454337832:
> It seems there is issues with the travis runs and it is actually failing. This PR just had a 10 minute time out run and it was not confirmed to be working. Another PR is failing.

In release 10.8.0 we renamed lots of config files to `kebab-case` and once the release was released, CI started failing because it was looking for the older names which used to be `snake_case`