### PR TITLE
minor: add leading asterisk to multiline comment

### DIFF
--- a/sevntu-checks/src/test/java/com/github/sevntu/checkstyle/checks/design/ConstructorWithoutParamsCheckTest.java
+++ b/sevntu-checks/src/test/java/com/github/sevntu/checkstyle/checks/design/ConstructorWithoutParamsCheckTest.java
@@ -61,7 +61,7 @@ public class ConstructorWithoutParamsCheckTest extends AbstractModuleTestSupport
     }
 
     /*
-     Added to comply with the sevntu.checkstyle regulation of 100% code coverage.
+     * Added to comply with the sevntu.checkstyle regulation of 100% code coverage.
      */
     @Test
     public void testGetAcceptableTokens() {


### PR DESCRIPTION
minor: Adding missing leading asterisk for multiline-comment
While adding new check [MultilineCommentLeadingAsteriskPresenceCheck](https://github.com/checkstyle/checkstyle/pull/20600)
Ref: https://checkstyle.semaphoreci.com/jobs/b3bab39a-c737-4804-8e72-de2c624a5a71#L665