### PR TITLE
Remove broken discovery sites

### DIFF
--- a/eclipsecs-sevntu-plugin-feature/feature.xml
+++ b/eclipsecs-sevntu-plugin-feature/feature.xml
@@ -1,5 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<feature id="com.github.sevntu.checkstyle.checks.feature" label="Extension for eclipse-cs plugin with additional Checks" version="1.44.1">
+<feature
+      id="com.github.sevntu.checkstyle.checks.feature"
+      label="Extension for eclipse-cs plugin with additional Checks"
+      version="1.44.1">
 
    <description url="http://sevntu-checkstyle.github.io/sevntu.checkstyle/">
       http://sevntu-checkstyle.github.io/sevntu.checkstyle/
@@ -15,11 +18,14 @@ Eclipse Public License - Version 1.0
    </license>
 
    <url>
-      <discovery label="Sources on GitHub" url="https://github.com/sevntu-checkstyle/sevntu.checkstyle"/>
-      <discovery label="SevNTU checks site" url="http://sevntu-checkstyle.github.io/sevntu.checkstyle/"/>
-      <discovery label="Eclipse Update site" url="http://sevntu-checkstyle.github.io/sevntu.checkstyle/update-site/"/>
+      <discovery label="Sevntu checkstyle update site" url="http://sevntu-checkstyle.github.io/sevntu.checkstyle/update-site/"/>
    </url>
 
-   <plugin id="eclipsecs-sevntu-plugin" download-size="0" install-size="0" version="1.44.1" unpack="false"/>
+   <plugin
+         id="eclipsecs-sevntu-plugin"
+         download-size="0"
+         install-size="0"
+         version="1.44.1"
+         unpack="false"/>
 
 </feature>


### PR DESCRIPTION
Discovery sites are used by the p2 installation system to discover additional update sites containing eclipse plugins and features. Adding arbitrary websites as discovery sites is an error and will lead to the Eclipse update mechanism trying to interpret those websites as update sites, failing, and then adding error messages in the log on each update.

