### PR TITLE
infra: Update JDK version from 17 to 21 in workflow as main library migrated to jdk21

### DIFF
--- a/.github/workflows/checks-no-exception-workflow.yml
+++ b/.github/workflows/checks-no-exception-workflow.yml
@@ -24,10 +24,10 @@ jobs:
 
     runs-on: ubuntu-latest
     steps:
-      - name: Set up JDK 17
+      - name: Set up JDK 21
         uses: actions/setup-java@v1
         with:
-          java-version: 17
+          java-version: 21
 
       - name: Install groovy
         run: sudo apt install groovy


### PR DESCRIPTION
detected as CI failure at https://github.com/sevntu-checkstyle/sevntu.checkstyle/pull/1138