### PR TITLE
Pull #1023: Add suppression for settersHaveSinceTag

### DIFF
--- a/sevntu-checks/config/suppressions.xml
+++ b/sevntu-checks/config/suppressions.xml
@@ -23,6 +23,9 @@
     <!-- this is allowed and legacy use case -->
     <suppress id="noUsageOfGetFileContentsMethod" files="TernaryPerExpressionCountCheck.java"/>
 
+    <!-- until https://github.com/sevntu-checkstyle/sevntu.checkstyle/issues/1022 -->
+    <suppress id="settersHaveSinceTag" files=".*" />
+
     <!-- until https://github.com/sevntu-checkstyle/sevntu.checkstyle/issues/669 -->
     <suppress id="MatchXPathBranchContains" files="[\\/]LogicConditionNeedOptimizationCheck.java"/>
     <suppress id="MatchXPathBranchContains" files="[\\/]NoNullForCollectionReturnCheck.java"/>


### PR DESCRIPTION
Related to #1022 

---
Adds suppression for settersHaveSinceTag because the pipeline at https://github.com/checkstyle/checkstyle/pull/13455 is failing
https://checkstyle.semaphoreci.com/jobs/b80149c4-f163-4908-a4ab-98a19bcb625e#L902
```
[ERROR] [checkstyle] [ERROR] /home/semaphore/checkstyle/.ci-temp/sevntu.checkstyle/sevntu-checks/src/main/java/com/github/sevntu/checkstyle/checks/sizes/LineLengthExtendedCheck.java:163:5: All property setters of a module should contain a @since tag. [settersHaveSinceTag] 01:13
[ERROR] [checkstyle] [ERROR] /home/semaphore/checkstyle/.ci-temp/sevntu.checkstyle/sevntu-checks/src/main/java/com/github/sevntu/checkstyle/checks/sizes/LineLengthExtendedCheck.java:255:5: All property setters of a module should contain a @since tag. [settersHaveSinceTag] 01:13
[ERROR] [checkstyle] [ERROR] /home/semaphore/checkstyle/.ci-temp/sevntu.checkstyle/sevntu-checks/src/main/java/com/github/sevntu/checkstyle/checks/sizes/LineLengthExtendedCheck.java:267:5: All property setters of a module should contain a @since tag. [settersHaveSinceTag]
```