### PR TITLE
Issue #1119: Avoid false positive for classes inside interfaces

### DIFF
--- a/sevntu-checks/src/main/java/com/github/sevntu/checkstyle/checks/coding/AvoidDefaultSerializableInInnerClassesCheck.java
+++ b/sevntu-checks/src/main/java/com/github/sevntu/checkstyle/checks/coding/AvoidDefaultSerializableInInnerClassesCheck.java
@@ -84,12 +84,33 @@ public class AvoidDefaultSerializableInInnerClassesCheck extends AbstractCheck {
                 detailAST.getParent().getType() == TokenTypes.COMPILATION_UNIT;
         if (!topLevelClass && isSerializable(detailAST)
                 && !isStatic(detailAST)
+                && !isInsideInterface(detailAST)
                 && !hasSerialazableMethods(detailAST)) {
             final DetailAST implementsBlock = detailAST
                     .findFirstToken(TokenTypes.IMPLEMENTS_CLAUSE);
             log(implementsBlock,
                     MSG_KEY);
         }
+    }
+
+    /**
+     * Checks whether the class is inside an interface.
+     *
+     * @param ast DetailAST of the class
+     * @return true if inside interface
+     */
+    private static boolean isInsideInterface(DetailAST ast) {
+        boolean result = false;
+        DetailAST parent = ast.getParent();
+
+        while (parent != null && !result) {
+            if (parent.getType() == TokenTypes.INTERFACE_DEF) {
+                result = true;
+            }
+            parent = parent.getParent();
+        }
+
+        return result;
     }
 
     /**

--- a/sevntu-checks/src/test/java/com/github/sevntu/checkstyle/checks/coding/AvoidDefaultSerializableInInnerClassesCheckTest.java
+++ b/sevntu-checks/src/test/java/com/github/sevntu/checkstyle/checks/coding/AvoidDefaultSerializableInInnerClassesCheckTest.java
@@ -112,4 +112,16 @@ public class AvoidDefaultSerializableInInnerClassesCheckTest extends AbstractMod
                 expected);
     }
 
+    @Test
+    public void testInterfaceInnerClassShouldNotTrigger() throws Exception {
+        final DefaultConfiguration checkConfig =
+                        createModuleConfig(AvoidDefaultSerializableInInnerClassesCheck.class);
+
+        final String[] expected = {};
+
+        verify(checkConfig,
+                        getPath("InputAvoidDefaultSerializableInInnerClassesCheck.java"),
+                        expected);
+    }
+
 }

--- a/sevntu-checks/src/test/resources/com/github/sevntu/checkstyle/checks/coding/InputAvoidDefaultSerializableInInnerClassesCheck.java
+++ b/sevntu-checks/src/test/resources/com/github/sevntu/checkstyle/checks/coding/InputAvoidDefaultSerializableInInnerClassesCheck.java
@@ -1,0 +1,11 @@
+package com.github.sevntu.checkstyle.checks.coding;
+
+import java.io.Serializable;
+
+public class InputAvoidDefaultSerializableInInnerClassesCheck {
+
+    interface Test {
+        class TestClass implements Serializable {
+        }
+    }
+}


### PR DESCRIPTION
Issue #1119

Fixes false positive in AvoidDefaultSerializableInInnerClassesCheck.

Classes inside interfaces are implicitly static in Java, but the checks
only verifies the explicit 'static' modifier. This caused incorrect violations.

Changes:
- Added test case to reproduce the issue
- Updated logic to skip classes inside interfaces