### PR TITLE
infra: Update default OpenJDK image version in config to jdk21 for runtime

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,6 +36,7 @@ workflows:
     jobs:
       - validate-with-maven-script:
           name: "eclipse-cs"
+          image-name: "cimg/openjdk:17.0.7"
           command: "./.ci/validation.sh eclipse-cs"
       - validate-with-maven-script:
           name: "idea-extension"


### PR DESCRIPTION
in same update as https://github.com/sevntu-checkstyle/sevntu.checkstyle/pull/1139

eclipse-cs on jdk21:
```
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  37.287 s
[INFO] Finished at: 2026-01-25T02:38:53Z
[INFO] ------------------------------------------------------------------------
Cloning into 'eclipse-cs'...
remote: Enumerating objects: 33939, done.        
remote: Counting objects: 100% (334/334), done.        
remote: Compressing objects: 100% (192/192), done.        
remote: Total 33939 (delta 227), reused 148 (delta 134), pack-reused 33605 (from 3)        
Receiving objects: 100% (33939/33939), 678.46 MiB | 49.86 MiB/s, done.
Resolving deltas: 100% (22639/22639), done.
Eclipse-cs tag: 10.4.0
Note: switching to '10.4.0'.

You are in 'detached HEAD' state. You can look around, make experimental
changes and commit them, and you can discard any commits you make in this
state without impacting any branches by switching back to a branch.

If you want to create a new branch to retain commits you create, you may
do so (now or later) by using -c with the switch command. Example:

  git switch -c <new-branch-name>

Or undo this operation with:

  git switch -

Turn off this advice by setting config variable advice.detachedHead to false

HEAD is now at 538e4a76 config: release 10.4.0
[INFO] Error stacktraces are turned on.
[INFO] Scanning for projects...
[ERROR] Internal error: org.eclipse.tycho.core.ee.UnknownEnvironmentException: Unknown OSGi execution environment: 'JavaSE-21' -> [Help 1]
org.apache.maven.InternalErrorException: Internal error: org.eclipse.tycho.core.ee.UnknownEnvironmentException: Unknown OSGi execution environment: 'JavaSE-21'
    at org.apache.maven.DefaultMaven.execute (DefaultMaven.java:109)
    at org.apache.maven.cli.MavenCli.execute (MavenCli.java:906)
    at org.apache.maven.cli.MavenCli.doMain (MavenCli.java:283)
    at org.apache.maven.cli.MavenCli.main (MavenCli.java:206)
    at jdk.internal.reflect.DirectMethodHandleAccessor.invoke (DirectMethodHandleAccessor.java:103)
    at java.lang.reflect.Method.invoke (Method.java:580)
    at org.codehaus.plexus.classworlds.launcher.Launcher.launchEnhanced (Launcher.java:255)
    at org.codehaus.plexus.classworlds.launcher.Launcher.launch (Launcher.java:201)
    at org.codehaus.plexus.classworlds.launcher.Launcher.mainWithExitCode (Launcher.java:361)
    at org.codehaus.plexus.classworlds.launcher.Launcher.main (Launcher.java:314)
Caused by: org.eclipse.tycho.core.ee.UnknownEnvironmentException: Unknown OSGi execution environment: 'JavaSE-21'
    at org.eclipse.tycho.core.ee.ExecutionEnvironmentUtils.getExecutionEnvironment (ExecutionEnvironmentUtils.java:96)
    at org.eclipse.tycho.core.osgitools.OsgiBundleProject.applyBestOfCurrentOrConfiguredProfile (OsgiBundleProject.java:778)
    at org.eclipse.tycho.core.osgitools.OsgiBundleProject.readExecutionEnvironmentConfiguration (OsgiBundleProject.java:748)
    at org.eclipse.tycho.core.resolver.DefaultTychoResolver.setupProject (DefaultTychoResolver.java:103)
    at org.eclipse.tycho.core.maven.TychoMavenLifecycleParticipant.afterProjectsRead (TychoMavenLifecycleParticipant.java:111)
    at org.apache.maven.DefaultMaven.doExecute (DefaultMaven.java:223)
    at org.apache.maven.DefaultMaven.doExecute (DefaultMaven.java:173)
    at org.apache.maven.DefaultMaven.execute (DefaultMaven.java:101)
    at org.apache.maven.cli.MavenCli.execute (MavenCli.java:906)
    at org.apache.maven.cli.MavenCli.doMain (MavenCli.java:283)
    at org.apache.maven.cli.MavenCli.main (MavenCli.java:206)
    at jdk.internal.reflect.DirectMethodHandleAccessor.invoke (DirectMethodHandleAccessor.java:103)
    at java.lang.reflect.Method.invoke (Method.java:580)
    at org.codehaus.plexus.classworlds.launcher.Launcher.launchEnhanced (Launcher.java:255)
    at org.codehaus.plexus.classworlds.launcher.Launcher.launch (Launcher.java:201)
    at org.codehaus.plexus.classworlds.launcher.Launcher.mainWithExitCode (Launcher.java:361)
    at org.codehaus.plexus.classworlds.launcher.Launcher.main (Launcher.java:314)
[ERROR] 
[ERROR] Re-run Maven using the -X switch to enable full debug logging.
[ERROR] 
[ERROR] For more information about the errors and possible solutions, please read the following articles:
[ERROR] [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/InternalErrorException

Exited with code exit status 1
```