### PR TITLE
infra: Update Checkstyle versions in pom.xml to 12.2.0

### DIFF
--- a/sevntu-checks/pom.xml
+++ b/sevntu-checks/pom.xml
@@ -16,9 +16,9 @@
   <properties>
     <project.build.sourceEncoding>iso-8859-1</project.build.sourceEncoding>
     <!-- It is compile dependency to checkstyle, this version has to be the same as eclipse-cs depends on -->
-    <checkstyle.eclipse-cs.version>12.1.2</checkstyle.eclipse-cs.version>
+    <checkstyle.eclipse-cs.version>12.2.0</checkstyle.eclipse-cs.version>
     <!-- verify time version -->
-    <checkstyle.version>12.1.2</checkstyle.version>
+    <checkstyle.version>12.2.0</checkstyle.version>
     <checkstyle.configLocation>https://raw.githubusercontent.com/checkstyle/checkstyle/checkstyle-${checkstyle.version}/config/checkstyle-checks.xml</checkstyle.configLocation>
     <checkstyle.nonMain.configLocation>https://raw.githubusercontent.com/checkstyle/checkstyle/checkstyle-${checkstyle.version}/config/checkstyle-non-main-files-checks.xml</checkstyle.nonMain.configLocation>
     <checkstyle.non-main-files-suppressions.file>config/checkstyle-non-main-files-suppressions.xml</checkstyle.non-main-files-suppressions.file>


### PR DESCRIPTION
to fix https://github.com/sevntu-checkstyle/sevntu.checkstyle/actions/runs/19804722825/job/56737387227#step:6:185

`Error:  Failed to execute goal org.apache.maven.plugins:maven-site-plugin:3.12.1:site (default-site) on project sample: Error generating maven-checkstyle-plugin:3.1.1:checkstyle report: Failed during checkstyle configuration: Exception was thrown while processing /home/runner/work/sevntu.checkstyle/sevntu.checkstyle/sevntu-checks/.ci-temp/contribution/checkstyle-tester/src/main/java/checkstyle/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/imports/redundantimport/InputRedundantImportBuiltInModules.java: IllegalStateException occurred while parsing file /home/runner/work/sevntu.checkstyle/sevntu.checkstyle/sevntu-checks/.ci-temp/contribution/checkstyle-tester/src/main/java/checkstyle/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/imports/redundantimport/InputRedundantImportBuiltInModules.java. 10:14: mismatched input 'java' expecting ';': InputMismatchException -> [Help 1]`