### PR TITLE
minor: suppress MissingCtor temporarily

### DIFF
--- a/sevntu-checks/config/suppressions.xml
+++ b/sevntu-checks/config/suppressions.xml
@@ -48,4 +48,6 @@
     <!-- Suppress MatchXpath from checkstyle#19168 -->
     <suppress checks="MatchXpath" files=".*[\\/]CommitValidationTest\.java"/>
 
+    <!-- temporal suppression until we have time to fix it -->
+    <suppress checks="MissingCtor" files=".*"/>
 </suppressions>


### PR DESCRIPTION
Temporary suppression for MissingCtor until explicit constructors are added throughout the repository.

Related:
checkstyle/checkstyle#20813