### PR TITLE
config: suppress new check JavaLineLengthCheck

### DIFF
--- a/sevntu-checks/config/suppressions.xml
+++ b/sevntu-checks/config/suppressions.xml
@@ -48,4 +48,10 @@
     <!-- Suppress MatchXpath from checkstyle#19168 -->
     <suppress checks="MatchXpath" files=".*[\\/]CommitValidationTest\.java"/>
 
+    <!-- suppressed for javadoc exceeding max length -->
+    <suppress checks="JavaLineLengthCheck"
+              files=".*[\\/]src[\\/]main[\\/]java[\\/]checkstyle[\\/]checks[\\/]coding[\\/]RequireFailForTryCatchInJunitCheck\.java"/>
+    <suppress checks="JavaLineLengthCheck"
+              files=".*[\\/]src[\\/]main[\\/]java[\\/]checkstyle[\\/]checks[\\/]coding[\\/]DiamondOperatorForVariableDefinitionCheck\.java"/>
+
 </suppressions>


### PR DESCRIPTION
Supress new check JavaLineLengthCheck for DiamondOperatorForVariableDefinitionCheck and RequireFailForTryCatchInJunitCheck untill support for javadoc added.
Related to : https://github.com/checkstyle/checkstyle/pull/19009