### PR TITLE
Pull #1018: Add suppression for missingMessageKeyAnnotation

### DIFF
--- a/sevntu-checks/config/suppressions.xml
+++ b/sevntu-checks/config/suppressions.xml
@@ -29,4 +29,7 @@
     <suppress id="MatchXPathBranchContains" files="[\\/]ConfusingConditionCheck.java"/>
     <suppress id="MatchXPathBranchContains" files="[\\/]StaticMethodCandidateCheck.java"/>
 
+    <!-- until https://github.com/sevntu-checkstyle/sevntu.checkstyle/issues/1017 -->
+    <suppress id="missingMessageKeyAnnotation" files=".*" />
+
 </suppressions>


### PR DESCRIPTION
Suppresses check that requires all message keys to have a `@MessageKey` annotation.

This blocks PR https://github.com/checkstyle/checkstyle/pull/13129

https://checkstyle.semaphoreci.com/jobs/d049f8c2-24e8-45bd-a7da-91bb44d9e113
```
[INFO] --- maven-antrun-plugin:3.1.0:run (ant-phase-verify) @ sevntu-checks ---
[INFO] Executing tasks
[INFO]      [echo] Checkstyle started (../../../config/checkstyle-checks.xml): 04/06/2023 01:21:58 PM
[INFO] [checkstyle] Running Checkstyle 10.12.1-SNAPSHOT on 141 files
[ERROR] [checkstyle] [ERROR] /home/stoyan/open-source/checkstyle/.ci-temp/sevntu.checkstyle/sevntu-checks/src/main/java/com/github/sevntu/checkstyle/checks/annotation/ForbidAnnotationCheck.java:50:5: Message keys should have @MessageKey annotation [missingMessageKeyAnnotation]
[ERROR] [checkstyle] [ERROR] /home/stoyan/open-source/checkstyle/.ci-temp/sevntu.checkstyle/sevntu-checks/src/main/java/com/github/sevntu/checkstyle/checks/annotation/ForbidAnnotationElementValueCheck.java:118:5: Message keys should have @MessageKey annotation [missingMessageKeyAnnotation]
[ERROR] [checkstyle] [ERROR] /home/stoyan/open-source/checkstyle/.ci-temp/sevntu.checkstyle/sevntu-checks/src/main/java/com/github/sevntu/checkstyle/checks/annotation/RequiredParameterForAnnotationCheck.java:106:5: Message keys should have @MessageKey annotation [missingMessageKeyAnnotation]
[ERROR] [checkstyle] [ERROR] /home/stoyan/open-source/checkstyle/.ci-temp/sevntu.checkstyle/sevntu-checks/src/main/java/com/github/sevntu/checkstyle/checks/coding/AvoidConstantAsFirstOperandInConditionCheck.java:65:5: Message keys should have @MessageKey annotation [missingMessageKeyAnnotation]
[ERROR] [checkstyle] [ERROR] /home/stoyan/open-source/checkstyle/.ci-temp/sevntu.checkstyle/sevntu-checks/src/main/java/com/github/sevntu/checkstyle/checks/coding/AvoidDefaultSerializableInInnerClassesCheck.java:45:5: Message keys should have @MessageKey annotation [missingMessageKeyAnnotation]
[ERROR] [checkstyle] [ERROR] /home/stoyan/open-source/checkstyle/.ci-temp/sevntu.checkstyle/sevntu-checks/src/main/java/com/github/sevntu/checkstyle/checks/coding/AvoidHidingCauseExceptionCheck.java:75:5: Message keys should have @MessageKey annotation [missingMessageKeyAnnotation]
[ERROR] [checkstyle] [ERROR] /home/stoyan/open-source/checkstyle/.ci-temp/sevntu.checkstyle/sevntu-checks/src/main/java/com/github/sevntu/checkstyle/checks/coding/AvoidModifiersForTypesCheck.java:158:5: Message keys should have @MessageKey annotation [missingMessageKeyAnnotation]
[ERROR] [checkstyle] [ERROR] /home/stoyan/open-source/checkstyle/.ci-temp/sevntu.checkstyle/sevntu-checks/src/main/java/com/github/sevntu/checkstyle/checks/coding/AvoidNotShortCircuitOperatorsForBooleanCheck.java:81:5: Message keys should have @MessageKey annotation [missingMessageKeyAnnotation]
[ERROR] [checkstyle] [ERROR] /home/stoyan/open-source/checkstyle/.ci-temp/sevntu.checkstyle/sevntu-checks/src/main/java/com/github/sevntu/checkstyle/checks/coding/ConfusingConditionCheck.java:70:5: Message keys should have @MessageKey annotation [missingMessageKeyAnnotation]
[ERROR] [checkstyle] [ERROR] /home/stoyan/open-source/checkstyle/.ci-temp/sevntu.checkstyle/sevntu-checks/src/main/java/com/github/sevntu/checkstyle/checks/coding/CustomDeclarationOrderCheck.java:164:5: Message keys should have @MessageKey annotation [missingMessageKeyAnnotation]
[ERROR] [checkstyle] [ERROR] /home/stoyan/open-source/checkstyle/.ci-temp/sevntu.checkstyle/sevntu-checks/src/main/java/com/github/sevntu/checkstyle/checks/coding/CustomDeclarationOrderCheck.java:170:5: Message keys should have @MessageKey annotation [missingMessageKeyAnnotation]
[ERROR] [checkstyle] [ERROR] /home/stoyan/open-source/checkstyle/.ci-temp/sevntu.checkstyle/sevntu-checks/src/main/java/com/github/sevntu/checkstyle/checks/coding/CustomDeclarationOrderCheck.java:176:5: Message keys should have @MessageKey annotation [missingMessageKeyAnnotation]
[ERROR] [checkstyle] [ERROR] /home/stoyan/open-source/checkstyle/.ci-temp/sevntu.checkstyle/sevntu-checks/src/main/java/com/github/sevntu/checkstyle/checks/coding/CustomDeclarationOrderCheck.java:182:5: Message keys should have @MessageKey annotation [missingMessageKeyAnnotation]
[ERROR] [checkstyle] [ERROR] /home/stoyan/open-source/checkstyle/.ci-temp/sevntu.checkstyle/sevntu-checks/src/main/java/com/github/sevntu/checkstyle/checks/coding/CustomDeclarationOrderCheck.java:188:5: Message keys should have @MessageKey annotation [missingMessageKeyAnnotation]
[ERROR] [checkstyle] [ERROR] /home/stoyan/open-source/checkstyle/.ci-temp/sevntu.checkstyle/sevntu-checks/src/main/java/com/github/sevntu/checkstyle/checks/coding/CustomDeclarationOrderCheck.java:194:5: Message keys should have @MessageKey annotation [missingMessageKeyAnnotation]
[ERROR] [checkstyle] [ERROR] /home/stoyan/open-source/checkstyle/.ci-temp/sevntu.checkstyle/sevntu-checks/src/main/java/com/github/sevntu/checkstyle/checks/coding/CustomDeclarationOrderCheck.java:200:5: Message keys should have @MessageKey annotation [missingMessageKeyAnnotation]
[ERROR] [checkstyle] [ERROR] /home/stoyan/open-source/checkstyle/.ci-temp/sevntu.checkstyle/sevntu-checks/src/main/java/com/github/sevntu/checkstyle/checks/coding/DiamondOperatorForVariableDefinitionCheck.java:50:5: Message keys should have @MessageKey annotation [missingMessageKeyAnnotation]
[ERROR] [checkstyle] [ERROR] /home/stoyan/open-source/checkstyle/.ci-temp/sevntu.checkstyle/sevntu-checks/src/main/java/com/github/sevntu/checkstyle/checks/coding/EitherLogOrThrowCheck.java:129:5: Message keys should have @MessageKey annotation [missingMessageKeyAnnotation]
[ERROR] [checkstyle] [ERROR] /home/stoyan/open-source/checkstyle/.ci-temp/sevntu.checkstyle/sevntu-checks/src/main/java/com/github/sevntu/checkstyle/checks/coding/EmptyPublicCtorInClassCheck.java:111:5: Message keys should have @MessageKey annotation [missingMessageKeyAnnotation]
[ERROR] [checkstyle] [ERROR] /home/stoyan/open-source/checkstyle/.ci-temp/sevntu.checkstyle/sevntu-checks/src/main/java/com/github/sevntu/checkstyle/checks/coding/FinalizeImplementationCheck.java:62:5: Message keys should have @MessageKey annotation [missingMessageKeyAnnotation]
[ERROR] [checkstyle] [ERROR] /home/stoyan/open-source/checkstyle/.ci-temp/sevntu.checkstyle/sevntu-checks/src/main/java/com/github/sevntu/checkstyle/checks/coding/FinalizeImplementationCheck.java:69:5: Message keys should have @MessageKey annotation [missingMessageKeyAnnotation]
[ERROR] [checkstyle] [ERROR] /home/stoyan/open-source/checkstyle/.ci-temp/sevntu.checkstyle/sevntu-checks/src/main/java/com/github/sevntu/checkstyle/checks/coding/FinalizeImplementationCheck.java:75:5: Message keys should have @MessageKey annotation [missingMessageKeyAnnotation]
[ERROR] [checkstyle] [ERROR] /home/stoyan/open-source/checkstyle/.ci-temp/sevntu.checkstyle/sevntu-checks/src/main/java/com/github/sevntu/checkstyle/checks/coding/FinalizeImplementationCheck.java:81:5: Message keys should have @MessageKey annotation [missingMessageKeyAnnotation]
[ERROR] [checkstyle] [ERROR] /home/stoyan/open-source/checkstyle/.ci-temp/sevntu.checkstyle/sevntu-checks/src/main/java/com/github/sevntu/checkstyle/checks/coding/ForbidCCommentsInMethodsCheck.java:43:5: Message keys should have @MessageKey annotation [missingMessageKeyAnnotation]
[ERROR] [checkstyle] [ERROR] /home/stoyan/open-source/checkstyle/.ci-temp/sevntu.checkstyle/sevntu-checks/src/main/java/com/github/sevntu/checkstyle/checks/coding/ForbidCertainImportsCheck.java:68:5: Message keys should have @MessageKey annotation [missingMessageKeyAnnotation]
[ERROR] [checkstyle] [ERROR] /home/stoyan/open-source/checkstyle/.ci-temp/sevntu.checkstyle/sevntu-checks/src/main/java/com/github/sevntu/checkstyle/checks/coding/ForbidCertainMethodCheck.java:91:5: Message keys should have @MessageKey annotation [missingMessageKeyAnnotation]
[ERROR] [checkstyle] [ERROR] /home/stoyan/open-source/checkstyle/.ci-temp/sevntu.checkstyle/sevntu-checks/src/main/java/com/github/sevntu/checkstyle/checks/coding/ForbidInstantiationCheck.java:54:5: Message keys should have @MessageKey annotation [missingMessageKeyAnnotation]
[ERROR] [checkstyle] [ERROR] /home/stoyan/open-source/checkstyle/.ci-temp/sevntu.checkstyle/sevntu-checks/src/main/java/com/github/sevntu/checkstyle/checks/coding/ForbidReturnInFinallyBlockCheck.java:47:5: Message keys should have @MessageKey annotation [missingMessageKeyAnnotation]
[ERROR] [checkstyle] [ERROR] /home/stoyan/open-source/checkstyle/.ci-temp/sevntu.checkstyle/sevntu-checks/src/main/java/com/github/sevntu/checkstyle/checks/coding/ForbidThrowAnonymousExceptionsCheck.java:69:5: Message keys should have @MessageKey annotation [missingMessageKeyAnnotation]
[ERROR] [checkstyle] [ERROR] /home/stoyan/open-source/checkstyle/.ci-temp/sevntu.checkstyle/sevntu-checks/src/main/java/com/github/sevntu/checkstyle/checks/coding/IllegalCatchExtendedCheck.java:43:5: Message keys should have @MessageKey annotation [missingMessageKeyAnnotation]
[ERROR] [checkstyle] [ERROR] /home/stoyan/open-source/checkstyle/.ci-temp/sevntu.checkstyle/sevntu-checks/src/main/java/com/github/sevntu/checkstyle/checks/coding/Jsr305AnnotationsCheck.java:174:5: Message keys should have @MessageKey annotation [missingMessageKeyAnnotation]
[ERROR] [checkstyle] [ERROR] /home/stoyan/open-source/checkstyle/.ci-temp/sevntu.checkstyle/sevntu-checks/src/main/java/com/github/sevntu/checkstyle/checks/coding/Jsr305AnnotationsCheck.java:178:5: Message keys should have @MessageKey annotation [missingMessageKeyAnnotation]
[ERROR] [checkstyle] [ERROR] /home/stoyan/open-source/checkstyle/.ci-temp/sevntu.checkstyle/sevntu-checks/src/main/java/com/github/sevntu/checkstyle/checks/coding/Jsr305AnnotationsCheck.java:182:5: Message keys should have @MessageKey annotation [missingMessageKeyAnnotation]
[ERROR] [checkstyle] [ERROR] /home/stoyan/open-source/checkstyle/.ci-temp/sevntu.checkstyle/sevntu-checks/src/main/java/com/github/sevntu/checkstyle/checks/coding/Jsr305AnnotationsCheck.java:186:5: Message keys should have @MessageKey annotation [missingMessageKeyAnnotation]
[ERROR] [checkstyle] [ERROR] /home/stoyan/open-source/checkstyle/.ci-temp/sevntu.checkstyle/sevntu-checks/src/main/java/com/github/sevntu/checkstyle/checks/coding/Jsr305AnnotationsCheck.java:190:5: Message keys should have @MessageKey annotation [missingMessageKeyAnnotation]
[ERROR] [checkstyle] [ERROR] /home/stoyan/open-source/checkstyle/.ci-temp/sevntu.checkstyle/sevntu-checks/src/main/java/com/github/sevntu/checkstyle/checks/coding/Jsr305AnnotationsCheck.java:194:5: Message keys should have @MessageKey annotation [missingMessageKeyAnnotation]
[ERROR] [checkstyle] [ERROR] /home/stoyan/open-source/checkstyle/.ci-temp/sevntu.checkstyle/sevntu-checks/src/main/java/com/github/sevntu/checkstyle/checks/coding/Jsr305AnnotationsCheck.java:198:5: Message keys should have @MessageKey annotation [missingMessageKeyAnnotation]
[ERROR] [checkstyle] [ERROR] /home/stoyan/open-source/checkstyle/.ci-temp/sevntu.checkstyle/sevntu-checks/src/main/java/com/github/sevntu/checkstyle/checks/coding/Jsr305AnnotationsCheck.java:202:5: Message keys should have @MessageKey annotation [missingMessageKeyAnnotation]
[ERROR] [checkstyle] [ERROR] /home/stoyan/open-source/checkstyle/.ci-temp/sevntu.checkstyle/sevntu-checks/src/main/java/com/github/sevntu/checkstyle/checks/coding/Jsr305AnnotationsCheck.java:206:5: Message keys should have @MessageKey annotation [missingMessageKeyAnnotation]
[ERROR] [checkstyle] [ERROR] /home/stoyan/open-source/checkstyle/.ci-temp/sevntu.checkstyle/sevntu-checks/src/main/java/com/github/sevntu/checkstyle/checks/coding/Jsr305AnnotationsCheck.java:210:5: Message keys should have @MessageKey annotation [missingMessageKeyAnnotation]
[ERROR] [checkstyle] [ERROR] /home/stoyan/open-source/checkstyle/.ci-temp/sevntu.checkstyle/sevntu-checks/src/main/java/com/github/sevntu/checkstyle/checks/coding/Jsr305AnnotationsCheck.java:214:5: Message keys should have @MessageKey annotation [missingMessageKeyAnnotation]
[ERROR] [checkstyle] [ERROR] /home/stoyan/open-source/checkstyle/.ci-temp/sevntu.checkstyle/sevntu-checks/src/main/java/com/github/sevntu/checkstyle/checks/coding/Jsr305AnnotationsCheck.java:218:5: Message keys should have @MessageKey annotation [missingMessageKeyAnnotation]
[ERROR] [checkstyle] [ERROR] /home/stoyan/open-source/checkstyle/.ci-temp/sevntu.checkstyle/sevntu-checks/src/main/java/com/github/sevntu/checkstyle/checks/coding/Jsr305AnnotationsCheck.java:222:5: Message keys should have @MessageKey annotation [missingMessageKeyAnnotation]
[ERROR] [checkstyle] [ERROR] /home/stoyan/open-source/checkstyle/.ci-temp/sevntu.checkstyle/sevntu-checks/src/main/java/com/github/sevntu/checkstyle/checks/coding/Jsr305AnnotationsCheck.java:226:5: Message keys should have @MessageKey annotation [missingMessageKeyAnnotation]
[ERROR] [checkstyle] [ERROR] /home/stoyan/open-source/checkstyle/.ci-temp/sevntu.checkstyle/sevntu-checks/src/main/java/com/github/sevntu/checkstyle/checks/coding/Jsr305AnnotationsCheck.java:230:5: Message keys should have @MessageKey annotation [missingMessageKeyAnnotation]
[ERROR] [checkstyle] [ERROR] /home/stoyan/open-source/checkstyle/.ci-temp/sevntu.checkstyle/sevntu-checks/src/main/java/com/github/sevntu/checkstyle/checks/coding/Jsr305AnnotationsCheck.java:234:5: Message keys should have @MessageKey annotation [missingMessageKeyAnnotation]
[ERROR] [checkstyle] [ERROR] /home/stoyan/open-source/checkstyle/.ci-temp/sevntu.checkstyle/sevntu-checks/src/main/java/com/github/sevntu/checkstyle/checks/coding/Jsr305AnnotationsCheck.java:238:5: Message keys should have @MessageKey annotation [missingMessageKeyAnnotation]
[ERROR] [checkstyle] [ERROR] /home/stoyan/open-source/checkstyle/.ci-temp/sevntu.checkstyle/sevntu-checks/src/main/java/com/github/sevntu/checkstyle/checks/coding/Jsr305AnnotationsCheck.java:242:5: Message keys should have @MessageKey annotation [missingMessageKeyAnnotation]
[ERROR] [checkstyle] [ERROR] /home/stoyan/open-source/checkstyle/.ci-temp/sevntu.checkstyle/sevntu-checks/src/main/java/com/github/sevntu/checkstyle/checks/coding/Jsr305AnnotationsCheck.java:246:5: Message keys should have @MessageKey annotation [missingMessageKeyAnnotation]
[ERROR] [checkstyle] [ERROR] /home/stoyan/open-source/checkstyle/.ci-temp/sevntu.checkstyle/sevntu-checks/src/main/java/com/github/sevntu/checkstyle/checks/coding/Jsr305AnnotationsCheck.java:250:5: Message keys should have @MessageKey annotation [missingMessageKeyAnnotation]
[ERROR] [checkstyle] [ERROR] /home/stoyan/open-source/checkstyle/.ci-temp/sevntu.checkstyle/sevntu-checks/src/main/java/com/github/sevntu/checkstyle/checks/coding/Jsr305AnnotationsCheck.java:254:5: Message keys should have @MessageKey annotation [missingMessageKeyAnnotation]
[ERROR] [checkstyle] [ERROR] /home/stoyan/open-source/checkstyle/.ci-temp/sevntu.checkstyle/sevntu-checks/src/main/java/com/github/sevntu/checkstyle/checks/coding/Jsr305AnnotationsCheck.java:258:5: Message keys should have @MessageKey annotation [missingMessageKeyAnnotation]
[ERROR] [checkstyle] [ERROR] /home/stoyan/open-source/checkstyle/.ci-temp/sevntu.checkstyle/sevntu-checks/src/main/java/com/github/sevntu/checkstyle/checks/coding/Jsr305AnnotationsCheck.java:262:5: Message keys should have @MessageKey annotation [missingMessageKeyAnnotation]
[ERROR] [checkstyle] [ERROR] /home/stoyan/open-source/checkstyle/.ci-temp/sevntu.checkstyle/sevntu-checks/src/main/java/com/github/sevntu/checkstyle/checks/coding/Jsr305AnnotationsCheck.java:266:5: Message keys should have @MessageKey annotation [missingMessageKeyAnnotation]
[ERROR] [checkstyle] [ERROR] /home/stoyan/open-source/checkstyle/.ci-temp/sevntu.checkstyle/sevntu-checks/src/main/java/com/github/sevntu/checkstyle/checks/coding/Jsr305AnnotationsCheck.java:270:5: Message keys should have @MessageKey annotation [missingMessageKeyAnnotation]
[ERROR] [checkstyle] [ERROR] /home/stoyan/open-source/checkstyle/.ci-temp/sevntu.checkstyle/sevntu-checks/src/main/java/com/github/sevntu/checkstyle/checks/coding/LogicConditionNeedOptimizationCheck.java:45:5: Message keys should have @MessageKey annotation [missingMessageKeyAnnotation]
[ERROR] [checkstyle] [ERROR] /home/stoyan/open-source/checkstyle/.ci-temp/sevntu.checkstyle/sevntu-checks/src/main/java/com/github/sevntu/checkstyle/checks/coding/MapIterationInForEachLoopCheck.java:135:5: Message keys should have @MessageKey annotation [missingMessageKeyAnnotation]
[ERROR] [checkstyle] [ERROR] /home/stoyan/open-source/checkstyle/.ci-temp/sevntu.checkstyle/sevntu-checks/src/main/java/com/github/sevntu/checkstyle/checks/coding/MapIterationInForEachLoopCheck.java:141:5: Message keys should have @MessageKey annotation [missingMessageKeyAnnotation]
[ERROR] [checkstyle] [ERROR] /home/stoyan/open-source/checkstyle/.ci-temp/sevntu.checkstyle/sevntu-checks/src/main/java/com/github/sevntu/checkstyle/checks/coding/MapIterationInForEachLoopCheck.java:147:5: Message keys should have @MessageKey annotation [missingMessageKeyAnnotation]
[ERROR] [checkstyle] [ERROR] /home/stoyan/open-source/checkstyle/.ci-temp/sevntu.checkstyle/sevntu-checks/src/main/java/com/github/sevntu/checkstyle/checks/coding/MoveVariableInsideIfCheck.java:123:5: Message keys should have @MessageKey annotation [missingMessageKeyAnnotation]
[ERROR] [checkstyle] [ERROR] /home/stoyan/open-source/checkstyle/.ci-temp/sevntu.checkstyle/sevntu-checks/src/main/java/com/github/sevntu/checkstyle/checks/coding/MultipleStringLiteralsExtendedCheck.java:47:5: Message keys should have @MessageKey annotation [missingMessageKeyAnnotation]
[ERROR] [checkstyle] [ERROR] /home/stoyan/open-source/checkstyle/.ci-temp/sevntu.checkstyle/sevntu-checks/src/main/java/com/github/sevntu/checkstyle/checks/coding/MultipleVariableDeclarationsExtendedCheck.java:52:5: Message keys should have @MessageKey annotation [missingMessageKeyAnnotation]
[ERROR] [checkstyle] [ERROR] /home/stoyan/open-source/checkstyle/.ci-temp/sevntu.checkstyle/sevntu-checks/src/main/java/com/github/sevntu/checkstyle/checks/coding/MultipleVariableDeclarationsExtendedCheck.java:57:5: Message keys should have @MessageKey annotation [missingMessageKeyAnnotation]
[ERROR] [checkstyle] [ERROR] /home/stoyan/open-source/checkstyle/.ci-temp/sevntu.checkstyle/sevntu-checks/src/main/java/com/github/sevntu/checkstyle/checks/coding/NameConventionForJunit4TestClassesCheck.java:118:5: Message keys should have @MessageKey annotation [missingMessageKeyAnnotation]
[ERROR] [checkstyle] [ERROR] /home/stoyan/open-source/checkstyle/.ci-temp/sevntu.checkstyle/sevntu-checks/src/main/java/com/github/sevntu/checkstyle/checks/coding/NoNullForCollectionReturnCheck.java:60:5: Message keys should have @MessageKey annotation [missingMessageKeyAnnotation]
[ERROR] [checkstyle] [ERROR] /home/stoyan/open-source/checkstyle/.ci-temp/sevntu.checkstyle/sevntu-checks/src/main/java/com/github/sevntu/checkstyle/checks/coding/NumericLiteralNeedsUnderscoreCheck.java:150:5: Message keys should have @MessageKey annotation [missingMessageKeyAnnotation]
[ERROR] [checkstyle] [ERROR] /home/stoyan/open-source/checkstyle/.ci-temp/sevntu.checkstyle/sevntu-checks/src/main/java/com/github/sevntu/checkstyle/checks/coding/OverridableMethodInConstructorCheck.java:138:5: Message keys should have @MessageKey annotation [missingMessageKeyAnnotation]
[ERROR] [checkstyle] [ERROR] /home/stoyan/open-source/checkstyle/.ci-temp/sevntu.checkstyle/sevntu-checks/src/main/java/com/github/sevntu/checkstyle/checks/coding/OverridableMethodInConstructorCheck.java:144:5: Message keys should have @MessageKey annotation [missingMessageKeyAnnotation]
[ERROR] [checkstyle] [ERROR] /home/stoyan/open-source/checkstyle/.ci-temp/sevntu.checkstyle/sevntu-checks/src/main/java/com/github/sevntu/checkstyle/checks/coding/PreferMethodReferenceCheck.java:141:5: Message keys should have @MessageKey annotation [missingMessageKeyAnnotation]
[ERROR] [checkstyle] [ERROR] /home/stoyan/open-source/checkstyle/.ci-temp/sevntu.checkstyle/sevntu-checks/src/main/java/com/github/sevntu/checkstyle/checks/coding/RedundantReturnCheck.java:88:5: Message keys should have @MessageKey annotation [missingMessageKeyAnnotation]
[ERROR] [checkstyle] [ERROR] /home/stoyan/open-source/checkstyle/.ci-temp/sevntu.checkstyle/sevntu-checks/src/main/java/com/github/sevntu/checkstyle/checks/coding/RequireFailForTryCatchInJunitCheck.java:109:5: Message keys should have @MessageKey annotation [missingMessageKeyAnnotation]
[ERROR] [checkstyle] [ERROR] /home/stoyan/open-source/checkstyle/.ci-temp/sevntu.checkstyle/sevntu-checks/src/main/java/com/github/sevntu/checkstyle/checks/coding/ReturnBooleanFromTernaryCheck.java:40:5: Message keys should have @MessageKey annotation [missingMessageKeyAnnotation]
[ERROR] [checkstyle] [ERROR] /home/stoyan/open-source/checkstyle/.ci-temp/sevntu.checkstyle/sevntu-checks/src/main/java/com/github/sevntu/checkstyle/checks/coding/ReturnCountExtendedCheck.java:77:5: Message keys should have @MessageKey annotation [missingMessageKeyAnnotation]
[ERROR] [checkstyle] [ERROR] /home/stoyan/open-source/checkstyle/.ci-temp/sevntu.checkstyle/sevntu-checks/src/main/java/com/github/sevntu/checkstyle/checks/coding/ReturnCountExtendedCheck.java:84:5: Message keys should have @MessageKey annotation [missingMessageKeyAnnotation]
[ERROR] [checkstyle] [ERROR] /home/stoyan/open-source/checkstyle/.ci-temp/sevntu.checkstyle/sevntu-checks/src/main/java/com/github/sevntu/checkstyle/checks/coding/ReturnCountExtendedCheck.java:91:5: Message keys should have @MessageKey annotation [missingMessageKeyAnnotation]
[ERROR] [checkstyle] [ERROR] /home/stoyan/open-source/checkstyle/.ci-temp/sevntu.checkstyle/sevntu-checks/src/main/java/com/github/sevntu/checkstyle/checks/coding/ReturnNullInsteadOfBooleanCheck.java:44:5: Message keys should have @MessageKey annotation [missingMessageKeyAnnotation]
[ERROR] [checkstyle] [ERROR] /home/stoyan/open-source/checkstyle/.ci-temp/sevntu.checkstyle/sevntu-checks/src/main/java/com/github/sevntu/checkstyle/checks/coding/SimpleAccessorNameNotationCheck.java:59:5: Message keys should have @MessageKey annotation [missingMessageKeyAnnotation]
[ERROR] [checkstyle] [ERROR] /home/stoyan/open-source/checkstyle/.ci-temp/sevntu.checkstyle/sevntu-checks/src/main/java/com/github/sevntu/checkstyle/checks/coding/SimpleAccessorNameNotationCheck.java:64:5: Message keys should have @MessageKey annotation [missingMessageKeyAnnotation]
[ERROR] [checkstyle] [ERROR] /home/stoyan/open-source/checkstyle/.ci-temp/sevntu.checkstyle/sevntu-checks/src/main/java/com/github/sevntu/checkstyle/checks/coding/SingleBreakOrContinueCheck.java:119:5: Message keys should have @MessageKey annotation [missingMessageKeyAnnotation]
[ERROR] [checkstyle] [ERROR] /home/stoyan/open-source/checkstyle/.ci-temp/sevntu.checkstyle/sevntu-checks/src/main/java/com/github/sevntu/checkstyle/checks/coding/TernaryPerExpressionCountCheck.java:100:5: Message keys should have @MessageKey annotation [missingMessageKeyAnnotation]
[ERROR] [checkstyle] [ERROR] /home/stoyan/open-source/checkstyle/.ci-temp/sevntu.checkstyle/sevntu-checks/src/main/java/com/github/sevntu/checkstyle/checks/coding/UnnecessaryParenthesesExtendedCheck.java:58:5: Message keys should have @MessageKey annotation [missingMessageKeyAnnotation]
[ERROR] [checkstyle] [ERROR] /home/stoyan/open-source/checkstyle/.ci-temp/sevntu.checkstyle/sevntu-checks/src/main/java/com/github/sevntu/checkstyle/checks/coding/UnnecessaryParenthesesExtendedCheck.java:60:5: Message keys should have @MessageKey annotation [missingMessageKeyAnnotation]
[ERROR] [checkstyle] [ERROR] /home/stoyan/open-source/checkstyle/.ci-temp/sevntu.checkstyle/sevntu-checks/src/main/java/com/github/sevntu/checkstyle/checks/coding/UnnecessaryParenthesesExtendedCheck.java:62:5: Message keys should have @MessageKey annotation [missingMessageKeyAnnotation]
[ERROR] [checkstyle] [ERROR] /home/stoyan/open-source/checkstyle/.ci-temp/sevntu.checkstyle/sevntu-checks/src/main/java/com/github/sevntu/checkstyle/checks/coding/UnnecessaryParenthesesExtendedCheck.java:64:5: Message keys should have @MessageKey annotation [missingMessageKeyAnnotation]
[ERROR] [checkstyle] [ERROR] /home/stoyan/open-source/checkstyle/.ci-temp/sevntu.checkstyle/sevntu-checks/src/main/java/com/github/sevntu/checkstyle/checks/coding/UnnecessaryParenthesesExtendedCheck.java:66:5: Message keys should have @MessageKey annotation [missingMessageKeyAnnotation]
[ERROR] [checkstyle] [ERROR] /home/stoyan/open-source/checkstyle/.ci-temp/sevntu.checkstyle/sevntu-checks/src/main/java/com/github/sevntu/checkstyle/checks/coding/UnnecessaryParenthesesExtendedCheck.java:68:5: Message keys should have @MessageKey annotation [missingMessageKeyAnnotation]
[ERROR] [checkstyle] [ERROR] /home/stoyan/open-source/checkstyle/.ci-temp/sevntu.checkstyle/sevntu-checks/src/main/java/com/github/sevntu/checkstyle/checks/coding/UselessSingleCatchCheck.java:48:5: Message keys should have @MessageKey annotation [missingMessageKeyAnnotation]
[ERROR] [checkstyle] [ERROR] /home/stoyan/open-source/checkstyle/.ci-temp/sevntu.checkstyle/sevntu-checks/src/main/java/com/github/sevntu/checkstyle/checks/coding/UselessSuperCtorCallCheck.java:151:5: Message keys should have @MessageKey annotation [missingMessageKeyAnnotation]
[ERROR] [checkstyle] [ERROR] /home/stoyan/open-source/checkstyle/.ci-temp/sevntu.checkstyle/sevntu-checks/src/main/java/com/github/sevntu/checkstyle/checks/coding/UselessSuperCtorCallCheck.java:157:5: Message keys should have @MessageKey annotation [missingMessageKeyAnnotation]
[ERROR] [checkstyle] [ERROR] /home/stoyan/open-source/checkstyle/.ci-temp/sevntu.checkstyle/sevntu-checks/src/main/java/com/github/sevntu/checkstyle/checks/coding/WhitespaceBeforeArrayInitializerCheck.java:65:5: Message keys should have @MessageKey annotation [missingMessageKeyAnnotation]
[ERROR] [checkstyle] [ERROR] /home/stoyan/open-source/checkstyle/.ci-temp/sevntu.checkstyle/sevntu-checks/src/main/java/com/github/sevntu/checkstyle/checks/design/AvoidConditionInversionCheck.java:93:5: Message keys should have @MessageKey annotation [missingMessageKeyAnnotation]
[ERROR] [checkstyle] [ERROR] /home/stoyan/open-source/checkstyle/.ci-temp/sevntu.checkstyle/sevntu-checks/src/main/java/com/github/sevntu/checkstyle/checks/design/CauseParameterInExceptionCheck.java:58:5: Message keys should have @MessageKey annotation [missingMessageKeyAnnotation]
[ERROR] [checkstyle] [ERROR] /home/stoyan/open-source/checkstyle/.ci-temp/sevntu.checkstyle/sevntu-checks/src/main/java/com/github/sevntu/checkstyle/checks/design/CheckstyleTestMakeupCheck.java:78:5: Message keys should have @MessageKey annotation [missingMessageKeyAnnotation]
[ERROR] [checkstyle] [ERROR] /home/stoyan/open-source/checkstyle/.ci-temp/sevntu.checkstyle/sevntu-checks/src/main/java/com/github/sevntu/checkstyle/checks/design/CheckstyleTestMakeupCheck.java:80:5: Message keys should have @MessageKey annotation [missingMessageKeyAnnotation]
[ERROR] [checkstyle] [ERROR] /home/stoyan/open-source/checkstyle/.ci-temp/sevntu.checkstyle/sevntu-checks/src/main/java/com/github/sevntu/checkstyle/checks/design/CheckstyleTestMakeupCheck.java:82:5: Message keys should have @MessageKey annotation [missingMessageKeyAnnotation]
[ERROR] [checkstyle] [ERROR] /home/stoyan/open-source/checkstyle/.ci-temp/sevntu.checkstyle/sevntu-checks/src/main/java/com/github/sevntu/checkstyle/checks/design/CheckstyleTestMakeupCheck.java:85:5: Message keys should have @MessageKey annotation [missingMessageKeyAnnotation]
[ERROR] [checkstyle] [ERROR] /home/stoyan/open-source/checkstyle/.ci-temp/sevntu.checkstyle/sevntu-checks/src/main/java/com/github/sevntu/checkstyle/checks/design/CheckstyleTestMakeupCheck.java:87:5: Message keys should have @MessageKey annotation [missingMessageKeyAnnotation]
[ERROR] [checkstyle] [ERROR] /home/stoyan/open-source/checkstyle/.ci-temp/sevntu.checkstyle/sevntu-checks/src/main/java/com/github/sevntu/checkstyle/checks/design/ChildBlockLengthCheck.java:57:5: Message keys should have @MessageKey annotation [missingMessageKeyAnnotation]
[ERROR] [checkstyle] [ERROR] /home/stoyan/open-source/checkstyle/.ci-temp/sevntu.checkstyle/sevntu-checks/src/main/java/com/github/sevntu/checkstyle/checks/design/ConstructorWithoutParamsCheck.java:94:5: Message keys should have @MessageKey annotation [missingMessageKeyAnnotation]
[ERROR] [checkstyle] [ERROR] /home/stoyan/open-source/checkstyle/.ci-temp/sevntu.checkstyle/sevntu-checks/src/main/java/com/github/sevntu/checkstyle/checks/design/ForbidWildcardAsReturnTypeCheck.java:75:5: Message keys should have @MessageKey annotation [missingMessageKeyAnnotation]
[ERROR] [checkstyle] [ERROR] /home/stoyan/open-source/checkstyle/.ci-temp/sevntu.checkstyle/sevntu-checks/src/main/java/com/github/sevntu/checkstyle/checks/design/HideUtilityClassConstructorCheck.java:43:5: Message keys should have @MessageKey annotation [missingMessageKeyAnnotation]
[ERROR] [checkstyle] [ERROR] /home/stoyan/open-source/checkstyle/.ci-temp/sevntu.checkstyle/sevntu-checks/src/main/java/com/github/sevntu/checkstyle/checks/design/InnerClassCheck.java:40:5: Message keys should have @MessageKey annotation [missingMessageKeyAnnotation]
[ERROR] [checkstyle] [ERROR] /home/stoyan/open-source/checkstyle/.ci-temp/sevntu.checkstyle/sevntu-checks/src/main/java/com/github/sevntu/checkstyle/checks/design/NestedSwitchCheck.java:62:5: Message keys should have @MessageKey annotation [missingMessageKeyAnnotation]
[ERROR] [checkstyle] [ERROR] /home/stoyan/open-source/checkstyle/.ci-temp/sevntu.checkstyle/sevntu-checks/src/main/java/com/github/sevntu/checkstyle/checks/design/NoMainMethodInAbstractClassCheck.java:41:5: Message keys should have @MessageKey annotation [missingMessageKeyAnnotation]
[ERROR] [checkstyle] [ERROR] /home/stoyan/open-source/checkstyle/.ci-temp/sevntu.checkstyle/sevntu-checks/src/main/java/com/github/sevntu/checkstyle/checks/design/PublicReferenceToPrivateTypeCheck.java:81:5: Message keys should have @MessageKey annotation [missingMessageKeyAnnotation]
[ERROR] [checkstyle] [ERROR] /home/stoyan/open-source/checkstyle/.ci-temp/sevntu.checkstyle/sevntu-checks/src/main/java/com/github/sevntu/checkstyle/checks/design/StaticMethodCandidateCheck.java:71:5: Message keys should have @MessageKey annotation [missingMessageKeyAnnotation]
[ERROR] [checkstyle] [ERROR] /home/stoyan/open-source/checkstyle/.ci-temp/sevntu.checkstyle/sevntu-checks/src/main/java/com/github/sevntu/checkstyle/checks/naming/UniformEnumConstantNameCheck.java:85:5: Message keys should have @MessageKey annotation [missingMessageKeyAnnotation]
[ERROR] [checkstyle] [ERROR] /home/stoyan/open-source/checkstyle/.ci-temp/sevntu.checkstyle/sevntu-checks/src/main/java/com/github/sevntu/checkstyle/checks/naming/UniformEnumConstantNameCheck.java:90:5: Message keys should have @MessageKey annotation [missingMessageKeyAnnotation]
[ERROR] [checkstyle] [ERROR] /home/stoyan/open-source/checkstyle/.ci-temp/sevntu.checkstyle/sevntu-checks/src/main/java/com/github/sevntu/checkstyle/checks/sizes/LineLengthExtendedCheck.java:94:5: Message keys should have @MessageKey annotation [missingMessageKeyAnnotation]
[INFO]      [echo] Checkstyle finished (../../../config/checkstyle-checks.xml) : 04/06/2023 01:22:17 PM
[INFO]      [echo] Checkstyle started (../../../config/checkstyle-non-main-files-checks.xml): 04/06/2023 01:21:58 PM
[INFO] [checkstyle] Running Checkstyle 10.12.1-SNAPSHOT on 314 files
[INFO]      [echo] Checkstyle finished (../../../config/checkstyle-non-main-files-checks.xml): 04/06/2023 01:22:17 PM
[INFO]      [echo]     
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
```

Opened an issue to deal with this https://github.com/sevntu-checkstyle/sevntu.checkstyle/issues/1017