### PR TITLE
Pull #1002: Suppress check for keeping spacing between workflow job steps

### DIFF
--- a/sevntu-checks/config/checkstyle-non-main-files-suppressions.xml
+++ b/sevntu-checks/config/checkstyle-non-main-files-suppressions.xml
@@ -29,4 +29,8 @@
 
   <!-- numberOfTestCasesInXpath does not apply to sevntu -->
   <suppress id="numberOfTestCasesInXpath" files=".*" />
+
+  <!-- Suppressed until https://github.com/checkstyle/checkstyle/pull/12900
+       is merged and 10.9.3 is released. -->
+  <suppress id="workflowJobStepSpacing" files=".*" />
 </suppressions>


### PR DESCRIPTION
We are implementing a check to enforce workflow job steps are spaced out in https://github.com/checkstyle/checkstyle/pull/12900

It is better to suppress it for now and implement it when PR gets merged and 10.9.3 is out.